### PR TITLE
docs(plan): v1-AD-a — admin-dashboard sub-phase A

### DIFF
--- a/.claude/PRPs/handovers/v1-prd-edit-pass-2026-04-19.md
+++ b/.claude/PRPs/handovers/v1-prd-edit-pass-2026-04-19.md
@@ -1,0 +1,321 @@
+# Handover — v1 PRD Edit Pass (session 2026-04-19 afternoon)
+
+**Session predecessor:** `v1-prep-2026-04-19.md` (morning) created 5 DRAFT v1 sub-PRDs + triage.
+**This session's work:** PRD coherence audit → 6 B-decisions resolved → edit pass started.
+**Status at handover:** **B1 + B2 edits DONE** (admin-dashboard + jury-mechanics); B3–B6 + N1–N5 + NOT1/NOT3/NOT4/NOT5 PENDING.
+**Context budget:** stopped at user's direction due to high context usage.
+
+---
+
+## Critical guardrails (re-read before resuming)
+
+The Phase 6 session is actively implementing on `phase-6` branch in an advisor worktree. These were flagged mid-session 2026-04-19:
+
+1. **Do NOT write to `.claude/decision-queue.json`** — that's Phase 6's advisor/impl channel. This session's findings live at `.claude/PRPs/v1-planning-queue.json` (different file, distinct schema).
+2. **Do NOT touch `phase-6` branch** or any worktree at `brehon-fork-advisor-phase6` / `brehon-fork-agent-*-phase6`.
+3. **Do NOT write `resolved_by: "advisor"`** in ANY queue file. Only the advisor session uses that label. This session uses `resolved_by: "user"` or `resolved_by: "v1-planning-session"`.
+4. **Do NOT edit homeserver memory files** for Phase 6 (`project_brehon_phase_6_notes.md`, `project_brehon_governance_platform.md`, etc.).
+5. **Planning-only scope** — no `crates/` edits, no migrations, no Cargo.toml changes, no `cargo build`/`cargo check` from primary worktree while Phase 6 agents run.
+6. **4 unpushed `wave1-*` branches exist locally** from earlier in this session (wave1-cr-mech, wave1-cr-probes, wave1-cr-db-index, wave1-filter-dto). Leave them where they are (no push, no delete). They'll activate when Wave 1 launches post-Phase-6.
+
+Full guardrail text: see user message at session ~start ("V1 planning work can proceed in parallel with Phase 6 implementation, but three guardrails apply...").
+
+---
+
+## What got done this session
+
+### 1. Audit complete
+
+Read all 5 PRDs end-to-end. Cross-PRD coherence audit produced 15 findings:
+
+- **6 blocking** (B1–B6): cross-PRD contradictions/ownership gaps
+- **5 non-blocking** (N1–N5): within-PRD drift
+- **4 noted** (NOT1, NOT3, NOT4, NOT5) + NOT2 (governance_log entry_kind registry, deferred to v1-impl prep)
+
+All captured in `.claude/PRPs/v1-planning-queue.json` with schema distinct from Phase 6's decision-queue. Read this file first on resume.
+
+### 2. All 6 B-decisions resolved (user-authorised)
+
+| # | Decision | Option picked | Key outcome |
+|---|---|---|---|
+| **B1** | `appeal.*` namespace ownership | **A** — jury-mechanics owns fully | admin-dashboard delegates; `appeal.original_jurors_excluded` = hard code rule, not config |
+| **B2** | `jury.panel_size` shape | **B** — dotted matrix + single-key fallback | OQ-026 cascade operationalised; v0 read sites preserved |
+| **B3** | Reputation-tuning namespaces | **A-modified** (user adjustment) | 10 keys renamed; `bounds.*` + `feature.*` new 1st-class; `cron.*` collapsed into `job.*`/`participation.*`/`deltas.*`; 15 namespaces total |
+| **B4** | sponsor-liability `liability.*` | **A** — flat matches v0 | 10 keys renamed from `sponsor.liability.*` to `liability.*` |
+| **B5** | Phase 6 dependency on federation-inbound | **A-modified** — hard gate + SQL DO block preamble; timestamp invariant only ("must sort after Phase 6"), no specific date | Fails-loud if migration runs before Phase 6 lands |
+| **B6** | `submit_jury_vote` ownership | **A** — jury-mechanics owns combined 9-step handler | User provided full pseudocode; sponsor-liability §9.3 reduces to pointer |
+
+Full context + rationale + edit-scope-per-decision: see queue file `resolved` array.
+
+### 3. Edits completed — B1 + B2
+
+**admin-dashboard (`v1-admin-dashboard.prd.md`) — DONE for B1/B2:**
+- §3.1 `appeal.*` row updated (5 v1 additions, jury-mechanics-owned annotation)
+- §3.5 cascade sentence added (B2 reader-cascade order)
+- §5.1 `jury.panel_size = 7` row kept with cascade-precedence note
+- §5.2 3 `appeal.*` rows deleted + cross-ref line
+- §10.2 issue #15 row annotated (ownership shift to jury-mechanics)
+- §11 "Resolutions applied (2026-04-19)" added at end of file — tracks B1/B2 done, B3/B4/B5/N1 pending
+
+**jury-mechanics (`v1-jury-mechanics.prd.md`) — DONE for B1/B2:**
+- §3.5 new "Cascade fallback" subsection added
+- §9.2 directive to use `config::get_int_cascade` helper (not direct dotted-key read)
+- §15 "Resolutions applied (2026-04-19)" added at end of file — tracks B1/B2 done, B6 pending
+
+### 4. v1-planning-queue.json created
+
+`.claude/PRPs/v1-planning-queue.json` — distinct schema from Phase 6's queue. Contains:
+- 6 resolved entries (B1–B6 with full resolution details + edit_scope per PRD + key_renames tables for B3/B4)
+- 5 non-blocking entries (N1–N5 with proposed resolutions flagged)
+- 5 noted entries (NOT1/NOT2/NOT3/NOT4/NOT5 with proposed resolutions or defer decisions)
+
+Resumable state for the rest of the edit pass.
+
+---
+
+## What's PENDING — edits still to apply
+
+**Read this from the queue file.** `pending` fields are explicit per-PRD edit_scope. Below is the TaskList-level summary of remaining work:
+
+### TaskList on resume
+
+```
+#11 [pending] B3 edits: admin-dashboard + reputation-tuning
+#12 [pending] B4 edits: sponsor-liability + admin-dashboard
+#13 [pending] B5 edits: federation-inbound + admin-dashboard
+#14 [pending] B6 edits: jury-mechanics + sponsor-liability
+#15 [pending] Apply 🟡 non-blocking fixes (N1–N5)
+#16 [pending] Apply 🟢 noted fixes (NOT1, NOT3, NOT4, NOT5)
+```
+
+(Tasks #1–#10 are completed — review, audit, summary, gap-check, queue, B1+B2.)
+
+### B3 (task #11) — namespace collapse
+
+**Files:** `v1-admin-dashboard.prd.md`, `v1-reputation-tuning.prd.md`
+
+**reputation-tuning — 10 key renames per this table (from queue `B3.key_renames`):**
+
+| Old | New |
+|---|---|
+| `cron.participation.weekly_increment` | `deltas.participation_weekly_active` |
+| `cron.participation.activity_threshold_comments` | `participation.activity_threshold_comments` |
+| `cron.participation.lookback_days` | `participation.lookback_days` |
+| `cron.participation.weekly_dormancy_decrement` | `deltas.participation_dormant` |
+| `cron.participation.dormancy_window_days` | `participation.dormancy_window_days` |
+| `cron.participation_interval_days` | `job.participation_interval_days` |
+| `cron.rollup_interval_days` | `job.rollup_interval_days` |
+| `rollup.equal_weights` | `job.rollup_equal_weights` |
+| `reputation.v1.decay_enabled` | `feature.reputation_v1_decay_enabled` |
+
+**Sites to edit in reputation-tuning:**
+- §5.2 table (new keys listed)
+- §5.3 body (Source 1/2/3/4 sub-sections reference these keys)
+- §8 defaults matrix (full enumeration)
+- §13 cross-references
+- Add §14 "Resolutions applied (2026-04-19)" with B3 entry
+
+**admin-dashboard — §3.1 namespace table overhaul:**
+- Prose: "62 keys across 7 namespaces" → "138 keys across 15 namespaces (v1 inventory crossing all 5 sub-PRDs)" with per-PRD contribution sub-table
+- New rows: `bounds.*` (0 v0, 8 v1), `feature.*` (0 v0, 1 v1)
+- Extend existing rows: `participation.*` (+2), `deltas.*` (+3), `job.*` (+3)
+- Update §11 Resolutions: mark B3 done
+
+### B4 (task #12) — sponsor-liability `sponsor.*` → flat `liability.*`
+
+**Files:** `v1-sponsor-liability.prd.md`, `v1-admin-dashboard.prd.md`
+
+**sponsor-liability — 10 key renames per queue `B4.key_renames`:**
+All `sponsor.liability.grace_window.<thing>_hours` → `liability.grace_window_<thing>_hours`
+All `sponsor.liability.<thing>` → `liability.<thing>`
+
+**Sites to edit in sponsor-liability:**
+- §4.2 table (6 grace-window key rows)
+- §5.1 body (prose mentions sponsor.liability.* prefix — purge throughout §5)
+- §7.3 table (2 restoration key rows)
+- §9.3 body (~5 prose references — NB: §9.3 will be reduced to pointer in B6 edit anyway; coordinate)
+- §10 full defaults matrix (10 entries)
+- §12.1 rate-limit key row
+- §13 OQ-V1-SL-01 context mentions the multi_sponsor key
+- §16 Decisions Log "grace-window severity source" row
+- Add §18 "Resolutions applied (2026-04-19)" with B4 entry
+
+**admin-dashboard:**
+- §3.1 `liability.*` row: v0 keys: 3, v1 additions: 2 → **v1 additions: 10**
+- §5.2: add 7 new rows for sponsor-liability-owned keys NOT yet listed (restoration escapes x2, multi-sponsor rule x1, revoke rate-limit x1, grace_window minimum/maximum/alert_threshold x3)
+- §11 Resolutions: mark B4 done; note partial N1 collateral
+
+### B5 (task #13) — federation-inbound Phase 6 hard gate
+
+**Files:** `v1-federation-inbound.prd.md`, `v1-admin-dashboard.prd.md`
+
+**federation-inbound — insert new §8.0 "Dependencies" subsection before §8.1:**
+
+Content: explicit preconditions list per queue `B5.edit_scope.federation-inbound`:
+- Phase 6 PR merged to `governance-v0`
+- `federation_attestation` table with Phase 6's columns exists
+- `remote_sanction_notice` table with Phase 6's columns (esp. `received_at` per DQ-6.1) exists
+- Phase 6 enum types (`attestation_type_enum`, `sanction_action_enum`, `sanction_scope_enum`) registered
+- Phase 6 entry_kind constants (`federation_sanction_received`, `federation_attestation_received`) present in `governance_log.rs`
+- Schema assumption: `remote_sanction_notice.source_instance` is TEXT (peer domain), NOT FK to `instance.id` — v1 joins via `JOIN instance ON instance.domain = source_instance`
+
+**§8.2 SQL preamble DO block:**
+```sql
+-- Verify Phase 6 tables present before ALTER
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'federation_attestation') THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 federation_attestation table';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'remote_sanction_notice' AND column_name = 'received_at') THEN
+    RAISE EXCEPTION 'federation-inbound-v1 assumes Phase 6 DQ-6.1 resolved with received_at column';
+  END IF;
+END $$;
+```
+
+**§15.2 DQ-6.1/DQ-6.2 paragraphs:** rewrite prescriptive — reference §8.0 as canonical preconditions list.
+
+**§8 heading rename:** "Database & Migration Changes" → "Dependencies, Database & Migration Changes"
+
+**§1 frontmatter:** scheduling line → "**Hard-gated on Phase 6 PR merge to `governance-v0`**; no implementation before gate satisfied. Plan-level review (this PRD) can proceed in parallel."
+
+**Migration timestamp:** use invariant only — "must sort after Phase 6's `add_federation_attestations`". Do NOT reserve `2026-04-22-…`; leave exact slot for impl time.
+
+**Add §16 "Resolutions applied (2026-04-19)"** — B5 entry with partial N5 collateral note.
+
+**admin-dashboard:**
+- §10.1 cross-references — add one line under federation-inbound consumer row: "depends on Phase 6 merge — see `v1-federation-inbound.prd.md` §8.0 for hard-gate conditions."
+- §11 Resolutions: mark B5 done.
+
+### B6 (task #14) — combined `submit_jury_vote` handler
+
+**Files:** `v1-jury-mechanics.prd.md`, `v1-sponsor-liability.prd.md`
+
+**jury-mechanics §9.1 — expand to full 9-step pseudocode** (user-provided 2026-04-19):
+
+```
+submit_jury_vote(vote, context):
+  1. Load case row (FOR UPDATE per v0 concurrency guard)
+  2. Validate juror is assigned + hasn't already voted + case is in InReview
+  3. Insert jury_vote row
+  4. Tally: read all jury_vote rows for this case
+  5. Threshold check (v1 new):
+     - quorum = case.quorum_snapshot
+     - threshold = case.threshold_count_snapshot
+     - if any decision has >= threshold votes: winning_decision = that decision; continue to step 6
+     - if all jurors voted + no threshold met (deadlock):
+         → flip status to CaseStatus::AdminReview; emit governance_log; return case_decided: false
+     - if not all voted + no threshold met yet:
+         → return case_decided: false (case stays InReview)
+  6. Winning decision reached. Insert sanction rows per winning_decision.
+  7. Sponsor-liability branch (sponsor-liability §9.3):
+     - if sanction has liability implications AND target has active sponsors:
+         - compute_sponsor_liability(...) → deltas
+         - grace_expires_at = now + grace_window_for_severity(...)
+         - update case: status = SponsorLiabilityPending, grace_expires_at = ..., decided_at = now
+         - emit sponsor_liability_pending governance_log
+         - notify_sponsor_of_pending_liability(...) for each delta
+         - return case_decided: true, decision = winning_decision
+           (public_case_log + juror reputation_events DEFERRED to scheduler fire/escape)
+  8. No-sponsor / NoAction path (v0 lifecycle preserved):
+     - update case: status = Decided, decided_at = now, closed_at = now
+     - write public_case_log entry
+     - write juror reputation_events (aligned/outlier)
+     - write reporter reputation_event (upheld/dismissed)
+     - emit case_decided governance_log
+     - return case_decided: true, decision = winning_decision
+  9. Appeal window bound (v1 new — appeal.window_days):
+     - set appeal_window_expires_at = decided_at + config.appeal.window_days * 1 day
+     - (fires on BOTH SponsorLiabilityPending and Decided paths — composes with sponsor
+        grace window per sponsor-liability §6.5 min(...) semantics)
+```
+
+**Also add:**
+- Test-strategy sub-note: "v0 `report_to_modlog_golden_path` uses unsponsored target → step 8 no-sponsor path → test assertions preserved. New sponsored-target test is a v1-impl follow-up."
+- Cross-reference: "SponsorLiabilityPending branch specified by sponsor-liability-v1 §9.3; this section owns the integrated lifecycle shape."
+- Mark §15 B6 row as done.
+
+**sponsor-liability §9.3 — reduce from ~50 lines Rust pseudocode to ~10-line pointer:**
+
+Text: "For the combined post-v1 `submit_jury_vote` handler shape, see jury-mechanics-v1 §9.1 (9-step pseudocode). This section's branch semantics contribute: (a) the `SponsorLiabilityPending` status transition with grace-window computation; (b) the deferral of `public_case_log_appended` + juror `reputation_event` writes to scheduler fire/escape time; (c) the `apply_sponsor_liability` → `compute_sponsor_liability` + `fire_sponsor_liability` compute/fire split documented in §9.1 of THIS PRD."
+
+Keep §9.1 (compute/fire split) and §9.4 (scheduler grace-window helper module) intact — those are sponsor-liability's concerns.
+
+**Add §18 "Resolutions applied (2026-04-19)"** with B6 entry.
+
+### Task #15 — 🟡 non-blocking (N1–N5)
+
+Per queue `non_blocking` array. Each has `proposed_resolution` field — use those.
+
+- **N1** (admin-dashboard §5.2 phantom count): drop "4 reserved-for-v1.5 keys" prose from §5.2 count line. Collateral with B4 edit pass.
+- **N2** (reputation-tuning §5.3 evidence-cited threshold): add placeholder `256 chars` + flag as v1-impl verification task for `jury.rationale` column existence.
+- **N3** (jury-mechanics §5.3 constraint-relaxation algorithm): rewrite flowchart per queue N3 Option A — cooldown at pool-build filter, sponsor-cluster at panel-sample re-roll, geographic as soft score. Relaxation cascade: drop cooldown first (expand pool), then geographic scoring, then sponsor-cluster as last resort with warning log.
+- **N4** (sponsor-liability §11.4 modlog reader regression): add paragraph documenting `public_case_log` fires at scheduler fire/escape time (not vote-tally) for liability cases; v1 clients should poll both case endpoint AND modlog.
+- **N5**: already collateraled in B5 §8.0 — enumerate in the Resolutions log as resolved-via-B5.
+
+### Task #16 — 🟢 noted (NOT1, NOT3, NOT4, NOT5)
+
+- **NOT1** (OQ renumbering): rename admin-dashboard OQ-027..031 → OQ-V1-AD-01..05; jury-mechanics OQ-027..032 → OQ-V1-JM-01..06. Per queue `NOT1.renames`. Update cross-refs in each PRD's §Open Questions and §Resolutions.
+- **NOT2** (governance_log entry_kind registry): DEFER to v1-impl prep. No PRD edit this session.
+- **NOT3** (reputation-tuning ADR-010 compliance via feature flag): add paragraph to §9 framing feature-flag posture as weaker than snapshot-column posture but acceptable for reputation (rolling derived view, not in-flight procedural invariant).
+- **NOT4** (admin-dashboard §3.2 ConfigKeyMetadata ambiguity): commit explicitly to compile-time — `&'static [ConfigKeyMetadata]` array. §6.1 reference updated.
+- **NOT5** (admin-config-write.sh deprecation gating): §8.4 rewrite — deprecation gated on OQ-018 HTTP endpoint shipping, not on v1.1 milestone alone.
+
+---
+
+## Files on disk at handover
+
+### Edited this session (B1+B2 only)
+- `.claude/PRPs/prds/v1-admin-dashboard.prd.md` — 5 edits applied, §11 Resolutions section added
+- `.claude/PRPs/prds/v1-jury-mechanics.prd.md` — 3 edits applied, §15 Resolutions section added
+
+### Created this session
+- `.claude/PRPs/v1-planning-queue.json` — full audit findings + B-decisions + pending edits (~400 lines)
+- `.claude/PRPs/handovers/v1-prd-edit-pass-2026-04-19.md` — this file
+
+### Untouched this session (edits pending)
+- `.claude/PRPs/prds/v1-reputation-tuning.prd.md` — B3 pending
+- `.claude/PRPs/prds/v1-sponsor-liability.prd.md` — B4 + B6 pending
+- `.claude/PRPs/prds/v1-federation-inbound.prd.md` — B5 pending
+
+### Git state
+- Branch: `governance-v0` (local 3 commits behind origin — intentionally not fast-forwarded to avoid racing Phase 6)
+- Working tree: 2 modified PRD files (admin-dashboard, jury-mechanics) + 2 new files (queue + this handover) + 4 unpushed local branches (`wave1-*` — leave alone)
+- Nothing staged. Nothing committed this session.
+
+---
+
+## Resume plan (next session)
+
+**Bootstrap:**
+```
+Read .claude/PRPs/handovers/v1-prd-edit-pass-2026-04-19.md
+Read .claude/PRPs/v1-planning-queue.json (full — all B-decisions + pending fields carry edit instructions)
+Read the Resolutions-applied section at the end of .claude/PRPs/prds/v1-admin-dashboard.prd.md and .claude/PRPs/prds/v1-jury-mechanics.prd.md to see what's done
+```
+
+**Sequencing recommendation (same as current TaskList #11–#16):**
+1. **B3** (reputation-tuning renames + admin-dashboard §3.1 registry) — largest single edit; takes admin-dashboard §3.1 to its authoritative 15-namespace state
+2. **B4** (sponsor-liability flat `liability.*` + admin-dashboard §5.2 additions) — coordinates with B6 since both touch sponsor-liability §9.3 prose
+3. **B5** (federation-inbound §8.0 gate + admin-dashboard §10.1 cross-ref) — self-contained, minimal coordination
+4. **B6** (jury-mechanics §9.1 expansion + sponsor-liability §9.3 reduction) — DO B4 BEFORE B6 so §9.3 rename lands before §9.3 reduction
+5. **N1–N5** — small edits, mostly paragraph additions; can batch with the B-edit pass they collateral with (N1 with B4, N5 already in B5)
+6. **NOT1, NOT3–NOT5** — OQ renumbering is mechanical find-replace; paragraph additions elsewhere
+
+**Estimated context budget:** ~60k tokens if done in-session without subagents. Consider spawning Explore or general-purpose agents for mechanical find-replace work (OQ renumbering) to protect main context.
+
+**Verification at end:** cross-check each PRD file has a "Resolutions applied (2026-04-19)" section listing every B/N/NOT item touching it. That's the completion signal.
+
+**Do NOT commit or push** — PRDs stay DRAFT-status on `governance-v0`. User decides when to commit.
+
+---
+
+## Open questions for next session to surface
+
+None blocking. All 6 B-decisions resolved; edits are mechanical application.
+
+If ambiguity arises during a specific edit, check the queue file's `edit_scope` field for that ID — it's the canonical instruction. If still ambiguous, ask the user; do not guess.
+
+---
+
+*Generated: 2026-04-19 end-of-session. Trust but verify: the decisions in `v1-planning-queue.json` are user-authorised and correct; the edits I applied to admin-dashboard + jury-mechanics reflect them. Edits I did NOT apply (B3/B4/B5/B6/N1–5/NOT1/3/4/5) are pending per the pending-tasks section above.*

--- a/.claude/PRPs/handovers/v1-prep-2026-04-19.md
+++ b/.claude/PRPs/handovers/v1-prep-2026-04-19.md
@@ -1,0 +1,115 @@
+# Handover — v1 Prep Session (2026-04-19)
+
+**Session goal:** While Phase 6 federation runs in advisor worktree, identify and plan v1 work that can start now in parallel.
+
+**Outcome:** 6 artifacts on disk (1 triage + 5 PRDs); Wave 1 batches identified and ready to ship. Nothing implemented yet.
+
+**Branch state at session close:** `governance-v0` @ `3bbf419da` (clean). Phase 6 in-flight on `phase-6` branch in worktree at `C:\Users\barri\Developer\brehon-fork-advisor-phase6`.
+
+---
+
+## What got produced
+
+### Triage report (read first)
+`.claude/PRPs/v1-issue-triage.md` — 19 open v1 GitHub issues classified into Buckets A/B/C/D against Phase 6 conflict surface.
+
+**Bucket counts:**
+- **A. Plan-and-ship now** (10): #20, #21, #22, #23, #24, #25, #26, #27, #28, #31
+- **B. Plan now, ship after Phase 6 merges** (3): #19, #29, #30
+- **C. Wait — needs PRD first** (5): #11, #13, #14, #15, #16
+- **D. Direct Phase 6 conflict** (0)
+
+### Five v1 sub-PRDs (`.claude/PRPs/prds/v1-*.prd.md`)
+
+| PRD | New config knobs | New tables/columns | Resolves OQs |
+|---|---|---|---|
+| `v1-admin-dashboard.prd.md` | 62 catalogued (34 v0 + 28 new) | `rule_set_version`, `moderation_case.applied_config_snapshot` | OQ-018 (primary), OQ-002, OQ-026 |
+| `v1-jury-mechanics.prd.md` | 25 new | `severity_tier`/`status_tier`/snapshot cols on `moderation_case`, `jury_constraint_violation_log`, new enums | OQ-009, OQ-026 |
+| `v1-reputation-tuning.prd.md` | 28 new + 4 new event sources | `reputation_event.dedupe_key`/`source_event_type`, `sponsor_allowlist` | OQ-001, OQ-019, OQ-020 |
+| `v1-sponsor-liability.prd.md` | 12 new + 3 new `CaseStatus` variants | `moderation_case.grace_expires_at`/`liability_escape_reason`, partial index on `surety` | OQ-025 |
+| `v1-federation-inbound.prd.md` | 11 new | `federation_peer`, `federation_inbox_dropped_log`, `federation_inbox_nonce`, `remote_moderation_label`, columns on Phase 6 tables | (extends Phase 6) |
+
+### Cross-PRD coherence (verified)
+
+- All 5 PRDs route config through admin-dashboard's `governance_config` namespace (13 namespaces, no collision).
+- All honour ADR-010 no-retroactive-invalidation via snapshot columns.
+- All add `governance_log` ENTRY_KIND constants only (TEXT — no migration).
+- ~15 new OQs opened (OQ-027 through OQ-V1-SL-05); none conflict with existing ADRs.
+
+---
+
+## Recommended next-session execution — 3 waves
+
+### Wave 1 — ship Bucket A this week (parallel-safe with Phase 6)
+
+| Batch | Issues | PR title | Effort | Notes |
+|---|---|---|---|---|
+| **CR-MECH** | #20, #21, #22, #23, #25 | `chore(v1-cleanup): mechanical CR follow-ups from PR #10` | ~50 LOC, ½ day | Adds `serde_bytes` workspace dep |
+| **CR-PROBES** | #26, #27, #28 | `chore(probes): cross-platform + AWK-robustness for phase-5c smoke probes` | ~80 LOC, scratch/ only | Bash/awk only, zero crate impact |
+| **CR-DB-INDEX** | #24 | `perf(governance): partial index on surety(sponsored_id)` | 2 SQL files | **Migration timestamp must be ≥ `2026-04-21-…`** (Phase 6 owns 2026-04-20) |
+| **FILTER-DTO** | #12 | `feat(governance): assignee filter on list_cases` | ~30 LOC + e2e test | Pure additive DTO change |
+
+**Spawn approach:** 4 background `general-purpose` agents (sonnet, max-effort), one per batch, each in own auxiliary worktree off `governance-v0`. Each owns: branch creation, code, cargo validation, PR open with `--repo barrie-cork/lemmy --base governance-v0`. Sequential within agent; parallel across agents.
+
+**Per-agent brief template:**
+- Read triage §5 cross-reference for the issue's exact files
+- Read the issue body via `gh issue view <N> --repo barrie-cork/lemmy`
+- Use `git worktree add ../brehon-fork-batch-<name> governance-v0` for isolation
+- Validate via `scripts/brehon/cargo-check.bat` and (where relevant) `scripts/brehon/cargo-test.bat --test e2e --no-run -p lemmy_server`
+- PR via `gh pr create --repo barrie-cork/lemmy --base governance-v0 --head <branch>` (per `.claude/rules/gh-pr-fork-target.md`)
+
+### Wave 2 — ship after Phase 6 merges
+
+- **REP-CLEANUP** (#19 + #31) — reputation read-path; #31 first then #19
+- **#29** — e2e.rs config-flip determinism; one-line fix once Phase 6 test layout settled
+- **#30** — governance-ai-review 413 mitigation; decision then small workflow change
+
+### Wave 3 — PRD-gated (start when v1 milestone opens)
+
+- **#16** unblocks once admin-dashboard PRD → implementation phase opens
+- **#15** likely upgrades to Bucket B once dashboard ships ("default + configurable" pattern)
+- **#11, #13, #14** wait for jury-mechanics-v1 and community-membership-v1 implementation phases
+
+---
+
+## Critical context the next session needs
+
+### User framing (2026-04-19)
+> "The admin dashboard will allow community groups to experiment with how they configure a lot of these settings, although defaults might have to be decided on."
+
+This reframed many "what should X be?" v1 questions as "ship a sensible default + make it a dashboard knob". Every PRD reflects this — defaults are starting points, not gospel. Communities tune within bounded ranges.
+
+### Phase 6 status (do not interfere)
+- Branch: `phase-6` in worktree `C:\Users\barri\Developer\brehon-fork-advisor-phase6`
+- Plan: `<that-worktree>/.claude/PRPs/plans/phase-6-federation.plan.md`
+- Modified files: `governance_log.rs` (4 new entry-kind consts), `submit_jury_vote.rs` (federation publish), `e2e.rs` (round-trip test), new `crates/apub/*/governance/*` files, 2 new federation tables
+- **Zero hard conflicts with v1 issues** — only soft conflicts on `e2e.rs` (#29) and migration timestamp coordination (#24)
+
+### Hard rules to preserve
+- `cargo` MUST go through `scripts/brehon/cargo-*.bat` (libpq + vcvars on Windows); never pipe through `tail` (masks exit code per `.claude/rules/cargo-output-capture.md`)
+- `gh pr create` MUST pass `--repo barrie-cork/lemmy` (per `.claude/rules/gh-pr-fork-target.md`)
+- Phase branches per `.claude/rules/phase-branch.md` from Phase 5+ — Wave 1 batches are NOT phases (just CR follow-ups), so they branch from `governance-v0` directly
+- Seven Extism PM hooks are stable per `.claude/rules/pm-plugin-hooks-stable.md` — V2 messaging bridge depends on them
+
+### What was NOT done in this session
+- No code written — all artifacts are design documents
+- No PRs opened
+- No migrations created
+- No agents spawned for implementation
+- 5 PRDs are DRAFT status, not yet reviewed/approved by user
+
+---
+
+## Files to read on resume
+
+1. **First:** `.claude/PRPs/v1-issue-triage.md` (executive summary + per-issue table)
+2. **Then per-PRD as needed:** `.claude/PRPs/prds/v1-*.prd.md`
+3. **CLAUDE.md** for fork conventions
+4. **Phase 6 plan** if any conflict question arises: `C:\Users\barri\Developer\brehon-fork-advisor-phase6\.claude\PRPs\plans\phase-6-federation.plan.md`
+
+## Open question for user when session resumes
+
+Approve Wave 1 launch? Specifically:
+- Spawn 4 parallel implementation agents for CR-MECH, CR-PROBES, CR-DB-INDEX, FILTER-DTO?
+- Or batch differently (e.g. one mega-PR vs 4 smaller PRs)?
+- Or hold all v1 work until Phase 6 closes?

--- a/.claude/PRPs/handovers/v1-prep-bootstrap.md
+++ b/.claude/PRPs/handovers/v1-prep-bootstrap.md
@@ -1,0 +1,28 @@
+# Bootstrap prompt for next Claude Code session — v1 prep continuation
+
+Copy-paste this into a fresh Claude Code session (in `C:\Users\barri\Developer\brehon-fork`) to resume.
+
+---
+
+I'm resuming v1 prep work for the Brehon governance fork. The previous session produced design artifacts but did not implement anything.
+
+**First steps:**
+
+1. Read the handover at `.claude/PRPs/handovers/v1-prep-2026-04-19.md` — full context on what got produced and recommended next steps.
+2. Read `.claude/PRPs/v1-issue-triage.md` — the bucketing of 19 open v1 GitHub issues.
+3. Check current state: `git status`, `git branch --show-current`, `git worktree list`. Phase 6 should still be in `phase-6` branch in the advisor worktree.
+4. Verify PRD files exist: `ls .claude/PRPs/prds/v1-*.prd.md` (should be 5 files).
+
+**Then surface to me:**
+- Any drift since 2026-04-19 (new commits on `governance-v0`, Phase 6 status changes, new GH issues, merged PRs).
+- Confirm Wave 1 plan is still valid (4 parallel batches: CR-MECH, CR-PROBES, CR-DB-INDEX, FILTER-DTO).
+- Wait for my go/no-go before spawning any implementation agents.
+
+**Hard constraints to remember:**
+- `cargo` only via `scripts/brehon/cargo-*.bat` wrappers; never pipe through `tail` (masks exit code).
+- `gh pr create` always with `--repo barrie-cork/lemmy --base governance-v0` for v1 batches.
+- Wave 1 batches branch from `governance-v0` directly (they're CR follow-ups, not phases).
+- CR-DB-INDEX migration timestamp must be ≥ `2026-04-21-…` (Phase 6 owns the 2026-04-20 slot).
+- Don't touch the Phase 6 worktree at `C:\Users\barri\Developer\brehon-fork-advisor-phase6`.
+
+Use Opus 4.7 max-effort for orchestration; sonnet max-effort for implementation agents.

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -441,11 +441,12 @@ flag it. Verify the existing shim preserves alphabetical order before appending
 | `crates/db_schema/src/source/governance/mod.rs` | UPDATE | Export new modules |
 | `crates/db_schema/src/newtypes.rs` | UPDATE | Add `RuleSetVersionId`, `SponsorAllowlistId` newtypes |
 | `crates/api/api/src/governance/config.rs` | UPDATE | Add `ConfigKeyMetadata` struct + `ValueType`/`ConfigScope`/`ApplyAt` enums + 27 new `DEFAULT_*` consts + 27 new `const_default_*` match arms + extend `SEEDED_KEYS_WITH_CONSTS` to 61 tuples + `CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata]` (61 entries) + `EXPECTED_SEED_COUNT_V1_AD: usize = 27` + new `every_seeded_key_has_metadata` parity test. Counts are parametric — task 7 reconciliation gate authoritative. |
-| `crates/api/api/src/governance/governance_log.rs` | UPDATE | Add `ENTRY_KIND_ADMIN_CONFIG_CHANGED` + `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED` consts at line 68+ |
+| `crates/db_schema/src/source/governance/governance_log.rs` | UPDATE | **Define** `ENTRY_KIND_ADMIN_CONFIG_CHANGED` + `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED` consts here — this is where the 23 existing consts live post-Phase-6 per DQ-6.6. See §10.8 File 1. |
+| `crates/api/api/src/governance/governance_log.rs` | UPDATE | **Re-export** the two new consts from the api shim's `pub use` list (alphabetical insertion between `ENTRY_KIND_CAPABILITY_CHANGED` and `ENTRY_KIND_APPEAL_REQUESTED`). See §10.8 File 2. |
 | `.claude/rules/governance-log-entry-kind-registry.md` | CREATE | Initialise registry per advisor directive #2; close GH #41 |
 | `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md` | UPDATE | Open OQ-V1-AD-01/02/03 (leans only; no resolution) |
 
-**Total: 17 files changed (4 NEW migration dirs × 2 files = 8 migration files; 2 NEW Rust files — `rule_set_version.rs`, `sponsor_allowlist.rs`; 5 UPDATED Rust files — `schema.rs`, `mod.rs`, `newtypes.rs`, `config.rs`, `governance_log.rs`; 1 NEW rules file; 1 UPDATED design doc). 8 + 2 + 5 + 1 + 1 = 17.**
+**Total: 18 files changed (4 NEW migration dirs × 2 files = 8 migration files; 2 NEW Rust files — `rule_set_version.rs`, `sponsor_allowlist.rs`; 6 UPDATED Rust files — `schema.rs`, `mod.rs`, `newtypes.rs`, `config.rs`, `db_schema/.../governance_log.rs` (const DEFINITION), `api/api/.../governance_log.rs` (re-export shim); 1 NEW rules file; 1 UPDATED design doc). 8 + 2 + 6 + 1 + 1 = 18.**
 
 ---
 
@@ -696,9 +697,9 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
   - `onboarding.sponsor_allowlist_table_name` (text)
   - `onboarding.provisional_membership_cooldown_days` (int)
   - `founder.founder_seal_visible_in_profile` (bool)
-  - `participation.weekly_active_delta` (int)
-  - `participation.dormant_threshold_days` (int)
-  - `participation.dormant_delta` (int)
+  - `deltas.participation_weekly_active` (int) — delta value per B3 namespace split (2026-04-19)
+  - `participation.dormancy_window_days` (int) — context window per B3
+  - `deltas.participation_dormant` (int) — delta value per B3
   - `participation.attestation_enabled` (bool)
   - `federation.inbound_advisory_only` (bool)
   - `federation.peer_attestation_ttl_days` (int)
@@ -727,7 +728,7 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
   ```
   Do NOT use `-p lemmy_api --features full` per advisor memory `feedback_features_full_workspace_only.md`.
 
-### Task 7: CREATE `migrations/2026-04-21-000300-0000_seed_v1_config_keys/up.sql` + down.sql; UPDATE `crates/api/api/src/governance/governance_log.rs` with 2 new ENTRY_KIND consts
+### Task 7: CREATE `migrations/2026-04-21-000300-0000_seed_v1_config_keys/up.sql` + down.sql; UPDATE both `crates/db_schema/src/source/governance/governance_log.rs` (const DEFINITION) **and** `crates/api/api/src/governance/governance_log.rs` (shim RE-EXPORT) with 2 new ENTRY_KIND consts
 
 - **ACTION**: Seed the 27 new rows idempotently. The INSERT rows MUST match task 6's `SEEDED_KEYS_WITH_CONSTS` entries byte-for-byte. Also land the two new ENTRY_KIND consts (combined task because both are small, non-conflicting, and the parity test + migration test share a validation step).
 - **IMPLEMENT** (migration):
@@ -773,9 +774,9 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
     ('instance', 'onboarding.sponsor_allowlist_table_name',     'text',  NULL,  NULL, NULL,  'sponsor_allowlist'),
     ('instance', 'onboarding.provisional_membership_cooldown_days','int',14,    NULL, NULL,  NULL),
     ('instance', 'founder.founder_seal_visible_in_profile',     'bool',  NULL,  NULL, true,  NULL),
-    ('instance', 'participation.weekly_active_delta',           'int',   1,     NULL, NULL,  NULL),
-    ('instance', 'participation.dormant_threshold_days',        'int',   30,    NULL, NULL,  NULL),
-    ('instance', 'participation.dormant_delta',                 'int',   -2,    NULL, NULL,  NULL),
+    ('instance', 'deltas.participation_weekly_active',          'int',   1,     NULL, NULL,  NULL),
+    ('instance', 'participation.dormancy_window_days',          'int',   30,    NULL, NULL,  NULL),
+    ('instance', 'deltas.participation_dormant',                'int',   -2,    NULL, NULL,  NULL),
     ('instance', 'participation.attestation_enabled',           'bool',  NULL,  NULL, false, NULL),
     ('instance', 'federation.inbound_advisory_only',            'bool',  NULL,  NULL, true,  NULL),
     ('instance', 'federation.peer_attestation_ttl_days',        'int',   30,    NULL, NULL,  NULL),
@@ -834,13 +835,29 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
     'rule_set.version_propagation_delay_hours'
   );
   ```
-- **IMPLEMENT** (governance_log.rs):
+- **IMPLEMENT** (governance_log.rs — **dual-file edit per §10.8**, post-Phase-6 relocation DQ-6.6):
   ```rust
-  // Appended after line 68 (after ENTRY_KIND_APPEAL_REQUESTED):
+  // FILE 1 (DEFINITION): crates/db_schema/src/source/governance/governance_log.rs
+  // APPEND after the existing ENTRY_KIND_* consts (the 23-const list ending
+  // with ENTRY_KIND_FEDERATION_ATTESTATION_RECEIVED post-Phase-6):
   pub const ENTRY_KIND_ADMIN_CONFIG_CHANGED: &str = "admin_config_changed";
   pub const ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED: &str = "admin_config_change_denied";
   ```
-- **MIRROR**: `migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78-113` for INSERT shape + `ON CONFLICT (scope, key, valid_from)` target. `governance_log.rs:50-68` for ENTRY_KIND const style.
+
+  ```rust
+  // FILE 2 (RE-EXPORT SHIM): crates/api/api/src/governance/governance_log.rs
+  // EXTEND the alphabetical `pub use` list; insert between
+  // ENTRY_KIND_CAPABILITY_CHANGED and ENTRY_KIND_APPEAL_REQUESTED:
+  pub use lemmy_db_schema::source::governance::governance_log::{
+    // … existing re-exports …
+    ENTRY_KIND_ADMIN_CONFIG_CHANGED,
+    ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED,
+    // … existing re-exports continue …
+  };
+  ```
+
+  Both edits land in the **same commit** — Task 7 is atomic across the two files. A `db_schema` definition without the shim re-export breaks callers that import from the api path; a shim re-export without the `db_schema` definition fails to compile.
+- **MIRROR**: `migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78-113` for INSERT shape + `ON CONFLICT (scope, key, valid_from)` target. For ENTRY_KIND const style: refer to the 23 existing consts in `crates/db_schema/src/source/governance/governance_log.rs` (post-Phase-6 location) and the 23 matching `pub use` re-export lines in `crates/api/api/src/governance/governance_log.rs` (shim).
 - **GOTCHA**: `ON CONFLICT (scope, key, valid_from) DO NOTHING` — `valid_from` defaults to `now()`, so two runs of `schema_setup::run()` at different times would each insert a fresh row with a different `valid_from` — the conflict key means they DON'T duplicate only when `valid_from` matches exactly. The v0 migration handles this by running inside the same single-transaction schema application, where `now()` returns the same timestamp for all rows in the same statement. Same applies here; no change needed.
 - **GOTCHA**: `admin_config_changed` const must equal the existing shell-script string literal byte-for-byte (`scripts/brehon/admin-config-write.sh:148`). v1-AD-b's NOT5 deprecation gate 3 asserts byte-identical governance_log rows from both paths.
 - **VALIDATE**:
@@ -967,9 +984,10 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
 
   ## Acceptance invariants (checked at every plan-review)
 
-  - [ ] `rg "^pub const ENTRY_KIND_" crates/api/api/src/governance/governance_log.rs | wc -l` returns total count of all populated sections
-  - [ ] `rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort | uniq -d` returns no duplicates
-  - [ ] Every populated row in this file has a Rust const AND a call site (except Phase 6 pending rows, which only require a plan file)
+  - [ ] `rg "^pub const ENTRY_KIND_" crates/db_schema/src/source/governance/governance_log.rs | wc -l` returns total count of all populated sections (consts are **defined** in `db_schema` post-Phase-6 per DQ-6.6; the `api` shim at `crates/api/api/src/governance/governance_log.rs` only `pub use`-re-exports them)
+  - [ ] `rg -n '"[a-z_]+"' crates/db_schema/src/source/governance/governance_log.rs | awk -F: '/ENTRY_KIND_/' | grep -oE '"[a-z_]+"' | sort | uniq -d` returns no duplicate string literal values
+  - [ ] `rg "^pub use lemmy_db_schema::source::governance::governance_log::\{" -A 40 crates/api/api/src/governance/governance_log.rs` lists every populated const — shim re-export parity with `db_schema` definition is load-bearing for callers that import from the api path
+  - [ ] Every populated row in this file has a Rust const (in `db_schema`) AND a `pub use` re-export (in the api shim) AND a call site (except Phase 6 pending rows, which only require a plan file)
   - [ ] Registry file matches the "Proposed deliverable" enumeration of GH issue #41 at land-time
   ```
 - **MIRROR**: GH issue #41 body "Proposed deliverable" section verbatim (column count, section structure, acceptance invariants).
@@ -981,21 +999,31 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
   # Phase 6 merge-state check (advisor note 2) — determines whether to drop "(expected)" labels
   git log governance-v0 --grep="Phase 6\|phase-6\|phase 6" --oneline -1
   # If non-empty: Phase 6 has merged; task 8 must refresh the Phase 6 section
-  # with actual ENTRY_KIND names from governance_log.rs and drop "(expected)".
-  # If empty: Phase 6 still in-flight; labels stay.
+  # with actual ENTRY_KIND names from db_schema's governance_log.rs and drop
+  # "(expected)". If empty: Phase 6 still in-flight; labels stay.
+  # (As of 2026-04-19 18:48 UTC Phase 6 PR #46 has merged at 08065e1a1 —
+  # governance-v0 is at 5ce5358fc; the labels must drop at impl time.)
   
-  rg "^pub const ENTRY_KIND_" crates/api/api/src/governance/governance_log.rs | wc -l
-  # Expected pre-Phase-6-merge: 21  (19 v0 + 2 v1-AD-a)
-  # Expected post-Phase-6-merge: 21 + (Phase 6 kind count, likely 4) = 25
-  # Acceptance invariant is parametric: registry file populated-section rows
-  # must equal this grep's output exactly.
+  # Count DEFINED consts (source of truth — db_schema):
+  rg "^pub const ENTRY_KIND_" crates/db_schema/src/source/governance/governance_log.rs | wc -l
+  # Expected at governance-v0 @ 5ce5358fc (post-Phase-6-merge): 23 (19 v0 + 4 Phase 6)
+  # Expected at v1-AD-a end: 25 (23 + 2 v1-AD admin-config consts)
   
-  rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | awk -F: '/ENTRY_KIND_/ {print}' | grep -oE '"[a-z_]+"' | sort | uniq -d
-  # Expected: empty output (no duplicates)
+  # Count RE-EXPORTED consts (shim parity):
+  rg "ENTRY_KIND_" crates/api/api/src/governance/governance_log.rs | rg -c "^\s+ENTRY_KIND_"
+  # Must equal the define count above exactly. Shim parity is load-bearing.
   
-  # Registry file structure match
+  # No duplicate string literal values (collision check):
+  rg -n '"[a-z_]+"' crates/db_schema/src/source/governance/governance_log.rs | awk -F: '/ENTRY_KIND_/ {print}' | grep -oE '"[a-z_]+"' | sort | uniq -d
+  # Expected: empty output
+  
+  # Registry file populated-row total must equal the define count:
+  rg "^\| \`[a-z_]+\`" .claude/rules/governance-log-entry-kind-registry.md | wc -l
+  # Must equal the `rg "^pub const ENTRY_KIND_"` db_schema count above (25 at v1-AD-a end).
+  
+  # Registry file section structure match
   grep -c "^## " .claude/rules/governance-log-entry-kind-registry.md
-  # Expected: >= 7  (v0, Phase 6 pending, v1-AD-a, 4 reserved sections, acceptance)
+  # Expected: >= 7  (v0, Phase 6, v1-AD-a, 3 reserved for future v1 PRDs, acceptance)
   ```
 
 ### Task 9: OPEN OQ-V1-AD-01/02/03 in `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md`

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -82,7 +82,7 @@ Per-sub-phase merge discipline: v1-AD-a ships as its own PR `phase-v1-AD-a` → 
 | Complexity | MEDIUM |
 | Crates affected | `db_schema_file` (schema.rs hand-edit), `db_schema` (model/InsertForm), `api` (config.rs + governance_log.rs), `migrations/` (4 new) |
 | v0 step | v1 post-MVP per [ADR-010](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — keystone sub-phase |
-| Dependencies | governance-v0 HEAD `3bbf419da`; no Phase 6 dependency (verified in PRD §8.2 migration list) |
+| Dependencies | governance-v0 HEAD `5ce5358fc` (post-Phase-6 merge `08065e1a1`); no further Phase 6 dependency — Phase 6 preconditions already met on trunk (verified in PRD §8.2 migration list). Pre-Phase-6 baseline was `3bbf419da` — see §8 before-state. |
 | Estimated tasks | **9 implementation tasks + pre-flight Task 0** (10 total; Tasks 0–9 enumerated in §13) |
 | Sub-phase target branch | `phase-v1-AD-a` branched from `governance-v0` |
 | PR target | `governance-v0` (per `.claude/rules/phase-branch.md`) |
@@ -474,19 +474,26 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
 
 ### Task 0: PRE-FLIGHT — verify branch + wrapper sanity + v0 baseline
 
-- **ACTION**: Confirm `phase-v1-AD-a` branched from `governance-v0` at `3bbf419da` per `.claude/rules/phase-branch.md`. Run the pre-phase harness audit per `.claude/rules/pre-phase-harness-audit.md` — all four probes against `governance-v0` HEAD, capturing logs under `.claude/PRPs/debug/phase-v1-AD-a-audit-*.log`.
+- **ACTION**: Confirm `phase-v1-AD-a` is branched from current `governance-v0` HEAD (which at plan-write time 2026-04-19 is `5ce5358fc`, post-Phase-6-merge — may have advanced since if `governance-v0` has taken further merges; verify the branch-point matches current HEAD parametrically, not against a hardcoded SHA) per `.claude/rules/phase-branch.md`. Run the pre-phase harness audit per `.claude/rules/pre-phase-harness-audit.md` — all four probes against `governance-v0` HEAD, capturing logs under `.claude/PRPs/debug/phase-v1-AD-a-audit-*.log`.
 - **GOTCHA**: If the current branch is `governance-v0`, STOP and write a `.claude/decision-queue.json` entry — advisor cuts the phase branch, not the impl agent.
 - **GOTCHA**: All four probes must pass AND the negative probes must return non-zero exit codes. Failure = wrapper bug that will invalidate every downstream cargo signal. Fix wrapper in a pre-task commit before Task 1.
 - **VALIDATE**:
   ```bash
   git branch --show-current            # → phase-v1-AD-a
-  git log -1 --format=%H governance-v0 # → 3bbf419da
+  # Verify the branch-point parametrically — phase-v1-AD-a's merge-base with
+  # governance-v0 must equal current governance-v0 HEAD (branch was just cut
+  # and has no commits yet, OR advisor has cut it fresh from current HEAD).
+  git merge-base phase-v1-AD-a governance-v0   # record output
+  git log -1 --format=%H governance-v0         # record output
+  # The two SHAs above must be equal. If they differ, phase-v1-AD-a was cut
+  # from a stale governance-v0; stop and re-cut from current HEAD.
+  # (At plan-write time 2026-04-19 this value is 5ce5358fc, post-Phase-6.)
   cmd //c "scripts\\brehon\\cargo-check.bat -p lemmy_api > .claude/PRPs/debug/phase-v1-AD-a-audit-probe1.log 2>&1"
   echo "probe1 exit: $?"  # expect 0
   cmd //c "scripts\\brehon\\cargo-check.bat -p lemmy_api --features nonexistent_xyz > .claude/PRPs/debug/phase-v1-AD-a-audit-probe4.log 2>&1"
   echo "probe4 exit: $?"  # expect non-zero
   ```
-- **EXPECT**: branch correct; exit codes as commented; no commits from this task.
+- **EXPECT**: `git merge-base` output equals `git log -1 --format=%H governance-v0` output (SHAs match, parametric); exit codes as commented; no commits from this task.
 
 ### Task 1: CREATE `migrations/2026-04-21-000000-0000_add_rule_set_versions/up.sql` + down.sql
 
@@ -1134,7 +1141,7 @@ v1-AD-a adds **no new test files**. It extends the two existing tests:
 
 ## 15. Validation commands (DoD)
 
-**Every command below was dry-run-tested against governance-v0 HEAD 3bbf419da on 2026-04-19 per `.claude/rules/pre-phase-harness-audit.md` + advisor directive.** Expected exit codes annotated inline.
+**Every command below was dry-run-tested against governance-v0 HEAD `3bbf419da` on 2026-04-19 (pre-Phase-6-merge) per `.claude/rules/pre-phase-harness-audit.md` + advisor directive. Post-Phase-6 HEAD is `5ce5358fc` (merged 2026-04-19 17:15 UTC); the commands remain valid — `config.rs` and the schema additions are unchanged between `3bbf419da` and `5ce5358fc`, and the ENTRY_KIND definition-path move to `db_schema` is handled by the §10.8 dual-file edit and Task 8 parametric greps (not by these validation commands).** Expected exit codes annotated inline.
 
 ### Level 1: per-task `cargo check` (run after every task)
 

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -129,7 +129,7 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 
 ### Before state (governance-v0 HEAD 3bbf419da)
 
-```
+```text
 ╔═══════════════════════════════════════════════════════════════════════════════╗
 ║                              BEFORE STATE                                      ║
 ╠═══════════════════════════════════════════════════════════════════════════════╣
@@ -153,7 +153,7 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 
 ### After state (end of v1-AD-a)
 
-```
+```text
 ╔═══════════════════════════════════════════════════════════════════════════════╗
 ║                               AFTER STATE                                      ║
 ╠═══════════════════════════════════════════════════════════════════════════════╣
@@ -169,7 +169,7 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 ║   sponsor_allowlist: new table, 4 columns (reserved; read-path lands in v1-AD-b)║
 ║   ENTRY_KIND_* consts: 21 (19 v0 + ENTRY_KIND_ADMIN_CONFIG_CHANGED,           ║
 ║                            ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED)             ║
-║   CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata; 62] compile-time          ║
+║   CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata] len=61 compile-time       ║
 ║   parity::every_seeded_key_has_metadata test passes                           ║
 ║   .claude/rules/governance-log-entry-kind-registry.md initialised             ║
 ║                                                                               ║
@@ -687,8 +687,24 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
 
 - **ACTION**: Seed the 27 new rows idempotently. The INSERT rows MUST match task 6's `SEEDED_KEYS_WITH_CONSTS` entries byte-for-byte. Also land the two new ENTRY_KIND consts (combined task because both are small, non-conflicting, and the parity test + migration test share a validation step).
 - **IMPLEMENT** (migration):
+
+  **⚠ NON-AUTHORITATIVE SQL BLOCK — reconciliation at plan-review (see GOTCHA below).** The rows listed below are drawn from PRD §5.2's full v1 cross-PRD enumeration and include keys owned by sponsor-liability-v1 (10× `liability.*`), federation-inbound-v1 (5× `federation.*` partial), reputation-tuning-v1 (3× `decay.*` partial, 4× `participation.*` partial), and jury-mechanics-v1 (some `jury.*` cascade rows). v1-AD-a ships ONLY the admin-dashboard-owned subset (per PRD §3.1 contribution sub-table: ~24 keys minus `rule_set.active_version_id` = **expected 23-27 admin-dashboard rows** — reconciliation gate below narrows this).
+
+  The authoritative count (`EXPECTED_SEED_COUNT_V1_AD`, currently estimated 27) is reconciled at task-7-pre-commit time against PRD §3.1's per-sub-PRD ownership split, NOT against the rows listed below. The implementer:
+  1. Reads PRD §3.1 contribution sub-table to extract admin-dashboard-owned keys
+  2. Writes task 6's `SEEDED_KEYS_WITH_CONSTS` extension to match
+  3. Writes task 7's INSERT block to match task 6 byte-for-byte
+  4. Runs the reconciliation gate (below) before committing
+  5. Adjusts `EXPECTED_SEED_COUNT_V1_AD` to the actual count
+
+  If the implementer is unclear which keys belong to admin-dashboard vs sponsor-liability vs reputation-tuning etc., they MUST write a DQ entry pointing to PRD §3.1 "per-PRD contribution sub-table" and wait for advisor clarification — do NOT self-resolve by picking keys arbitrarily from the SQL block below.
+
   ```sql
-  -- up.sql
+  -- up.sql — NON-AUTHORITATIVE, see reconciliation gate above.
+  -- Full PRD §5.2 enumeration (35 rows); v1-AD-a ships admin-dashboard-
+  -- owned subset only (~27). Sponsor-liability, federation-inbound,
+  -- reputation-tuning, and jury-mechanics keys below land in their own
+  -- sub-PRD plans, NOT in v1-AD-a.
   INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text) VALUES
     ('instance', 'jury.severity_thresholds.minor',              'text',  NULL,  NULL, NULL,  'majority'),
     ('instance', 'jury.severity_thresholds.moderate',           'text',  NULL,  NULL, NULL,  '60%'),
@@ -791,7 +807,7 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
   cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server config_parity_round_trip > .claude/PRPs/debug/task7-e2e.log 2>&1"
   echo "e2e exit: $?"
   ```
-  Expect both to exit 0. The `config_parity_round_trip` test at `crates/server/tests/e2e.rs:1308-1366` will iterate all 62 `SEEDED_KEYS_WITH_CONSTS` entries and call the typed accessor — any missing seed row, missing const, or type mismatch fails here.
+  Expect both to exit 0. The `config_parity_round_trip` test at `crates/server/tests/e2e.rs:1308-1366` will iterate all `SEEDED_KEYS_WITH_CONSTS` entries (currently `EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` = 34 + 27 = 61 post-reconciliation) and call the typed accessor — any missing seed row, missing const, or type mismatch fails here.
 
 ### Task 8: INITIALISE `.claude/rules/governance-log-entry-kind-registry.md` (closes #41)
 
@@ -813,9 +829,24 @@ Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a
   3. Grep DoD in plan file: `rg "ENTRY_KIND_<NAME>" crates/api/api/src/governance/governance_log.rs`
      returns the const; `rg '"<snake_case>"' crates/` returns the const line
      + every call site.
-  4. Collision check at plan-review: `rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort -u | wc -l`
-     returns exactly `EXPECTED_SEED_COUNT + sum(EXPECTED_SEED_COUNT_V1_*)`
-     and every literal appears exactly once.
+  4. Collision check at plan-review: the count of lowercase string literals in
+     governance_log.rs (the entry_kind &str values) must equal the count of
+     `pub const ENTRY_KIND_*` declarations in the same file, and every literal
+     must appear exactly once. Two greps, same file, same domain:
+     ```bash
+     rg -c '^pub const ENTRY_KIND_' crates/api/api/src/governance/governance_log.rs
+     # Count A: number of ENTRY_KIND_* consts
+
+     rg -oE '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort -u | wc -l
+     # Count B: number of unique lowercase string literals
+
+     # Invariant: A == B, AND no duplicate literals
+     rg -oE '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort | uniq -d
+     # Expected: empty (no duplicates)
+     ```
+     NOTE: this invariant is **governance-log-domain only** — it does NOT
+     reference `EXPECTED_SEED_COUNT` or `EXPECTED_SEED_COUNT_V1_*` (which are
+     config-key-seed parity counters, a different domain).
 
   This file is MANDATORY READING in `-p` mode. Every PRP plan that touches
   governance writes reads it at first iteration. Mirrors
@@ -1011,7 +1042,7 @@ v1-AD-a adds **no new test files**. It extends the two existing tests:
 |---|---|---|
 | `parity::every_seeded_key_has_metadata` (NEW) | `crates/api/api/src/governance/config.rs::parity` | Every `SEEDED_KEYS_WITH_CONSTS` entry has a matching `CONFIG_KEY_METADATA` row |
 | `parity::seeded_keys_count_matches_const_count` (EXTENDED) | same file | Now asserts `SEEDED_KEYS_WITH_CONSTS.len() == EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` |
-| `config_parity_round_trip` (UNCHANGED BODY, BROADER COVERAGE) | `crates/server/tests/e2e.rs:1308-1366` | Runs all 62 typed reads against a real Postgres with all 62 seeded rows |
+| `config_parity_round_trip` (UNCHANGED BODY, BROADER COVERAGE) | `crates/server/tests/e2e.rs:1308-1366` | Runs one typed read per `SEEDED_KEYS_WITH_CONSTS` entry (currently 61 = EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD) against a real Postgres with the matching seeded rows |
 
 ### Edge cases covered by existing tests
 
@@ -1065,7 +1096,7 @@ echo "build exit: $?"
 cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server config_parity_round_trip > .claude/PRPs/debug/phase-v1-AD-a-e2e-run.log 2>&1"
 echo "run exit: $?"
 ```
-**EXPECT**: 0 on both. The `config_parity_round_trip` test applies all migrations (including the 4 new ones), then walks `SEEDED_KEYS_WITH_CONSTS` (62 entries) calling the typed accessors. Any missing seed row, missing const, or type mismatch fails here.
+**EXPECT**: 0 on both. The `config_parity_round_trip` test applies all migrations (including the 4 new ones), then walks `SEEDED_KEYS_WITH_CONSTS` (`EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` = 34 + 27 = 61 entries post-reconciliation; exact count is parametric) calling the typed accessors. Any missing seed row, missing const, or type mismatch fails here.
 
 ### Level 5: clippy (per plan-drift CI)
 

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -83,7 +83,7 @@ Per-sub-phase merge discipline: v1-AD-a ships as its own PR `phase-v1-AD-a` → 
 | Crates affected | `db_schema_file` (schema.rs hand-edit), `db_schema` (model/InsertForm), `api` (config.rs + governance_log.rs), `migrations/` (4 new) |
 | v0 step | v1 post-MVP per [ADR-010](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — keystone sub-phase |
 | Dependencies | governance-v0 HEAD `3bbf419da`; no Phase 6 dependency (verified in PRD §8.2 migration list) |
-| Estimated tasks | **7** |
+| Estimated tasks | **9 implementation tasks + pre-flight Task 0** (10 total; Tasks 0–9 enumerated in §13) |
 | Sub-phase target branch | `phase-v1-AD-a` branched from `governance-v0` |
 | PR target | `governance-v0` (per `.claude/rules/phase-branch.md`) |
 | Closes | GH issue #41 (entry-kind registry) as a side-effect |
@@ -97,7 +97,7 @@ The parent PRD's 8 HTTP routes + dashboard aggregate + SSE + askama pages exceed
 
 | Sub-phase | Scope | Task count | Blocks |
 |---|---|---|---|
-| **v1-AD-a** (this plan) | 4 migrations + `ConfigKeyMetadata` registry + 2 new ENTRY_KIND consts + entry-kind registry doc | 7 | v1-AD-b, c, d |
+| **v1-AD-a** (this plan) | 4 migrations + `ConfigKeyMetadata` registry + 2 new ENTRY_KIND consts + entry-kind registry doc | 9 (+ Task 0 pre-flight gate) | v1-AD-b, c, d |
 | v1-AD-b (future) | `POST/GET /admin/config` + `GET /admin/config/audit` + capability checks + dry-run impact computation + per-key type validation | 8-9 | v1-AD-e |
 | v1-AD-c (future) | `rule_set_version` routes + `moderation_case.rule_set_version_id` wire-up in `submit_jury_vote` | 4-5 | — |
 | v1-AD-d (future) | `GET /admin/dashboard` aggregate + `GET /admin/audit/stream` SSE | 3-4 | depends on OQ-V1-AD-02 |
@@ -445,7 +445,7 @@ flag it. Verify the existing shim preserves alphabetical order before appending
 | `.claude/rules/governance-log-entry-kind-registry.md` | CREATE | Initialise registry per advisor directive #2; close GH #41 |
 | `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md` | UPDATE | Open OQ-V1-AD-01/02/03 (leans only; no resolution) |
 
-**Total: 17 files changed (4 NEW migration dirs × 2 files = 8 migration files, 4 NEW Rust files, 5 UPDATED Rust files, 1 NEW rules file, 1 UPDATED design doc).**
+**Total: 17 files changed (4 NEW migration dirs × 2 files = 8 migration files; 2 NEW Rust files — `rule_set_version.rs`, `sponsor_allowlist.rs`; 5 UPDATED Rust files — `schema.rs`, `mod.rs`, `newtypes.rs`, `config.rs`, `governance_log.rs`; 1 NEW rules file; 1 UPDATED design doc). 8 + 2 + 5 + 1 + 1 = 17.**
 
 ---
 
@@ -1180,7 +1180,7 @@ echo "all PM hooks present"
 - [ ] `rule_set.active_version_id` is NOT seeded, NOT in `SEEDED_KEYS_WITH_CONSTS`, NOT in `CONFIG_KEY_METADATA`, NOT in `const_default_int` (per advisor edit #2 — absence-of-row IS the "no active version" signal)
 - [ ] `ENTRY_KIND_ADMIN_CONFIG_CHANGED == "admin_config_changed"` — byte-identical to shell-script emission at `scripts/brehon/admin-config-write.sh:148`
 - [ ] `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED == "admin_config_change_denied"`
-- [ ] `.claude/rules/governance-log-entry-kind-registry.md` exists and lists 21 populated kinds (19 v0 + 2 v1-AD) + Phase 6 pending section + 4 reserved sections for future v1 PRDs (7 sections + acceptance = ≥8 `## ` headings)
+- [ ] `.claude/rules/governance-log-entry-kind-registry.md` exists and its populated-kind total equals the current `ENTRY_KIND_*` literal count in `crates/db_schema/src/source/governance/governance_log.rs` (parametric by merge state — at `governance-v0` @ `5ce5358fc` this is **25** = 19 v0 + 4 Phase 6 + 2 v1-AD). Registry includes a Phase 6 section (4 kinds, merged) + 4 reserved sections for future v1 PRDs (7 sections + acceptance = ≥8 `## ` headings). Exact total is parametric, not pinned to a literal.
 - [ ] Registry file section structure matches GH #41 "Proposed deliverable" enumeration byte-for-byte (advisor edit #3)
 - [ ] GH #41 closeable with "landed at `.claude/rules/governance-log-entry-kind-registry.md` in v1-AD-a at `<commit>`" comment
 - [ ] OQ-V1-AD-01/02/03 opened in 99-decisions-and-open-questions.md (leans documented, no resolution)
@@ -1267,7 +1267,7 @@ These are planning scaffolds only. Each requires its own `/prp-plan` run against
 - `POST /api/v4/governance/admin/rule-sets` create handler (appends version)
 - `submit_jury_vote` edit: pin `moderation_case.rule_set_version_id = current_active_version` at decision time
 - `admin_assign_jury` edit: populate `moderation_case.applied_config_snapshot` at panel-assembly time
-- `rule_set.active_version_id = -1 → None` reader conversion
+- `rule_set.active_version_id` absence-of-row read path via `config::get_int_opt` (no sentinel values; `None` means "no active version" per locked decision in §4.1 and §16)
 
 **Blocked by:** v1-AD-a merged.
 

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -127,7 +127,15 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 
 ## 8. Flow design
 
-### Before state (governance-v0 HEAD 3bbf419da)
+### Before state (governance-v0 HEAD 5ce5358fc; post-Phase-6 merge at 08065e1a1)
+
+Baseline-SHA bumped from `3bbf419da` → `5ce5358fc` after Phase 6 (PR #46) merged.
+Phase 6 added 4 federation `ENTRY_KIND_*` constants AND relocated the writer +
+all constants from `crates/api/api/src/governance/governance_log.rs` DOWN to
+`crates/db_schema/src/source/governance/governance_log.rs` per DQ-6.6
+(the api-path file is now a thin `pub use` re-export shim, ~66 lines).
+`config.rs` is unchanged between `3bbf419da` and `5ce5358fc` — all `config.rs`
+references in this plan remain accurate.
 
 ```text
 ╔═══════════════════════════════════════════════════════════════════════════════╗
@@ -140,7 +148,9 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 ║   moderation_case: 16 columns — no applied_config_snapshot                    ║
 ║   rule_set_version: does NOT exist                                            ║
 ║   sponsor_allowlist: does NOT exist                                           ║
-║   ENTRY_KIND_* consts: 19 (governance_log.rs:50-68)                           ║
+║   ENTRY_KIND_* consts: 23 at                                                  ║
+║     crates/db_schema/src/source/governance/governance_log.rs                  ║
+║     (19 v0 + 4 Phase 6 federation kinds; re-exported via api shim).           ║
 ║   'admin_config_changed' entry_kind: used as a string literal by              ║
 ║     scripts/brehon/admin-config-write.sh:148 (no Rust const)                  ║
 ║   CONFIG_KEY_METADATA registry: does NOT exist                                ║
@@ -167,8 +177,9 @@ OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in par
 ║                    18 columns (+rule_set_version_id INT4 nullable FK)         ║
 ║   rule_set_version: new table, 7 columns, append-only                         ║
 ║   sponsor_allowlist: new table, 4 columns (reserved; read-path lands in v1-AD-b)║
-║   ENTRY_KIND_* consts: 21 (19 v0 + ENTRY_KIND_ADMIN_CONFIG_CHANGED,           ║
+║   ENTRY_KIND_* consts: 25 (23 pre-v1-AD + ENTRY_KIND_ADMIN_CONFIG_CHANGED,    ║
 ║                            ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED)             ║
+║     Consts defined in db_schema path; re-exported via api shim.               ║
 ║   CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata] len=61 compile-time       ║
 ║   parity::every_seeded_key_has_metadata test passes                           ║
 ║   .claude/rules/governance-log-entry-kind-registry.md initialised             ║
@@ -363,11 +374,25 @@ mod parity {
 }
 ```
 
-### 10.8 ENTRY_KIND const addition
+### 10.8 ENTRY_KIND const addition (dual-file edit post-Phase-6)
+
+**Phase 6 relocation note:** the `ENTRY_KIND_*` consts + `append` writer live in
+`crates/db_schema/src/source/governance/governance_log.rs` (moved from the
+`api` path per DQ-6.6). The `api` path at
+`crates/api/api/src/governance/governance_log.rs` is a ~66-line re-export shim
+holding a `pub use` list. Adding new kinds requires editing BOTH files:
+
+1. **Define** in `crates/db_schema/src/source/governance/governance_log.rs` —
+   append after the existing `ENTRY_KIND_*` consts (currently through
+   `ENTRY_KIND_FEDERATION_ATTESTATION_RECEIVED` on the 23-const list).
+2. **Re-export** in `crates/api/api/src/governance/governance_log.rs` — extend
+   the alphabetical `pub use lemmy_db_schema::source::governance::governance_log::{…}`
+   list (currently 23 names + `GovernanceLog` + `GovernanceLogInsertForm` + `append`).
 
 ```rust
-// SOURCE: crates/api/api/src/governance/governance_log.rs:50-68
-// APPEND after ENTRY_KIND_APPEAL_REQUESTED:
+// File 1: crates/db_schema/src/source/governance/governance_log.rs
+// APPEND after existing ENTRY_KIND_* consts (append-only, alphabetical is
+// NOT enforced; keep grouping with other v1-AD entries if/when added):
 
 // v1-AD-a additions (v1 admin dashboard sub-phase A):
 pub const ENTRY_KIND_ADMIN_CONFIG_CHANGED: &str = "admin_config_changed";
@@ -376,6 +401,25 @@ pub const ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED: &str = "admin_config_change_den
 // at scripts/brehon/admin-config-write.sh:148 — DO NOT rename. v1-AD-b's HTTP
 // path must write byte-identical payloads per NOT5 deprecation gate 3.
 ```
+
+```rust
+// File 2: crates/api/api/src/governance/governance_log.rs
+// EXTEND the existing `pub use` list; alphabetical order is enforced by the
+// shim (the 23 existing names are alphabetical). Insert ADMIN_* alphabetically
+// between CAPABILITY_CHANGED and APPEAL_REQUESTED.
+
+pub use lemmy_db_schema::source::governance::governance_log::{
+  ENTRY_KIND_ADMIN_CONFIG_CHANGED,         // new — v1-AD-a
+  ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED,   // new — v1-AD-a
+  ENTRY_KIND_APPEAL_REQUESTED,
+  // … existing names …
+};
+```
+
+**GOTCHA:** clippy workspace runs with `-D warnings`; if the shim's `pub use`
+list falls out of alphabetical order, some workspace lint configurations will
+flag it. Verify the existing shim preserves alphabetical order before appending
+(it does as of `5ce5358fc`).
 
 ---
 

--- a/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
+++ b/.claude/PRPs/plans/v1-admin-dashboard-a.plan.md
@@ -1,0 +1,1222 @@
+# Plan: v1-AD-a — Admin Dashboard migrations + ConfigKeyMetadata registry
+
+## Table of contents
+
+| § | Heading | Line |
+|---|---|---|
+| 1 | Summary | 30 |
+| 2 | Source | 38 |
+| 3 | Problem statement | 48 |
+| 4 | Solution statement | 59 |
+| 5 | Metadata | 77 |
+| 6 | Sub-phase split (v1-AD-a → v1-AD-e) | 94 |
+| 7 | Open questions (must land before dependent sub-phases) | 112 |
+| 8 | Flow design | 128 |
+| 9 | Mandatory reading | 189 |
+| 10 | Patterns to mirror | 219 |
+| 11 | Files to change | 382 |
+| 12 | NOT building in v1-AD-a | 408 |
+| 13 | Step-by-step tasks | 426 |
+| 14 | Testing strategy | 1000 |
+| 15 | Validation commands (DoD) | 1032 |
+| 16 | Acceptance criteria | 1096 |
+| 17 | Completion checklist | 1122 |
+| 18 | Risks and mitigations | 1140 |
+| 19 | Notes | 1157 |
+| 20 | Sub-phase stubs (v1-AD-b/c/d/e TOC) | 1166 |
+
+---
+
+## 1. Summary
+
+v1-AD-a is the **foundation sub-phase** of the v1 admin-dashboard keystone. It ships the four new v1 migrations (`add_rule_set_versions`, `add_sponsor_allowlist`, `add_case_applied_config_snapshot`, `seed_v1_config_keys`), extends the v0 `EXPECTED_SEED_COUNT = 34` parity contract with a parametric `EXPECTED_SEED_COUNT_V1_AD = 27` (27 admin-dashboard-owned keys — `rule_set.active_version_id` deliberately omitted per §4.1), adds the compile-time `CONFIG_KEY_METADATA` registry (per NOT4 2026-04-19: `&'static [ConfigKeyMetadata]`, not a DB table), adds two new `ENTRY_KIND_ADMIN_CONFIG_*` consts, and initialises `.claude/rules/governance-log-entry-kind-registry.md` from the v0 baseline (closes GH issue #41 as a side-effect). No HTTP routes land in v1-AD-a — endpoints ship in v1-AD-b.
+
+This sub-phase's value alone: the database is now capable of answering "what's the current value of each configurable knob?" and "what rule-set version was this case decided under?" — before any new write path exists. v1-AD-b then builds the write path on top.
+
+---
+
+## 2. Source
+
+- [../prds/v1-admin-dashboard.prd.md](../prds/v1-admin-dashboard.prd.md) §3 (schema), §5 (defaults), §8 (migrations). §4/§6/§7 are v1-AD-b/c/d scope.
+- [../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) ADR-008 (signed log), ADR-010 (staged releases), ADR-012 (Extism + Lemmy 1.0-beta), ADR-015 (pseudonyms), OQ-002 (rule-set versioning), OQ-018 (admin config write — **design authored by this plan's parent PRD**), OQ-026 (status-aware rule cascade).
+- [../../../docs/brehon-law-inspired-network/04-data-model-and-api.md](../../../docs/brehon-law-inspired-network/04-data-model-and-api.md) §3 (governance_config + governance_log models).
+- Parent PRD Resolutions applied §11 (2026-04-19) — B1/B2/B3/B4/B5, N1, NOT1, NOT4, NOT5 are locked; do NOT re-litigate.
+- [GH issue #41](https://github.com/barrie-cork/lemmy/issues/41) — entry-kind registry tracker, closed as a side-effect of this sub-phase per handover directive 2026-04-19.
+
+---
+
+## 3. Problem statement
+
+Four things must exist on disk before a v1 operator can edit any config via HTTP:
+
+1. A canonical compile-time metadata registry (`ConfigKeyMetadata` array) so the write endpoint can validate type, range, scope, and `requires_re_jury` on every key.
+2. An `applied_config_snapshot` JSONB column on `moderation_case` so in-flight juries can be grandfathered against panel-size / quorum / threshold edits (ADR-010 invariant: no retroactive invalidation).
+3. A versioned rule-set table (`rule_set_version`) so `submit_jury_vote` can pin a case to the rule text as it was when the case was decided (OQ-002).
+4. The v1 config rows seeded into `governance_config` with parity against new Rust `DEFAULT_*` consts (Watch-1 parity contract — already enforced for v0 at `config.rs:469`). Count is **parametric** (`EXPECTED_SEED_COUNT_V1_AD`, currently 27) and reconciled at task 7's pre-commit gate against PRD §5.2 as source of truth.
+
+v0 ships none of these. The v0 shell script `scripts/brehon/admin-config-write.sh:148` already writes `admin_config_changed` entries, but there is no Rust const for that string — v1-AD-b needs one before it can call `governance_log::append`.
+
+## 4. Solution statement
+
+Land four idempotent migrations under the existing `YYYY-MM-DD-HHMMSS-NNNN_name` convention (next free slot `2026-04-21-000000-0000_*`), extend `crates/api/api/src/governance/config.rs` with a `CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata]` array **additive to** `SEEDED_KEYS_WITH_CONSTS` (not a replacement), and add two new `ENTRY_KIND_*` consts to `governance_log.rs`. Extend the Diesel schema via hand-edit of `crates/db_schema_file/src/schema.rs` (the fork's convention: `@generated automatically by Diesel CLI` header + hand-added view/table blocks for governance; see schema.rs:426-441 for precedent). Add the `ConfigKeyMetadata` struct + `ValueType`/`ConfigScope`/`ApplyAt` enums in `config.rs` alongside the existing `Scope` enum.
+
+No HTTP handlers. No routes. No askama templates. No SSE.
+
+Per-sub-phase merge discipline: v1-AD-a ships as its own PR `phase-v1-AD-a` → `governance-v0`, earns its own CodeRabbit review, then v1-AD-b plans on top of the merged HEAD.
+
+### 4.1 Architecturally load-bearing decisions locked in this sub-phase
+
+- **CONFIG_KEY_METADATA is compile-time, not a DB table.** (NOT4 2026-04-19, PRD §3.2). A new key requires a PR-against-Rust-code edit. The parity test `every_seeded_key_has_metadata` rejects DB-only additions.
+- **EXPECTED_SEED_COUNT stays at 34 (v0 invariant).** A new `EXPECTED_SEED_COUNT_V1_AD: usize = 27` is added *beside* it; the parity test becomes `SEEDED_KEYS_WITH_CONSTS.len() == EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` so each subsequent v1 sub-PRD adds its own parametric count (`EXPECTED_SEED_COUNT_V1_JM`, etc.) without churning this one. See directive #4 from advisor 2026-04-19. (27, not 28, because `rule_set.active_version_id` is not seeded — its absence is the "no active version" signal; see next bullet.)
+- **`rule_set.active_version_id` is deliberately UN-seeded in v1-AD-a.** Per advisor edit #2 (2026-04-19): storing `-1` as a `None` sentinel in a Postgres INTEGER column is a footgun that leaks to every `config::get_int` read. Instead, the absence of a `governance_config` row for this key IS the signal for "no active version" — the v0 reader already returns the Rust const default when no row matches, and `config.rs` will NOT declare a `DEFAULT_RULE_SET_ACTIVE_VERSION_ID` const. v1-AD-c seeds the key via INSERT only when admin actually activates a rule set via `POST /api/v4/governance/admin/rule-sets`. v1-AD-b readers needing this key call a new `config::get_int_opt` accessor (added in v1-AD-b, not here) that returns `None` when both the DB row and the const default are absent. This is the append-only convention: you write the row when the fact exists, not before.
+- **Rule-set text is NOT federated in v0/v1-AD.** No `crates/apub/` changes. Federation of rule-set versions is v2+ scope.
+- **`moderation_case.applied_config_snapshot` is nullable.** Existing (pre-v1-AD) cases keep NULL; new cases populate. No backfill required.
+
+---
+
+## 5. Metadata
+
+| Field | Value |
+|---|---|
+| Type | `SCHEMA + CROSS_CUTTING` |
+| Complexity | MEDIUM |
+| Crates affected | `db_schema_file` (schema.rs hand-edit), `db_schema` (model/InsertForm), `api` (config.rs + governance_log.rs), `migrations/` (4 new) |
+| v0 step | v1 post-MVP per [ADR-010](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — keystone sub-phase |
+| Dependencies | governance-v0 HEAD `3bbf419da`; no Phase 6 dependency (verified in PRD §8.2 migration list) |
+| Estimated tasks | **7** |
+| Sub-phase target branch | `phase-v1-AD-a` branched from `governance-v0` |
+| PR target | `governance-v0` (per `.claude/rules/phase-branch.md`) |
+| Closes | GH issue #41 (entry-kind registry) as a side-effect |
+| Opens | 3 new OQs (see §7) before v1-AD-b plan writes |
+
+---
+
+## 6. Sub-phase split (v1-AD-a → v1-AD-e)
+
+The parent PRD's 8 HTTP routes + dashboard aggregate + SSE + askama pages exceeds the governance-v0 phase-splitting rule (≤10-12 tasks per ralph loop). Split matches Phase 5's three-sub-phase cadence:
+
+| Sub-phase | Scope | Task count | Blocks |
+|---|---|---|---|
+| **v1-AD-a** (this plan) | 4 migrations + `ConfigKeyMetadata` registry + 2 new ENTRY_KIND consts + entry-kind registry doc | 7 | v1-AD-b, c, d |
+| v1-AD-b (future) | `POST/GET /admin/config` + `GET /admin/config/audit` + capability checks + dry-run impact computation + per-key type validation | 8-9 | v1-AD-e |
+| v1-AD-c (future) | `rule_set_version` routes + `moderation_case.rule_set_version_id` wire-up in `submit_jury_vote` | 4-5 | — |
+| v1-AD-d (future) | `GET /admin/dashboard` aggregate + `GET /admin/audit/stream` SSE | 3-4 | depends on OQ-V1-AD-02 |
+| v1-AD-e (future, optional) | Askama HTML pages (§6 of parent PRD) | deferred | depends on OQ-V1-AD-01 |
+
+Each sub-phase = its own PR → `governance-v0` → CodeRabbit review → retro. Matches Phase 5's cadence.
+
+v1-AD-b through v1-AD-e are **stubbed** in §20 (TOC only) — they are not planned in detail here. Planning each requires its own `/prp-plan` run against the then-current `governance-v0` HEAD (v1-AD-a merged).
+
+---
+
+## 7. Open questions (must land before dependent sub-phases)
+
+Per advisor directive 2026-04-19 (#3), three OQs must be opened in `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md` **before** v1-AD-b/c/d plans are written. They block architecture choices those sub-phases depend on. v1-AD-a itself is unblocked — it only produces schema + metadata + consts.
+
+| OQ | Question | Lean | Blocks |
+|---|---|---|---|
+| OQ-V1-AD-01 (new) | askama vs maud vs defer HTML pages — workspace dep policy, build-time impact, supply-chain surface | **Defer to v1.x; ship v1-AD-d API-only.** Neither crate exists in `Cargo.lock` today. | v1-AD-e |
+| OQ-V1-AD-02 (new) | actix-web-lab for SSE vs hand-rolled chunked-response (~80 LOC) | Upstream Lemmy does NOT use `actix-web-lab` (grep against `Cargo.lock` 2026-04-19 returned no matches). Lean: hand-rolled via `async-stream` (already transitive dep). | v1-AD-d |
+| OQ-V1-AD-03 (new) | Dry-run impact computation inside vs outside `run_transaction` | `crates/diesel_utils/src/connection.rs:68-79` shows `run_transaction` calls `diesel-async`'s `.transaction()` — no SAVEPOINT primitive exposed. Lean: **compute impact BEFORE tx opens** (read-only query against current config + the proposed value). Cleaner architecturally. Reshape PRD §4.3 to match. | v1-AD-b |
+
+**Task 7 of this plan opens all three OQs.** The opening is the smallest possible change to 99-decisions — no resolution, no design. Resolution happens before v1-AD-b/c/d plans commit.
+
+OQ-V1-AD-04 (`participation.attestation_enabled` UX shape, already listed in parent PRD §9) is not re-opened here — it's an existing PRD-tracked item.
+
+---
+
+## 8. Flow design
+
+### Before state (governance-v0 HEAD 3bbf419da)
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                              BEFORE STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   governance_config table: 34 v0 rows seeded                                  ║
+║   SEEDED_KEYS_WITH_CONSTS = [34 tuples]                                       ║
+║   EXPECTED_SEED_COUNT = 34                                                    ║
+║   moderation_case: 16 columns — no applied_config_snapshot                    ║
+║   rule_set_version: does NOT exist                                            ║
+║   sponsor_allowlist: does NOT exist                                           ║
+║   ENTRY_KIND_* consts: 19 (governance_log.rs:50-68)                           ║
+║   'admin_config_changed' entry_kind: used as a string literal by              ║
+║     scripts/brehon/admin-config-write.sh:148 (no Rust const)                  ║
+║   CONFIG_KEY_METADATA registry: does NOT exist                                ║
+║                                                                               ║
+║   PAIN: no way for HTTP handler to validate config writes at type-level;      ║
+║   no rule-set versioning; no in-flight-jury grandfathering substrate.         ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### After state (end of v1-AD-a)
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                               AFTER STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║   governance_config table: 61 rows (34 v0 + 27 v1-AD)                         ║
+║   SEEDED_KEYS_WITH_CONSTS = [61 tuples]                                       ║
+║   EXPECTED_SEED_COUNT = 34  (unchanged)                                       ║
+║   EXPECTED_SEED_COUNT_V1_AD = 27  (new — 27 because rule_set.active_version_id║
+║     is deliberately un-seeded; absence-of-row is the "no active version" sig) ║
+║   moderation_case: 17 columns (+applied_config_snapshot JSONB nullable)       ║
+║                    18 columns (+rule_set_version_id INT4 nullable FK)         ║
+║   rule_set_version: new table, 7 columns, append-only                         ║
+║   sponsor_allowlist: new table, 4 columns (reserved; read-path lands in v1-AD-b)║
+║   ENTRY_KIND_* consts: 21 (19 v0 + ENTRY_KIND_ADMIN_CONFIG_CHANGED,           ║
+║                            ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED)             ║
+║   CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata; 62] compile-time          ║
+║   parity::every_seeded_key_has_metadata test passes                           ║
+║   .claude/rules/governance-log-entry-kind-registry.md initialised             ║
+║                                                                               ║
+║   VALUE: v1-AD-b can now build POST /admin/config without schema work.        ║
+║   VALUE: ADR-010 invariant has a substrate (applied_config_snapshot column).  ║
+║   VALUE: OQ-002 resolved at schema layer.                                     ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### Data flow — no HTTP surface changes in v1-AD-a
+
+This sub-phase ships no new endpoints. All existing endpoints unchanged. `cargo check --workspace --features full` is the primary behavioural signal. One parity test + the existing `config_parity_round_trip` prove the new seed rows are readable via typed accessors.
+
+---
+
+## 9. Mandatory reading
+
+The implementation agent MUST read these files before starting, in this order:
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 | `.claude/PRPs/prds/v1-admin-dashboard.prd.md` | §3 (schema), §5 (defaults), §8 (migrations), §11 (resolutions) | PRD is authoritative; §11 locks B1-B6/N1/NOT1-5 decisions |
+| P0 | `crates/api/api/src/governance/config.rs` | 1-501 | v0 reader + parity tests. `CONFIG_KEY_METADATA` lands here. `EXPECTED_SEED_COUNT` line 463. `SEEDED_KEYS_WITH_CONSTS` lines 423-458. |
+| P0 | `crates/api/api/src/governance/governance_log.rs` | 50-68 | 19 v0 ENTRY_KIND consts to NOT collide with. `append()` signature line 87. |
+| P0 | `migrations/2026-04-18-000000-0000_add_governance_config/up.sql` | 1-113 | CREATE TABLE + view + idempotent INSERT shape. `ON CONFLICT (scope, key, valid_from) DO NOTHING` at line 113. |
+| P0 | `crates/db_schema/src/source/governance/governance_config.rs` | 1-53 | `GovernanceConfig` Queryable + `GovernanceConfigInsertForm` Insertable |
+| P0 | `crates/db_schema_file/src/schema.rs` | 412-455 | `@generated` header + hand-edited `governance_config`, `governance_config_current` view, `governance_log` table! blocks; precedent for adding new tables/views |
+| P1 | `migrations/2026-04-15-100100-0000_add_governance_core/up.sql` | 1-18 | `moderation_case` CREATE TABLE — FK shape for `ON DELETE SET NULL` / `ON DELETE CASCADE` |
+| P1 | `scripts/brehon/admin-config-write.sh` | 140-160 | Exact `admin_config_changed` payload shape — v1-AD-b must match this byte-for-byte per NOT5 gate 3 |
+| P1 | `.claude/rules/cargo-output-capture.md` | all | Mandatory when running any validation |
+| P1 | `.claude/rules/no-cargo-output-paste.md` | all | Companion to above |
+| P1 | `.claude/rules/view-crate-selectable-template.md` | all | Not directly applicable (no view crate added) but load-bearing reasoning for future sub-phases |
+| P1 | `.claude/rules/phase-branch.md` | all | Branch flow: `phase-v1-AD-a` → PR → `governance-v0` |
+| P2 | `crates/server/tests/e2e.rs` | 1-60, 1293-1366 | e2e harness entry, `config_parity_round_trip` test |
+
+### External documentation
+
+| Source | Version | Section | Why |
+|---|---|---|---|
+| [diesel 2.x docs](https://docs.rs/diesel/2.2) | 2.2 (check workspace `Cargo.toml`) | Jsonb, `#[derive(Insertable)]`, `ON CONFLICT` | JSONB column precedent in governance_log; `ON CONFLICT DO NOTHING` shape |
+
+No new external dependencies added in v1-AD-a (askama, actix-web-lab, etc. are v1-AD-d/e scope, gated on OQ-V1-AD-01/02).
+
+---
+
+## 10. Patterns to mirror
+
+Every snippet below is **copied verbatim** from the current workspace — not invented. Implementer should copy-paste and edit field names only.
+
+### 10.1 Migration shape (idempotent UP)
+
+```sql
+-- SOURCE: migrations/2026-04-18-000000-0000_add_governance_config/up.sql:19-36
+-- COPY THIS PATTERN for rule_set_version and sponsor_allowlist CREATE TABLE:
+
+CREATE TABLE governance_config (
+    id          SERIAL PRIMARY KEY,
+    scope       TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    value_type  TEXT NOT NULL,
+    value_int   BIGINT,
+    value_float DOUBLE PRECISION,
+    value_bool  BOOLEAN,
+    value_text  TEXT,
+    valid_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by  INTEGER REFERENCES person (id) ON DELETE RESTRICT
+);
+```
+
+### 10.2 FK to community
+
+```sql
+-- SOURCE: migrations/2026-04-15-100100-0000_add_governance_core/up.sql:3
+-- COPY THIS PATTERN for rule_set_version.community_id:
+
+community_id INTEGER NOT NULL REFERENCES community (id) ON DELETE CASCADE,
+```
+
+### 10.3 Idempotent seed INSERT
+
+```sql
+-- SOURCE: migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78-113
+-- COPY THIS PATTERN for seed_v1_config_keys:
+
+INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text) VALUES
+    ('instance', 'jury.severity_thresholds.minor',       'text', NULL, NULL, NULL, 'majority'),
+    ('instance', 'jury.severity_thresholds.moderate',    'text', NULL, NULL, NULL, '60%'),
+    -- ... 26 more rows from §5.2 ...
+ON CONFLICT (scope, key, valid_from) DO NOTHING;
+```
+
+### 10.4 ALTER TABLE ADD COLUMN (fast path — non-volatile default)
+
+```sql
+-- SOURCE: migrations/2026-04-18-000100-0000_add_person_membership_state/up.sql
+-- COPY THIS PATTERN for moderation_case.rule_set_version_id + applied_config_snapshot:
+-- Nullable columns need NO default and NO backfill.
+
+ALTER TABLE moderation_case ADD COLUMN applied_config_snapshot JSONB;
+ALTER TABLE moderation_case ADD COLUMN rule_set_version_id INTEGER REFERENCES rule_set_version(id);
+```
+
+### 10.5 Schema.rs hand-edit pattern
+
+```rust
+// SOURCE: crates/db_schema_file/src/schema.rs:426-441
+// COPY THIS PATTERN for rule_set_version + sponsor_allowlist + column additions:
+// Header says "@generated automatically by Diesel CLI" but new tables/views
+// are hand-added under the generated block. Governance_config_current view
+// is hand-edited precedent.
+
+diesel::table! {
+    governance_config_current (id) {
+        id -> Int4,
+        scope -> Text,
+        // ... columns ...
+    }
+}
+```
+
+### 10.6 Diesel model + InsertForm
+
+```rust
+// SOURCE: crates/db_schema/src/source/governance/governance_config.rs:1-53
+// COPY THIS PATTERN for RuleSetVersion + SponsorAllowlist:
+
+#[skip_serializing_none]
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "full", derive(Identifiable, Queryable, Selectable))]
+#[cfg_attr(feature = "full", diesel(table_name = governance_config))]
+#[cfg_attr(feature = "full", diesel(check_for_backend(diesel::pg::Pg)))]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct GovernanceConfig {
+  pub id: GovernanceConfigId,
+  pub scope: String,
+  // ... fields ...
+}
+
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "full", derive(Insertable))]
+#[cfg_attr(feature = "full", diesel(table_name = governance_config))]
+pub struct GovernanceConfigInsertForm {
+  pub scope: String,
+  // ... fields (no id, no valid_from) ...
+}
+```
+
+### 10.7 Parity test extension
+
+```rust
+// SOURCE: crates/api/api/src/governance/config.rs:469-500
+// EXTEND THIS PATTERN — do not replace:
+
+#[cfg(test)]
+mod parity {
+  use super::*;
+
+  #[test]
+  fn seeded_keys_count_matches_const_count() {
+    // Existing v0 test — do not remove or weaken.
+    // v1-AD extension: also assert the new split count.
+    assert_eq!(
+      SEEDED_KEYS_WITH_CONSTS.len(),
+      EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD,
+      "SEEDED_KEYS_WITH_CONSTS length ({}) must equal EXPECTED_SEED_COUNT ({}) + \
+       EXPECTED_SEED_COUNT_V1_AD ({}) — add/remove keys in both places. \
+       v1-AD-a does NOT include rule_set.active_version_id (absence-of-row \
+       is the no-active-version signal per §4.1).",
+      SEEDED_KEYS_WITH_CONSTS.len(),
+      EXPECTED_SEED_COUNT,
+      EXPECTED_SEED_COUNT_V1_AD,
+    );
+  }
+
+  #[test]
+  fn every_seeded_key_has_metadata() {
+    // NEW v1-AD test — every SEEDED_KEYS_WITH_CONSTS entry must have a
+    // matching CONFIG_KEY_METADATA entry (Watch-2 parity contract, NOT4).
+    let metadata_keys: HashSet<&str> =
+      CONFIG_KEY_METADATA.iter().map(|m| m.key).collect();
+    for (key, _const_name, _vtype) in SEEDED_KEYS_WITH_CONSTS {
+      assert!(
+        metadata_keys.contains(key),
+        "seeded key `{key}` missing from CONFIG_KEY_METADATA — add a \
+         ConfigKeyMetadata entry in config.rs"
+      );
+    }
+  }
+}
+```
+
+### 10.8 ENTRY_KIND const addition
+
+```rust
+// SOURCE: crates/api/api/src/governance/governance_log.rs:50-68
+// APPEND after ENTRY_KIND_APPEAL_REQUESTED:
+
+// v1-AD-a additions (v1 admin dashboard sub-phase A):
+pub const ENTRY_KIND_ADMIN_CONFIG_CHANGED: &str = "admin_config_changed";
+pub const ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED: &str = "admin_config_change_denied";
+// The "admin_config_changed" string matches the existing shell-script emission
+// at scripts/brehon/admin-config-write.sh:148 — DO NOT rename. v1-AD-b's HTTP
+// path must write byte-identical payloads per NOT5 deprecation gate 3.
+```
+
+---
+
+## 11. Files to change
+
+| File | Action | Justification |
+|---|---|---|
+| `migrations/2026-04-21-000000-0000_add_rule_set_versions/up.sql` | CREATE | Rule-set versioning schema per PRD §3.6 + OQ-002 |
+| `migrations/2026-04-21-000000-0000_add_rule_set_versions/down.sql` | CREATE | Drop in reverse dependency order |
+| `migrations/2026-04-21-000100-0000_add_sponsor_allowlist/up.sql` | CREATE | Reserve sponsor_allowlist table per PRD §3.1 + OQ-020 |
+| `migrations/2026-04-21-000100-0000_add_sponsor_allowlist/down.sql` | CREATE | Clean rollback |
+| `migrations/2026-04-21-000200-0000_add_case_applied_config_snapshot/up.sql` | CREATE | `applied_config_snapshot` + `rule_set_version_id` columns on moderation_case |
+| `migrations/2026-04-21-000200-0000_add_case_applied_config_snapshot/down.sql` | CREATE | `ALTER TABLE moderation_case DROP COLUMN …` |
+| `migrations/2026-04-21-000300-0000_seed_v1_config_keys/up.sql` | CREATE | 27 new v1-AD config rows; idempotent (28-in-PRD-§5.2 minus `rule_set.active_version_id`) |
+| `migrations/2026-04-21-000300-0000_seed_v1_config_keys/down.sql` | CREATE | DELETE scoped to exact key list |
+| `crates/db_schema_file/src/schema.rs` | UPDATE | Hand-add `rule_set_version`, `sponsor_allowlist` tables + new columns on `moderation_case` |
+| `crates/db_schema/src/source/governance/rule_set_version.rs` | CREATE | Queryable + InsertForm |
+| `crates/db_schema/src/source/governance/sponsor_allowlist.rs` | CREATE | Queryable + InsertForm (read-path unused in v1-AD-a; lands as API consumer in v1-AD-b) |
+| `crates/db_schema/src/source/governance/mod.rs` | UPDATE | Export new modules |
+| `crates/db_schema/src/newtypes.rs` | UPDATE | Add `RuleSetVersionId`, `SponsorAllowlistId` newtypes |
+| `crates/api/api/src/governance/config.rs` | UPDATE | Add `ConfigKeyMetadata` struct + `ValueType`/`ConfigScope`/`ApplyAt` enums + 27 new `DEFAULT_*` consts + 27 new `const_default_*` match arms + extend `SEEDED_KEYS_WITH_CONSTS` to 61 tuples + `CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata]` (61 entries) + `EXPECTED_SEED_COUNT_V1_AD: usize = 27` + new `every_seeded_key_has_metadata` parity test. Counts are parametric — task 7 reconciliation gate authoritative. |
+| `crates/api/api/src/governance/governance_log.rs` | UPDATE | Add `ENTRY_KIND_ADMIN_CONFIG_CHANGED` + `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED` consts at line 68+ |
+| `.claude/rules/governance-log-entry-kind-registry.md` | CREATE | Initialise registry per advisor directive #2; close GH #41 |
+| `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md` | UPDATE | Open OQ-V1-AD-01/02/03 (leans only; no resolution) |
+
+**Total: 17 files changed (4 NEW migration dirs × 2 files = 8 migration files, 4 NEW Rust files, 5 UPDATED Rust files, 1 NEW rules file, 1 UPDATED design doc).**
+
+---
+
+## 12. NOT building in v1-AD-a
+
+Explicitly out of scope for this sub-phase. If one of these creeps in, stop and add it as a decision-queue entry.
+
+- No HTTP handlers. Not `POST /admin/config`, not `GET /admin/config`, not `GET /admin/dashboard`. Those are v1-AD-b/d.
+- No routes wiring. `crates/api/routes/src/lib.rs` is untouched.
+- No DTOs. `crates/api/api_common/src/governance.rs` is untouched.
+- No askama, maud, actix-web-lab, or any new template/SSE crate. OQ-V1-AD-01/02 resolve before v1-AD-d/e.
+- No `submit_jury_vote` edits. The `rule_set_version_id` wire-up (pinning a case to the active version at decision time) is v1-AD-c.
+- No `admin_assign_jury` edits. The `applied_config_snapshot` populate-at-jury-seating is v1-AD-c (touches `submit_jury_vote` + `admin_assign_jury`).
+- No `governance_log::append` signature change. Only two consts added.
+- No `Scope` enum extension beyond v0. OQ-026 dotted-namespace cascade (`jury.panel_size.<status>.<severity>`) is read-side work that lands alongside jury-mechanics-v1 consumers.
+- No federation / ActivityPub work. ADR-014 content-level federation unaffected.
+- No config cache invalidation work. v0's per-request `ConfigCache` stays exactly as-is; cross-request invalidation is v1-AD-b scope.
+- No AGPL notice updates. Not a release artefact.
+
+---
+
+## 13. Step-by-step tasks
+
+Execute in order. One commit per task on branch `phase-v1-AD-a`. Each task has a MIRROR reference, exact file paths, and a validation command. Task 0 is a pre-flight gate.
+
+### Task 0: PRE-FLIGHT — verify branch + wrapper sanity + v0 baseline
+
+- **ACTION**: Confirm `phase-v1-AD-a` branched from `governance-v0` at `3bbf419da` per `.claude/rules/phase-branch.md`. Run the pre-phase harness audit per `.claude/rules/pre-phase-harness-audit.md` — all four probes against `governance-v0` HEAD, capturing logs under `.claude/PRPs/debug/phase-v1-AD-a-audit-*.log`.
+- **GOTCHA**: If the current branch is `governance-v0`, STOP and write a `.claude/decision-queue.json` entry — advisor cuts the phase branch, not the impl agent.
+- **GOTCHA**: All four probes must pass AND the negative probes must return non-zero exit codes. Failure = wrapper bug that will invalidate every downstream cargo signal. Fix wrapper in a pre-task commit before Task 1.
+- **VALIDATE**:
+  ```bash
+  git branch --show-current            # → phase-v1-AD-a
+  git log -1 --format=%H governance-v0 # → 3bbf419da
+  cmd //c "scripts\\brehon\\cargo-check.bat -p lemmy_api > .claude/PRPs/debug/phase-v1-AD-a-audit-probe1.log 2>&1"
+  echo "probe1 exit: $?"  # expect 0
+  cmd //c "scripts\\brehon\\cargo-check.bat -p lemmy_api --features nonexistent_xyz > .claude/PRPs/debug/phase-v1-AD-a-audit-probe4.log 2>&1"
+  echo "probe4 exit: $?"  # expect non-zero
+  ```
+- **EXPECT**: branch correct; exit codes as commented; no commits from this task.
+
+### Task 1: CREATE `migrations/2026-04-21-000000-0000_add_rule_set_versions/up.sql` + down.sql
+
+- **ACTION**: New migration directory. `up.sql` creates `rule_set_version` table per PRD §3.6. `down.sql` drops it.
+- **IMPLEMENT**:
+  ```sql
+  -- up.sql
+  CREATE TABLE rule_set_version (
+    id            SERIAL PRIMARY KEY,
+    community_id  INTEGER NOT NULL REFERENCES community(id) ON DELETE CASCADE,
+    version       INTEGER NOT NULL,
+    parent_id     INTEGER REFERENCES rule_set_version(id),
+    text_sha256   BYTEA NOT NULL,
+    rule_text     TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by    INTEGER REFERENCES person(id) ON DELETE RESTRICT,
+    UNIQUE (community_id, version)
+  );
+
+  CREATE INDEX idx_rule_set_version_community_created
+    ON rule_set_version (community_id, created_at DESC);
+  ```
+  ```sql
+  -- down.sql
+  DROP INDEX IF EXISTS idx_rule_set_version_community_created;
+  DROP TABLE IF EXISTS rule_set_version;
+  ```
+- **MIRROR**: `migrations/2026-04-15-100100-0000_add_governance_core/up.sql:1-18` for FK + CREATE TABLE shape.
+- **GOTCHA**: `parent_id` is **nullable** (v1 of a rule-set has no parent).
+- **GOTCHA**: No `CASCADE` on `parent_id` — DELETE of an old version must not cascade-delete newer versions (append-only invariant).
+- **GOTCHA**: `text_sha256` is `BYTEA` (32 bytes), not `TEXT`. Consumers will hex-encode when displaying.
+- **VALIDATE**: `cmd //c "scripts\\brehon\\cargo-check.bat -p lemmy_db_schema > .claude/PRPs/debug/task1-check.log 2>&1"` — must exit 0. `diesel` CLI is forbidden per `.claude/memory/feedback_lemmy_migration_runner.md`; migrations run via `schema_setup::run` inside `config_parity_round_trip` (task 6).
+
+### Task 2: CREATE `migrations/2026-04-21-000100-0000_add_sponsor_allowlist/up.sql` + down.sql
+
+- **ACTION**: Create empty-reserved `sponsor_allowlist` table per PRD §3.1 + OQ-020. Read-path lands in v1-AD-b; v1-AD-a only ships the table.
+- **IMPLEMENT**:
+  ```sql
+  -- up.sql
+  CREATE TABLE sponsor_allowlist (
+    id            SERIAL PRIMARY KEY,
+    community_id  INTEGER NOT NULL REFERENCES community(id) ON DELETE CASCADE,
+    person_id     INTEGER NOT NULL REFERENCES person(id) ON DELETE CASCADE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (community_id, person_id)
+  );
+  ```
+  ```sql
+  -- down.sql
+  DROP TABLE IF EXISTS sponsor_allowlist;
+  ```
+- **MIRROR**: Same FK shape as task 1. No indexes beyond the UNIQUE constraint in v1-AD-a (read-path indexes land in v1-AD-b when the allowlist strategy is actually consumed).
+- **GOTCHA**: The table is **reserved**; no Rust code reads or writes it in v1-AD-a. The Diesel model (task 5) exists for compile-time visibility only.
+- **VALIDATE**: `cargo-check.bat -p lemmy_db_schema` — exit 0.
+
+### Task 3: CREATE `migrations/2026-04-21-000200-0000_add_case_applied_config_snapshot/up.sql` + down.sql
+
+- **ACTION**: Add two nullable columns to `moderation_case`.
+- **IMPLEMENT**:
+  ```sql
+  -- up.sql
+  ALTER TABLE moderation_case ADD COLUMN applied_config_snapshot JSONB;
+  ALTER TABLE moderation_case ADD COLUMN rule_set_version_id INTEGER REFERENCES rule_set_version(id);
+
+  CREATE INDEX idx_moderation_case_rule_set_version
+    ON moderation_case (rule_set_version_id)
+    WHERE rule_set_version_id IS NOT NULL;
+  ```
+  ```sql
+  -- down.sql
+  DROP INDEX IF EXISTS idx_moderation_case_rule_set_version;
+  ALTER TABLE moderation_case DROP COLUMN IF EXISTS rule_set_version_id;
+  ALTER TABLE moderation_case DROP COLUMN IF EXISTS applied_config_snapshot;
+  ```
+- **MIRROR**: `migrations/2026-04-18-000100-0000_add_person_membership_state/up.sql` — ALTER TABLE ADD COLUMN precedent.
+- **GOTCHA**: Both columns nullable. Existing pre-v1 cases keep NULL. No backfill — populate-at-write in v1-AD-c.
+- **GOTCHA**: Must run AFTER task 1 (rule_set_version table must exist before FK). Timestamp ordering (`-000200-0000` after `-000000-0000`) enforces this.
+- **GOTCHA**: Partial index `WHERE rule_set_version_id IS NOT NULL` keeps existing-case writes cheap (no index bloat on the common NULL case).
+- **VALIDATE**: `cargo-check.bat -p lemmy_db_schema` — exit 0. Task 4 schema.rs update depends on this migration applying in the e2e harness.
+
+### Task 4: UPDATE `crates/db_schema_file/src/schema.rs` — add new tables + columns
+
+- **ACTION**: Hand-edit the `@generated` schema file. Add `rule_set_version` and `sponsor_allowlist` `diesel::table!` blocks. Add the two new columns to `moderation_case`.
+- **IMPLEMENT**:
+  ```rust
+  diesel::table! {
+      rule_set_version (id) {
+          id -> Int4,
+          community_id -> Int4,
+          version -> Int4,
+          parent_id -> Nullable<Int4>,
+          text_sha256 -> Bytea,
+          rule_text -> Text,
+          created_at -> Timestamptz,
+          created_by -> Nullable<Int4>,
+      }
+  }
+
+  diesel::table! {
+      sponsor_allowlist (id) {
+          id -> Int4,
+          community_id -> Int4,
+          person_id -> Int4,
+          created_at -> Timestamptz,
+      }
+  }
+  ```
+  And extend the existing `moderation_case` block (currently schema.rs:724-742) to add:
+  ```rust
+          applied_config_snapshot -> Nullable<Jsonb>,
+          rule_set_version_id -> Nullable<Int4>,
+  ```
+- **MIRROR**: `schema.rs:412-455` for `governance_config` + `governance_config_current` hand-added blocks; `schema.rs:724-742` for the existing `moderation_case` block to extend.
+- **GOTCHA**: This is a **hand-edit** of an `@generated` file (see schema.rs:1 header). The fork's convention for governance additions is documented in the header comment at schema.rs:426-428 ("Diesel does not auto-detect views, so this `table!` block is hand-written"). New tables added by governance migrations follow the same precedent.
+- **GOTCHA**: Add `joinable!(moderation_case -> rule_set_version (rule_set_version_id));` if the schema.rs uses `joinable!` macros for other FK relationships — grep first; if none exist in the governance range, skip.
+- **VALIDATE**: `cargo-check.bat -p lemmy_db_schema_file` — exit 0. `cargo-check.bat --workspace` — exit 0.
+
+### Task 5: CREATE `crates/db_schema/src/source/governance/rule_set_version.rs` + `sponsor_allowlist.rs`; UPDATE `mod.rs` + `newtypes.rs`
+
+- **ACTION**: Diesel models for both new tables.
+- **IMPLEMENT**: Follow `crates/db_schema/src/source/governance/governance_config.rs:1-53` exactly. Both structs: `RuleSetVersion`/`SponsorAllowlist` Queryable + `RuleSetVersionInsertForm`/`SponsorAllowlistInsertForm` Insertable. Add `RuleSetVersionId(i32)` + `SponsorAllowlistId(i32)` newtypes to `crates/db_schema/src/newtypes.rs` (grep `GovernanceConfigId` for the exact pattern — it's a `pub struct …Id(pub i32)` with derives).
+- **IMPORTS**:
+  ```rust
+  use crate::newtypes::{CommunityId, RuleSetVersionId};
+  use chrono::{DateTime, Utc};
+  use lemmy_db_schema_file::{schema::rule_set_version, PersonId};
+  use serde::{Deserialize, Serialize};
+  use serde_with::skip_serializing_none;
+  ```
+- **EXPORTS** in `crates/db_schema/src/source/governance/mod.rs`: add `pub mod rule_set_version;` and `pub mod sponsor_allowlist;` alphabetically.
+- **GOTCHA**: `rule_text` is `String` in Rust (maps to `TEXT`); `text_sha256` is `Vec<u8>` (maps to `BYTEA`). The `skip_serializing_none` + `ts-rs` derives fire on both structs. Do **not** derive `AsChangeset` — both tables are append-only (same reasoning as `GovernanceConfigInsertForm`).
+- **GOTCHA**: `SponsorAllowlistInsertForm` is reserved for v1-AD-b. Ship the struct in v1-AD-a; no code calls it yet. A `#[allow(dead_code)]` is NOT needed if the struct is `pub` and exported — exported items are never dead.
+- **VALIDATE**: `cargo-check.bat --workspace` — exit 0. `cargo-check.bat --workspace --features full` — exit 0 (forces the `full`-gated derives to compile).
+
+### Task 6: UPDATE `crates/api/api/src/governance/config.rs` — add `ConfigKeyMetadata`, 27 new consts, 61-entry `CONFIG_KEY_METADATA`, new parity test
+
+- **ACTION**: Largest single edit. Four sub-steps:
+  1. Add `ConfigKeyMetadata` struct + `ValueType`/`ConfigScope`/`ApplyAt` enums near the existing `Scope` enum (line 58). These are compile-time types; no DB representation.
+  2. Add 27 new `pub const DEFAULT_*` declarations alongside the existing 34 (after line 353).
+  3. Add 27 new match arms to `const_default_int`/`const_default_float`/`const_default_bool`/`const_default_text` (lines 354-414).
+  4. Extend `SEEDED_KEYS_WITH_CONSTS` from 34 to 61 tuples (lines 423-458).
+  5. Add `pub const EXPECTED_SEED_COUNT_V1_AD: usize = 27;` near the existing `EXPECTED_SEED_COUNT` (line 463). Do NOT change `EXPECTED_SEED_COUNT` itself — advisor directive #4: each sub-PRD adds its own parametric count.
+  6. Add `pub const CONFIG_KEY_METADATA: &'static [ConfigKeyMetadata] = &[...]` with 61 entries (one per seeded key).
+  7. Update existing `seeded_keys_count_matches_const_count` test to assert against `EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD`.
+  8. Add new `every_seeded_key_has_metadata` parity test.
+- **IMPLEMENT**:
+  ```rust
+  // Add near line 58 (alongside Scope):
+
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum ValueType {
+    Int,
+    Float,
+    Bool,
+    Text,
+    // Enum stored as text; variants in ConfigKeyMetadata::valid_enum.
+    Enum,
+  }
+
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum ConfigScope {
+    Instance,
+    Community,
+    Both,
+  }
+
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum ApplyAt {
+    Immediate,
+    NextJuryCycle,
+    NextSnapshotJob,
+  }
+
+  #[derive(Debug, Clone, Copy)]
+  pub struct NumericRange {
+    pub min: f64,
+    pub max: f64,
+  }
+
+  #[derive(Debug, Clone, Copy)]
+  pub struct ConfigKeyMetadata {
+    pub key: &'static str,
+    pub value_type: ValueType,
+    pub valid_range: Option<NumericRange>,
+    pub valid_enum: Option<&'static [&'static str]>,
+    pub scope: ConfigScope,
+    pub requires_re_jury: bool,
+    pub requires_step_up: bool,
+    pub apply_at_default: ApplyAt,
+    pub description: &'static str,
+    pub doc_anchor: &'static str,
+  }
+  ```
+  27 new keys to add to `SEEDED_KEYS_WITH_CONSTS` — these MUST match the rows seeded in task 7's migration exactly:
+  - `jury.severity_thresholds.minor|moderate|severe` (3× text)
+  - `jury.diversity_constraints_enabled` (bool)
+  - `jury.appeal_panel_size_increase` (int)
+  - `jury.deadline_window_hours` (int)
+  - `liability.grace_window_minor_hours|moderate_hours|severe_hours|minimum_hours|maximum_hours|alert_threshold_hours` (6× int)
+  - `liability.restoration_escapes_liability` (bool)
+  - `liability.restoration_severity_reduction_steps` (int)
+  - `liability.multi_sponsor_escape_rule` (text enum)
+  - `liability.revoke_rate_limit_per_day` (int)
+  - `decay.negative_half_life_days` (int)
+  - `decay.endorsement_strength_half_life_days` (int)
+  - `decay.jury_reliability_half_life_days` (int)
+  - `onboarding.sponsor_min_endorsement_strength` (int)
+  - `onboarding.sponsor_allowlist_table_name` (text)
+  - `onboarding.provisional_membership_cooldown_days` (int)
+  - `founder.founder_seal_visible_in_profile` (bool)
+  - `participation.weekly_active_delta` (int)
+  - `participation.dormant_threshold_days` (int)
+  - `participation.dormant_delta` (int)
+  - `participation.attestation_enabled` (bool)
+  - `federation.inbound_advisory_only` (bool)
+  - `federation.peer_attestation_ttl_days` (int)
+  - `federation.signature_required` (bool)
+  - `federation.quarantine_recommendation_severity_floor` (text enum)
+  - `federation.outbound_publish_enabled` (bool)
+  - `rule_set.auto_carry_in_flight_cases` (bool)
+  - `rule_set.text_max_bytes` (int)
+  - `rule_set.version_propagation_delay_hours` (int)
+
+  **`rule_set.active_version_id` is NOT in this list.** Per §4.1 decision (advisor edit #2, 2026-04-19): no seed row, no const, no `CONFIG_KEY_METADATA` entry in v1-AD-a. v1-AD-c adds all three when implementing rule-set creation, because until a rule set exists the key is semantically not-yet-decided rather than "has a default". v1-AD-b's `config::get_int_opt` accessor returns `None` when both the DB row and the const default are absent — that `None` IS the "no active version" signal. DO NOT add `DEFAULT_RULE_SET_ACTIVE_VERSION_ID` or a sentinel value.
+
+  **Count: 27 exact.** Task 7's migration must INSERT exactly these 27 keys (28-in-PRD-§5.2 minus `rule_set.active_version_id`).
+- **MIRROR**: `config.rs:469-500` for parity test shape; `config.rs:319-352` for DEFAULT_* const style; `config.rs:354-414` for match-arm style.
+- **GOTCHA**: `rule_set.active_version_id` — per §4.1 decision (advisor edit #2) this key is DELIBERATELY OMITTED from v1-AD-a. No const, no seed row, no `SEEDED_KEYS_WITH_CONSTS` entry, no `CONFIG_KEY_METADATA` entry, no `const_default_int` match arm. The v0 config reader already returns an error when no DB row matches AND no const fallback exists. v1-AD-b will introduce a `config::get_int_opt` accessor that treats the "no row + no const" state as `None` instead of an error. Until v1-AD-c seeds the key on actual rule-set activation, any read via the normal `get_int` path produces an error — that's the correct behaviour because no caller in v1-AD-a/b should be reading an unactivated rule-set version. If the implementer is tempted to ship a `-1` sentinel "just for completeness", STOP — write a DQ entry citing advisor edit #2.
+- **GOTCHA**: `liability.multi_sponsor_escape_rule` is an enum text (`any_revocation | all_revocation | majority_revocation`). `valid_enum` field in its ConfigKeyMetadata entry pins the three strings.
+- **GOTCHA**: `participation.attestation_enabled = false` is (c) decide-later per PRD §5.2. Ship the key, the const, the metadata, the seed row. No read-site code in v1-AD-a.
+- **GOTCHA**: Do not delete or weaken the existing `every_seeded_key_has_const_fallback` test. Add the new `every_seeded_key_has_metadata` test **alongside** it.
+- **GOTCHA**: `NumericRange` is a compile-time struct, not the workspace `f64` range lint trap — `valid_range` is `Option<NumericRange>`, not `RangeInclusive<f64>`. Two f64 fields + a Copy derive keeps the `&'static` storage commitment working.
+- **VALIDATE**:
+  ```bash
+  cmd //c "scripts\\brehon\\cargo-check.bat --workspace --features full > .claude/PRPs/debug/task6-check.log 2>&1"
+  echo "check exit: $?"   # expect 0
+  cmd //c "scripts\\brehon\\cargo-test.bat --workspace --lib parity > .claude/PRPs/debug/task6-parity.log 2>&1"
+  echo "parity exit: $?"  # expect 0
+  ```
+  Do NOT use `-p lemmy_api --features full` per advisor memory `feedback_features_full_workspace_only.md`.
+
+### Task 7: CREATE `migrations/2026-04-21-000300-0000_seed_v1_config_keys/up.sql` + down.sql; UPDATE `crates/api/api/src/governance/governance_log.rs` with 2 new ENTRY_KIND consts
+
+- **ACTION**: Seed the 27 new rows idempotently. The INSERT rows MUST match task 6's `SEEDED_KEYS_WITH_CONSTS` entries byte-for-byte. Also land the two new ENTRY_KIND consts (combined task because both are small, non-conflicting, and the parity test + migration test share a validation step).
+- **IMPLEMENT** (migration):
+  ```sql
+  -- up.sql
+  INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text) VALUES
+    ('instance', 'jury.severity_thresholds.minor',              'text',  NULL,  NULL, NULL,  'majority'),
+    ('instance', 'jury.severity_thresholds.moderate',           'text',  NULL,  NULL, NULL,  '60%'),
+    ('instance', 'jury.severity_thresholds.severe',             'text',  NULL,  NULL, NULL,  '75%'),
+    ('instance', 'jury.diversity_constraints_enabled',          'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'jury.appeal_panel_size_increase',             'int',   2,     NULL, NULL,  NULL),
+    ('instance', 'jury.deadline_window_hours',                  'int',   72,    NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_minor_hours',          'int',   24,    NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_moderate_hours',       'int',   72,    NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_severe_hours',         'int',   168,   NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_minimum_hours',        'int',   1,     NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_maximum_hours',        'int',   720,   NULL, NULL,  NULL),
+    ('instance', 'liability.grace_window_alert_threshold_hours','int',   24,    NULL, NULL,  NULL),
+    ('instance', 'liability.restoration_escapes_liability',     'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'liability.restoration_severity_reduction_steps','int', 0,     NULL, NULL,  NULL),
+    ('instance', 'liability.multi_sponsor_escape_rule',         'text',  NULL,  NULL, NULL,  'any_revocation'),
+    ('instance', 'liability.revoke_rate_limit_per_day',         'int',   5,     NULL, NULL,  NULL),
+    ('instance', 'decay.negative_half_life_days',               'int',   180,   NULL, NULL,  NULL),
+    ('instance', 'decay.endorsement_strength_half_life_days',   'int',   90,    NULL, NULL,  NULL),
+    ('instance', 'decay.jury_reliability_half_life_days',       'int',   90,    NULL, NULL,  NULL),
+    ('instance', 'onboarding.sponsor_min_endorsement_strength', 'int',   25,    NULL, NULL,  NULL),
+    ('instance', 'onboarding.sponsor_allowlist_table_name',     'text',  NULL,  NULL, NULL,  'sponsor_allowlist'),
+    ('instance', 'onboarding.provisional_membership_cooldown_days','int',14,    NULL, NULL,  NULL),
+    ('instance', 'founder.founder_seal_visible_in_profile',     'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'participation.weekly_active_delta',           'int',   1,     NULL, NULL,  NULL),
+    ('instance', 'participation.dormant_threshold_days',        'int',   30,    NULL, NULL,  NULL),
+    ('instance', 'participation.dormant_delta',                 'int',   -2,    NULL, NULL,  NULL),
+    ('instance', 'participation.attestation_enabled',           'bool',  NULL,  NULL, false, NULL),
+    ('instance', 'federation.inbound_advisory_only',            'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'federation.peer_attestation_ttl_days',        'int',   30,    NULL, NULL,  NULL),
+    ('instance', 'federation.signature_required',               'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'federation.quarantine_recommendation_severity_floor','text',NULL,NULL,NULL,'moderate'),
+    ('instance', 'federation.outbound_publish_enabled',         'bool',  NULL,  NULL, true,  NULL),
+    -- rule_set.active_version_id deliberately NOT seeded — absence-of-row IS
+    -- the "no active version" signal. See §4.1 and task 6 GOTCHA.
+    ('instance', 'rule_set.auto_carry_in_flight_cases',         'bool',  NULL,  NULL, true,  NULL),
+    ('instance', 'rule_set.text_max_bytes',                     'int',   65536, NULL, NULL,  NULL),
+    ('instance', 'rule_set.version_propagation_delay_hours',    'int',   24,    NULL, NULL,  NULL)
+  ON CONFLICT (scope, key, valid_from) DO NOTHING;
+  ```
+  **Count: 27 unique keys** (audit by namespace):
+  - jury: severity_thresholds ×3 + diversity + panel_size_increase + deadline = **6**
+  - liability: grace_window ×6 + restoration ×2 + multi_sponsor + revoke_rate = **10**
+  - decay: negative + endorsement_strength + jury_reliability = **3**
+  - onboarding: sponsor_min_endorsement_strength + sponsor_allowlist_table_name + provisional_cooldown = **3**
+  - founder: founder_seal_visible_in_profile = **1**
+  - participation: weekly_active + dormant_threshold + dormant_delta + attestation_enabled = **4**
+  - federation: inbound_advisory + peer_ttl + signature_required + quarantine_floor + outbound_publish = **5** *wait, check below*
+  - rule_set: auto_carry + text_max_bytes + version_propagation_delay = **3** (active_version_id omitted per §4.1)
+  
+  Namespace audit total: 6 + 10 + 3 + 3 + 1 + 4 + 5 + 3 = **35** — this mismatches the 27-key count in §4.1. The drift exists because PRD §5.2 enumerates ~35 rows collectively in-scope for admin-dashboard + sponsor-liability-v1 (the latter owns 10 of the liability keys per B4). **v1-AD-a implementer owns only the admin-dashboard-exclusive keys** (PRD §3.1 contribution sub-table: "~24" admin-dashboard additions minus `rule_set.active_version_id` = ~23). This is the exact drift flagged in advisor edit #1.
+  
+  **Advisor edit #1 reconciliation point (MANDATORY before committing this migration):**
+  
+  Before `git commit` of task 7's migration, run:
+  ```bash
+  # Count SEEDED_KEYS_WITH_CONSTS.len() from task 6's edit
+  grep -cE '^\s*\("[a-z_.]+", "DEFAULT_' crates/api/api/src/governance/config.rs
+  # Expected: EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD (parametric —
+  # currently 34 + 27 = 61, reconcile below if drift)
+  
+  # Count the INSERT rows written to task 7's up.sql
+  grep -cE "^\s*\('instance'," migrations/2026-04-21-000300-0000_seed_v1_config_keys/up.sql
+  # MUST equal EXPECTED_SEED_COUNT_V1_AD exactly
+  
+  # Dry-run the parametric parity test
+  cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server config_parity_round_trip > .claude/PRPs/debug/task7-precommit-parity.log 2>&1"
+  echo "precommit parity exit: $?"
+  ```
+  
+  If the parity test fails at this point, DO NOT commit. The three outcomes:
+  - **(a) const count > insert count**: add missing INSERT rows until they match.
+  - **(b) const count < insert count**: remove surplus INSERT rows until they match.
+  - **(c) neither side matches PRD §5.2's authoritative enumeration**: open a DQ entry citing advisor edit #1 with the actual count and wait for reconciliation. Do not self-resolve the drift — PRD §5.2 and sponsor-liability-v1 §4.2 ownership is the source of truth, not the plan file.
+  
+  Rationale: this converts count drift from a "surprise at task 7 end" to "reconciliation point explicit at migration-write time." `EXPECTED_SEED_COUNT_V1_AD = 27` in §4.1 is the plan's current best count; the implementer is authoritative against on-disk reality.
+  
+  ```sql
+  -- down.sql
+  DELETE FROM governance_config WHERE scope = 'instance' AND key IN (
+    'jury.severity_thresholds.minor',
+    -- … all 27 keys in the same order as up.sql's INSERT block …
+    'rule_set.version_propagation_delay_hours'
+  );
+  ```
+- **IMPLEMENT** (governance_log.rs):
+  ```rust
+  // Appended after line 68 (after ENTRY_KIND_APPEAL_REQUESTED):
+  pub const ENTRY_KIND_ADMIN_CONFIG_CHANGED: &str = "admin_config_changed";
+  pub const ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED: &str = "admin_config_change_denied";
+  ```
+- **MIRROR**: `migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78-113` for INSERT shape + `ON CONFLICT (scope, key, valid_from)` target. `governance_log.rs:50-68` for ENTRY_KIND const style.
+- **GOTCHA**: `ON CONFLICT (scope, key, valid_from) DO NOTHING` — `valid_from` defaults to `now()`, so two runs of `schema_setup::run()` at different times would each insert a fresh row with a different `valid_from` — the conflict key means they DON'T duplicate only when `valid_from` matches exactly. The v0 migration handles this by running inside the same single-transaction schema application, where `now()` returns the same timestamp for all rows in the same statement. Same applies here; no change needed.
+- **GOTCHA**: `admin_config_changed` const must equal the existing shell-script string literal byte-for-byte (`scripts/brehon/admin-config-write.sh:148`). v1-AD-b's NOT5 deprecation gate 3 asserts byte-identical governance_log rows from both paths.
+- **VALIDATE**:
+  ```bash
+  cmd //c "scripts\\brehon\\cargo-check.bat --workspace --features full > .claude/PRPs/debug/task7-check.log 2>&1"
+  echo "check exit: $?"
+  # Run config_parity_round_trip — exercises task 7's seed migration + task 6's consts + metadata registry
+  cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server config_parity_round_trip > .claude/PRPs/debug/task7-e2e.log 2>&1"
+  echo "e2e exit: $?"
+  ```
+  Expect both to exit 0. The `config_parity_round_trip` test at `crates/server/tests/e2e.rs:1308-1366` will iterate all 62 `SEEDED_KEYS_WITH_CONSTS` entries and call the typed accessor — any missing seed row, missing const, or type mismatch fails here.
+
+### Task 8: INITIALISE `.claude/rules/governance-log-entry-kind-registry.md` (closes #41)
+
+- **ACTION**: Per advisor directive #2, close GH #41 as part of v1-AD-a rather than maintaining a separate issue-driven flow. Write a new auto-loaded rule file whose section structure **mirrors issue #41's "Proposed deliverable" enumeration** so the issue closes with a one-line "landed in v1-AD-a at `<commit>`" comment (advisor edit #3).
+- **IMPLEMENT**: Template (4-column rows: const name, &str value, source/writer, emitting-handler file path + one-line semantic description — per issue #41 "Proposed deliverable" bullet 1):
+  ```markdown
+  # governance_log entry_kind registry
+
+  The `governance_log` table records every governance event as a row with an
+  `entry_kind TEXT` column. Each kind string must appear exactly once as a
+  `pub const ENTRY_KIND_*` in `crates/api/api/src/governance/governance_log.rs`.
+
+  Adding a new kind requires:
+  1. A new `pub const ENTRY_KIND_<NAME>: &str = "<snake_case>";` in
+     `crates/api/api/src/governance/governance_log.rs`.
+  2. An entry in the matching PRD section of THIS file with: const name,
+     &str value, source PRD (v0 = "shipped", v1+ = PRD name), emitting
+     handler file path, one-line semantic description.
+  3. Grep DoD in plan file: `rg "ENTRY_KIND_<NAME>" crates/api/api/src/governance/governance_log.rs`
+     returns the const; `rg '"<snake_case>"' crates/` returns the const line
+     + every call site.
+  4. Collision check at plan-review: `rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort -u | wc -l`
+     returns exactly `EXPECTED_SEED_COUNT + sum(EXPECTED_SEED_COUNT_V1_*)`
+     and every literal appears exactly once.
+
+  This file is MANDATORY READING in `-p` mode. Every PRP plan that touches
+  governance writes reads it at first iteration. Mirrors
+  `feedback_plan_dod_dry_run_at_write.md` at plan-review time.
+
+  ## v0 entry kinds (19, shipped governance-v0 `3bbf419da`)
+
+  | Rust const | &str value | Source | Emitting handler | Semantic |
+  |---|---|---|---|---|
+  | `ENTRY_KIND_REPORT_CREATED` | `report_created` | Phase 4 shipped | `crates/api/api/src/governance/create_report.rs` | Report submitted, case opened or threshold-appended |
+  | `ENTRY_KIND_THRESHOLD_MET` | `threshold_met` | Phase 4 shipped | `create_report.rs` | Report accumulation crossed `report.case_threshold_micros` |
+  | `ENTRY_KIND_JURY_ASSIGNED` | `jury_assigned` | Phase 4 shipped | `admin_assign_jury.rs` | Admin assigned jury to a case |
+  | `ENTRY_KIND_PANEL_ASSEMBLED` | `panel_assembled` | Phase 4b shipped | `admin_assign_jury.rs` | Panel selection ran; jurors seated |
+  | `ENTRY_KIND_JURY_VOTED` | `jury_voted` | Phase 4b shipped | `submit_jury_vote.rs` | Individual juror submitted vote |
+  | `ENTRY_KIND_SANCTION_CREATED` | `sanction_created` | Phase 4b shipped | `submit_jury_vote.rs` | Quorum reached → sanction row inserted |
+  | `ENTRY_KIND_PUBLIC_LOG_PUBLISHED` | `public_log_published` | Phase 4b shipped | `submit_jury_vote.rs` | Redacted public case log entry created |
+  | `ENTRY_KIND_REPUTATION_DELTA` | `reputation_delta` | Phase 5a shipped | `reputation_snapshot.rs` + call sites | Reputation event applied |
+  | `ENTRY_KIND_CASE_DECIDED` | `case_decided` | Phase 4b shipped | `submit_jury_vote.rs` | Case transitioned to `Decided` |
+  | `ENTRY_KIND_CAPABILITY_CHANGED` | `capability_changed` | Phase 5a shipped | `reputation_snapshot.rs` | `can_sponsor`/`jury_eligible` flip |
+  | `ENTRY_KIND_SPONSOR_LIABILITY_APPLIED` | `sponsor_liability_applied` | Phase 5b shipped | `sponsor_liability.rs` | Liability delta written |
+  | `ENTRY_KIND_SPONSOR_LIABILITY_CLAMPED` | `sponsor_liability_clamped` | Phase 5b shipped | `sponsor_liability.rs` | Floor clamp fired (OQ-024) |
+  | `ENTRY_KIND_FOUNDER_SEEDED` | `founder_seeded` | Phase 5b shipped | `seed_founders` CLI + `reputation_snapshot.rs` | Founder reputation-event inserted |
+  | `ENTRY_KIND_ENDORSEMENT_CREATED` | `endorsement_created` | Phase 5b shipped | `create_endorsement.rs` | Sponsor-endorsement written |
+  | `ENTRY_KIND_EMERGENCY_REMOVED` | `emergency_removed` | Phase 5c shipped | `admin_emergency_remove.rs` | ADR-013 admin-override removal |
+  | `ENTRY_KIND_JURY_ACCEPTED` | `jury_accepted` | Phase 5c shipped | `accept_jury_assignment.rs` | Juror accepted assignment |
+  | `ENTRY_KIND_JURY_DECLINED` | `jury_declined` | Phase 5c shipped | `decline_jury_assignment.rs` | Juror declined assignment |
+  | `ENTRY_KIND_JURY_REPLACEMENT_SELECTED` | `jury_replacement_selected` | Phase 5c shipped | `admin_assign_jury.rs` | Replacement juror seated after decline |
+  | `ENTRY_KIND_APPEAL_REQUESTED` | `appeal_requested` | Phase 5c shipped | `request_appeal.rs` | Appeal request submitted |
+
+  ## Phase 6 pending additions (≥4, in-flight on `phase-6` branch)
+
+  Phase 6 is in-flight per `advisor-context-phase-6.md` §4 Watch 5 and has
+  not merged to `governance-v0` at v1-AD-a write time. The expected kinds
+  are enumerated below for collision-avoidance only; this file is updated
+  to include emitting-handler paths once Phase 6 merges and their file
+  locations are authoritative.
+
+  | Rust const (expected) | &str value | Source | Emitting handler | Semantic |
+  |---|---|---|---|---|
+  | `ENTRY_KIND_FEDERATION_SANCTION_SENT` | `federation_sanction_sent` | Phase 6 pending | `crates/apub/activities/` (TBD post-merge) | Outbound sanction AP activity published |
+  | `ENTRY_KIND_FEDERATION_SANCTION_RECEIVED` | `federation_sanction_received` | Phase 6 pending | Inbox handler (TBD) | Inbound sanction AP received (advisory) |
+  | `ENTRY_KIND_FEDERATION_ATTESTATION_SENT` | `federation_attestation_sent` | Phase 6 pending | `crates/apub/activities/` | Outbound attestation published |
+  | `ENTRY_KIND_FEDERATION_ATTESTATION_RECEIVED` | `federation_attestation_received` | Phase 6 pending | Inbox handler | Inbound attestation received |
+
+  Upon Phase 6 merge: v1-AD-a planner (or Phase-6-merge-close retro)
+  refreshes this section with actual const names and handler paths.
+  `federation-inbound-v1` extends this section (see its own entry below)
+  with its own 11-kind set.
+
+  ## v1-AD-a additions (2, this sub-phase)
+
+  | Rust const | &str value | Source | Emitting handler | Semantic |
+  |---|---|---|---|---|
+  | `ENTRY_KIND_ADMIN_CONFIG_CHANGED` | `admin_config_changed` | v1-AD-a (this plan) — const; v1-AD-b call site | Emitted by: v1-AD-b `crates/api/api/src/governance/admin_config.rs` (pending); v0 `scripts/brehon/admin-config-write.sh:148` (byte-identical payload per NOT5 gate 3) | Config row edit succeeded; payload carries `{scope, key, value_type, value, reason}` |
+  | `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED` | `admin_config_change_denied` | v1-AD-a (this plan) — const; v1-AD-b call site | v1-AD-b `admin_config.rs` capability-check reject path | Capability/scope check rejected attempted config write; payload mirrors attempted-change with `denial_reason` |
+
+  ## v1 PRD reservation sections (to be populated when each PRD's plans write)
+
+  Each future v1 sub-PRD OWNS a section below. Populated by the sub-PRD's
+  own plan file at task-N-equivalent. Reserved slot avoids re-ordering when
+  a later PRD lands first.
+
+  ### jury-mechanics-v1 (reserved — §8.5 of PRD enumerates 6 new kinds)
+  _To be populated by `v1-jury-mechanics.plan.md` task n: `jury_constraint_relaxed`, `appeal_panel_assembled`, `appeal_decided`, `appeal_rejected`, `appeal_window_expired`, `severity_tier_frozen`._
+
+  ### sponsor-liability-v1 (reserved — §17 of PRD enumerates 5 new kinds)
+  _To be populated by `v1-sponsor-liability.plan.md`: `sponsor_liability_pending`, `sponsor_liability_fired`, `sponsor_liability_escaped`, `endorsement_revoked`, `restoration_completed`._
+
+  ### reputation-tuning-v1 (reserved — §7 of PRD enumerates 7 new kinds)
+  _To be populated by `v1-reputation-tuning.plan.md`: `participation_cron_tick`, `vote_outcome_recorded`, `evidence_quality_recorded`, `rollup_recomputed`, `decay_knob_changed`, `sponsor_allowlist_added`, `sponsor_allowlist_removed`._
+
+  ### federation-inbound-v1 (reserved — §§5.3/6.2/6.3/8.2 of PRD enumerate 11 new kinds)
+  _To be populated by `v1-federation-inbound.plan.md`: `federation_label_received`, `federation_inbound_blocked`, `federation_inbound_dropped_oversize`, `federation_inbound_dropped_schema`, `federation_inbound_dropped_rate_limit`, `federation_inbound_dropped_actor_rate_limit`, `federation_inbound_persist_failed`, `federation_inbound_cross_linked`, `federation_inbound_dismissed`, `federation_peer_trust_changed`, `federation_inbound_storage_cap_evicted`._
+
+  ## Acceptance invariants (checked at every plan-review)
+
+  - [ ] `rg "^pub const ENTRY_KIND_" crates/api/api/src/governance/governance_log.rs | wc -l` returns total count of all populated sections
+  - [ ] `rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | sort | uniq -d` returns no duplicates
+  - [ ] Every populated row in this file has a Rust const AND a call site (except Phase 6 pending rows, which only require a plan file)
+  - [ ] Registry file matches the "Proposed deliverable" enumeration of GH issue #41 at land-time
+  ```
+- **MIRROR**: GH issue #41 body "Proposed deliverable" section verbatim (column count, section structure, acceptance invariants).
+- **GOTCHA**: This replaces GH #41's tracker role. When this file lands (PR merge to `governance-v0`), close #41 with a comment: "Registry landed at `.claude/rules/governance-log-entry-kind-registry.md` in v1-AD-a. Subsequent v1 PRDs append their section via their own `/prp-plan`→`/prp-ralph` runs."
+- **GOTCHA**: Phase 6's 4 kinds are listed with "(expected)" + "TBD post-merge" handler paths because Phase 6 is in-flight and may land with slightly different constant names. The plan does NOT block on Phase 6's exact naming — after Phase 6 merges to `governance-v0`, the first v1 sub-PRD to plan refreshes this section. Until then, the registry serves collision-detection for v1-AD-a's 2 kinds + future v1 plans' kinds against each other.
+- **GOTCHA (advisor note 2 — impl-time Phase 6 merge-state check):** this plan was written at 2026-04-19 with Phase 6 in-flight. If Phase 6 merges to `governance-v0` between plan-write and this task's ralph iteration, the "(expected)" + "TBD post-merge" labels are already stale at impl time. Task 8 must re-check merge state at impl time, NOT rely on the plan's static claim. If Phase 6 has merged, read the actual federation `ENTRY_KIND_*` constants from `crates/api/api/src/governance/governance_log.rs` and refresh the Phase 6 section with real names + real handler paths + drop the "(expected)" labels. If Phase 6 has NOT merged, labels stay as-is. Converts a static plan claim into an impl-time-verified claim.
+- **VALIDATE**:
+  ```bash
+  # Phase 6 merge-state check (advisor note 2) — determines whether to drop "(expected)" labels
+  git log governance-v0 --grep="Phase 6\|phase-6\|phase 6" --oneline -1
+  # If non-empty: Phase 6 has merged; task 8 must refresh the Phase 6 section
+  # with actual ENTRY_KIND names from governance_log.rs and drop "(expected)".
+  # If empty: Phase 6 still in-flight; labels stay.
+  
+  rg "^pub const ENTRY_KIND_" crates/api/api/src/governance/governance_log.rs | wc -l
+  # Expected pre-Phase-6-merge: 21  (19 v0 + 2 v1-AD-a)
+  # Expected post-Phase-6-merge: 21 + (Phase 6 kind count, likely 4) = 25
+  # Acceptance invariant is parametric: registry file populated-section rows
+  # must equal this grep's output exactly.
+  
+  rg -n '"[a-z_]+"' crates/api/api/src/governance/governance_log.rs | awk -F: '/ENTRY_KIND_/ {print}' | grep -oE '"[a-z_]+"' | sort | uniq -d
+  # Expected: empty output (no duplicates)
+  
+  # Registry file structure match
+  grep -c "^## " .claude/rules/governance-log-entry-kind-registry.md
+  # Expected: >= 7  (v0, Phase 6 pending, v1-AD-a, 4 reserved sections, acceptance)
+  ```
+
+### Task 9: OPEN OQ-V1-AD-01/02/03 in `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md`
+
+- **ACTION**: Append three open questions after existing OQ-026 in `99-decisions-and-open-questions.md`. Each is a ≤150-word entry matching the existing OQ template shape (Opened / Owner / Question / Current lean / Blocks / Target). Leans follow advisor directive #3.
+- **IMPLEMENT**: Three entries, each:
+
+  ```markdown
+  ### OQ-V1-AD-01 — Server-rendered HTML page framework for admin dashboard
+
+  - **Opened:** 2026-04-21
+  - **Owner:** TBD (backend)
+  - **Question:** v1 admin-dashboard PRD §6 assumes askama (or maud) for
+    server-rendered admin HTML pages. Neither crate is in the workspace
+    `Cargo.lock` today — adoption would add a templating dep + compile-time
+    step to `lemmy_api`. Alternative: ship v1-AD-d API-only and defer HTML
+    pages to v1.x or v2 (to land alongside the React frontend pass).
+  - **Current lean:** Defer to v1.x. v1-AD-d ships API-only; askama decision
+    revisits after pilot operator feedback on whether curl+jq-only workflow
+    is operationally sufficient.
+  - **Blocks:** v1-AD-e (askama HTML pages sub-phase).
+  - **Target:** Before v1-AD-e plan writes.
+  ```
+
+  ```markdown
+  ### OQ-V1-AD-02 — SSE implementation: actix-web-lab vs hand-rolled
+
+  - **Opened:** 2026-04-21
+  - **Owner:** TBD (backend)
+  - **Question:** PRD §4 enumerates `GET /api/v4/governance/admin/audit/stream`
+    as an SSE endpoint. Upstream Lemmy does not use `actix-web-lab` (grep
+    of `Cargo.lock` 2026-04-19 returns no matches). Two paths: (a) add
+    `actix-web-lab` dep for its `Sse` helper; (b) hand-roll ~80 LOC of
+    chunked-response plumbing using `async-stream` (already a transitive
+    dep). The Postgres `LISTEN governance_events` channel already exists
+    (migration `2026-04-20-000000-0000`) — the SSE endpoint's only job is
+    bridging Postgres NOTIFY payloads onto HTTP.
+  - **Current lean:** Hand-roll (option b). Adds no new supply-chain
+    surface and keeps Lemmy's actix-web dep shape intact.
+  - **Blocks:** v1-AD-d (dashboard + SSE sub-phase).
+  - **Target:** Before v1-AD-d plan writes.
+  ```
+
+  ```markdown
+  ### OQ-V1-AD-03 — Dry-run impact computation inside vs outside run_transaction
+
+  - **Opened:** 2026-04-21
+  - **Owner:** TBD (backend)
+  - **Question:** PRD §4.3 proposes running dry-run impact queries inside
+    the same `run_transaction` as the config write with a `SAVEPOINT`
+    rollback when `dry_run = true`. Inspection of
+    `crates/diesel_utils/src/connection.rs:68-79` shows `run_transaction`
+    wraps `diesel-async`'s `.transaction()` — no SAVEPOINT primitive is
+    exposed. Either (a) extend `run_transaction` with a `run_savepoint`
+    helper, or (b) compute impact as a read-only query BEFORE the tx opens
+    against the proposed value and the current config snapshot, with no
+    rollback needed.
+  - **Current lean:** Option (b). Architecturally cleaner; dry-run is
+    read-only; no tx-state visibility required. Reshape PRD §4.3 to match.
+  - **Blocks:** v1-AD-b (POST /admin/config sub-phase).
+  - **Target:** Before v1-AD-b plan writes.
+  ```
+
+- **MIRROR**: `docs/brehon-law-inspired-network/99-decisions-and-open-questions.md:431-438` for OQ-018 as the exact shape to follow.
+- **GOTCHA**: OQs are append-only. Do not edit existing ADRs. Do not resolve these three in v1-AD-a — resolution is user/advisor responsibility before v1-AD-b/c/d plans write.
+- **GOTCHA**: The changelog section at the bottom of `99-decisions-and-open-questions.md` (line 498+) needs an append entry:
+  ```markdown
+  **2026-04-21** — *99*
+  OQ-V1-AD-01, OQ-V1-AD-02, OQ-V1-AD-03 opened. All three block v1-AD
+  sub-phases (e/d/b respectively). Leans documented; resolution before
+  dependent plans write.
+  ```
+- **VALIDATE**: Grep check: `grep -c "^### OQ-" docs/brehon-law-inspired-network/99-decisions-and-open-questions.md` returns the previous count + 3. Markdown lint pass (if one is in CI) passes.
+
+---
+
+## 14. Testing strategy
+
+v0's test substrate already exists:
+- Unit tests: `crates/api/api/src/governance/config.rs::parity` (2 tests currently; becomes 3 with `every_seeded_key_has_metadata`)
+- Integration: `crates/server/tests/e2e.rs::config_parity_round_trip` — exercises every seeded key through the typed accessor against a real Postgres + all migrations applied
+
+v1-AD-a adds **no new test files**. It extends the two existing tests:
+
+### Tests added in this sub-phase
+
+| Test | Location | What it validates |
+|---|---|---|
+| `parity::every_seeded_key_has_metadata` (NEW) | `crates/api/api/src/governance/config.rs::parity` | Every `SEEDED_KEYS_WITH_CONSTS` entry has a matching `CONFIG_KEY_METADATA` row |
+| `parity::seeded_keys_count_matches_const_count` (EXTENDED) | same file | Now asserts `SEEDED_KEYS_WITH_CONSTS.len() == EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` |
+| `config_parity_round_trip` (UNCHANGED BODY, BROADER COVERAGE) | `crates/server/tests/e2e.rs:1308-1366` | Runs all 62 typed reads against a real Postgres with all 62 seeded rows |
+
+### Edge cases covered by existing tests
+
+- [x] Hash-chain integrity (unaffected — v1-AD-a doesn't write to governance_log)
+- [x] `actor_pseudonym` (unaffected — v1-AD-a writes no rows)
+- [x] `EmergencyRemove` branch (unaffected — `CaseStatus` enum untouched)
+- [x] Redaction (unaffected — no payload writes)
+- [x] Migration up+down round-trip via `config_parity_round_trip` run → fresh schema apply
+
+### Edge cases added
+
+- [x] `rule_set_version.parent_id` nullability — null-safe Queryable derive
+- [x] `moderation_case.applied_config_snapshot` JSONB optionality — Nullable<Jsonb> round-trips via `config_parity_round_trip` path (schema apply)
+- [x] Seed migration idempotency — running `schema_setup::run()` twice doesn't duplicate rows (already enforced by `ON CONFLICT DO NOTHING`; `config_parity_round_trip` runs once per test invocation, same transaction)
+
+---
+
+## 15. Validation commands (DoD)
+
+**Every command below was dry-run-tested against governance-v0 HEAD 3bbf419da on 2026-04-19 per `.claude/rules/pre-phase-harness-audit.md` + advisor directive.** Expected exit codes annotated inline.
+
+### Level 1: per-task `cargo check` (run after every task)
+
+```bash
+cmd //c "scripts\\brehon\\cargo-check.bat --workspace > .claude/PRPs/debug/phase-v1-AD-a-level1-taskN.log 2>&1"
+echo "exit: $?"
+```
+**EXPECT**: 0. Reviews per-task log via `tail -20 .claude/PRPs/debug/phase-v1-AD-a-level1-taskN.log` per `.claude/rules/no-cargo-output-paste.md`.
+
+### Level 2: `--features full` (tasks 5, 6, 7 specifically)
+
+```bash
+cmd //c "scripts\\brehon\\cargo-check.bat --workspace --features full > .claude/PRPs/debug/phase-v1-AD-a-level2-taskN.log 2>&1"
+echo "exit: $?"
+```
+**EXPECT**: 0. Forces the `full`-gated Diesel derives on new Queryable/Insertable structs to compile. NEVER use `-p <crate> --features full` per advisor memory — the `lemmy_server` crate doesn't declare the `full` feature.
+
+### Level 3: parity unit tests
+
+```bash
+cmd //c "scripts\\brehon\\cargo-test.bat --workspace --lib parity > .claude/PRPs/debug/phase-v1-AD-a-parity.log 2>&1"
+echo "exit: $?"
+```
+**EXPECT**: 0. Three tests pass: `seeded_keys_count_matches_const_count`, `every_seeded_key_has_const_fallback`, `every_seeded_key_has_metadata`.
+
+### Level 4: e2e parity + migration round-trip
+
+```bash
+cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server --no-run > .claude/PRPs/debug/phase-v1-AD-a-e2e-build.log 2>&1"
+echo "build exit: $?"
+cmd //c "scripts\\brehon\\cargo-test.bat --test e2e -p lemmy_server config_parity_round_trip > .claude/PRPs/debug/phase-v1-AD-a-e2e-run.log 2>&1"
+echo "run exit: $?"
+```
+**EXPECT**: 0 on both. The `config_parity_round_trip` test applies all migrations (including the 4 new ones), then walks `SEEDED_KEYS_WITH_CONSTS` (62 entries) calling the typed accessors. Any missing seed row, missing const, or type mismatch fails here.
+
+### Level 5: clippy (per plan-drift CI)
+
+```bash
+cmd //c "scripts\\brehon\\cargo-clippy.bat --workspace --features full -- -D warnings --no-deps > .claude/PRPs/debug/phase-v1-AD-a-clippy.log 2>&1"
+echo "exit: $?"
+```
+**EXPECT**: 0. Per memory `feedback_clippy_vs_check_wrapper.md` — must use `cargo-clippy.bat`, not `cargo-check.bat`. `--no-deps` avoids inherited lint debt per `.claude/rules/pre-phase-harness-audit.md` DoD-footgun #3.
+
+### Level 6: PM-hook integrity (belt-and-braces)
+
+```bash
+for h in \
+  local_private_message_before_create \
+  local_private_message_after_create \
+  local_private_message_before_update \
+  local_private_message_after_update \
+  federated_private_message_before_receive \
+  federated_private_message_after_receive; do
+  rg -q "\"$h\"" crates/ || { echo "missing hook literal: $h"; exit 1; }
+done
+echo "all PM hooks present"
+```
+**EXPECT**: prints "all PM hooks present". v1-AD-a doesn't touch PM code but the per-phase guard is mandatory per `.claude/rules/pm-plugin-hooks-stable.md`.
+
+---
+
+## 16. Acceptance criteria
+
+- [ ] All 9 tasks complete and committed on `phase-v1-AD-a`
+- [ ] Branch is exactly 9 commits ahead of `governance-v0` (one per task; task 0 produces no commit)
+- [ ] Levels 1-5 exit 0; level 6 prints all-hooks-present
+- [ ] `SEEDED_KEYS_WITH_CONSTS.len() == EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` (parametric, not a hard-coded 62 — the implementer reconciled the count at task 7's pre-commit gate per advisor edit #1)
+- [ ] `CONFIG_KEY_METADATA.len() == SEEDED_KEYS_WITH_CONSTS.len()` (every seeded key has metadata)
+- [ ] `EXPECTED_SEED_COUNT == 34` (unchanged, v0 invariant preserved)
+- [ ] `EXPECTED_SEED_COUNT_V1_AD` matches the actual number of `v1-AD-a`-added tuples in `SEEDED_KEYS_WITH_CONSTS` AND the actual number of `ON CONFLICT DO NOTHING` INSERT rows in task 7's `up.sql` — this is the advisor edit #1 reconciliation invariant
+- [ ] `rule_set.active_version_id` is NOT seeded, NOT in `SEEDED_KEYS_WITH_CONSTS`, NOT in `CONFIG_KEY_METADATA`, NOT in `const_default_int` (per advisor edit #2 — absence-of-row IS the "no active version" signal)
+- [ ] `ENTRY_KIND_ADMIN_CONFIG_CHANGED == "admin_config_changed"` — byte-identical to shell-script emission at `scripts/brehon/admin-config-write.sh:148`
+- [ ] `ENTRY_KIND_ADMIN_CONFIG_CHANGE_DENIED == "admin_config_change_denied"`
+- [ ] `.claude/rules/governance-log-entry-kind-registry.md` exists and lists 21 populated kinds (19 v0 + 2 v1-AD) + Phase 6 pending section + 4 reserved sections for future v1 PRDs (7 sections + acceptance = ≥8 `## ` headings)
+- [ ] Registry file section structure matches GH #41 "Proposed deliverable" enumeration byte-for-byte (advisor edit #3)
+- [ ] GH #41 closeable with "landed at `.claude/rules/governance-log-entry-kind-registry.md` in v1-AD-a at `<commit>`" comment
+- [ ] OQ-V1-AD-01/02/03 opened in 99-decisions-and-open-questions.md (leans documented, no resolution)
+- [ ] Changelog entry appended for 2026-04-21
+- [ ] No contradictions with ADRs 1-15 — especially ADR-010 (staged releases), ADR-013 (EmergencyRemove match exhaustiveness), ADR-015 (pseudonym write-path untouched)
+- [ ] No ActivityPub changes (no `crates/apub/` touched)
+- [ ] No new dependencies added to any `Cargo.toml`
+- [ ] Retro written at `.claude/PRPs/reports/phase-v1-AD-a-retro.md` BEFORE PR merge (per `feedback_retro_not_report.md`)
+- [ ] PR opened via `gh pr create --repo barrie-cork/lemmy --base governance-v0 --head phase-v1-AD-a` per `.claude/rules/gh-pr-fork-target.md`
+- [ ] PR merged with `--merge` (not `--squash`) — preserves task-per-commit history for CodeRabbit review per advisor close-out directive
+
+---
+
+## 17. Completion checklist
+
+- [ ] Task 0 PRE-FLIGHT — branch verified, wrapper probes pass
+- [ ] Task 1 — `add_rule_set_versions` migration
+- [ ] Task 2 — `add_sponsor_allowlist` migration
+- [ ] Task 3 — `add_case_applied_config_snapshot` migration
+- [ ] Task 4 — schema.rs hand-edit
+- [ ] Task 5 — Diesel models + newtypes + mod.rs
+- [ ] Task 6 — `ConfigKeyMetadata` registry + 27 consts + parity test extension
+- [ ] Task 7 — seed migration + 2 ENTRY_KIND consts
+- [ ] Task 8 — entry-kind registry file
+- [ ] Task 9 — three new OQs opened
+- [ ] Acceptance criteria (§16) pass
+- [ ] PR #TBD open against `governance-v0` with CodeRabbit auto-review triggered
+- [ ] GH issue #41 closed with a comment pointing to `.claude/rules/governance-log-entry-kind-registry.md`
+
+---
+
+## 18. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `ConfigKeyMetadata` struct churn as v1-AD-b/c/d add use sites | MED | LOW | Ship in v1-AD-a with a conservative field set (10 fields listed above). Adding a field later is `&'static` array churn but parity-test-covered. Avoid `Vec<…>` / heap types — kill the temptation to make it runtime. |
+| Seed-row count drift — PRD §5.2 "~28" vs plan §4.1 "27" vs actual task-6 tuples vs task-7 INSERT rows | MED | MED | **Advisor edit #1 mitigation (task 7 pre-commit reconciliation gate):** before committing task 7's migration, the implementer runs the two grep-count invariants + the parametric `config_parity_round_trip` test against a fresh container. Three reconciliation outcomes documented (add rows / remove rows / DQ). This converts drift from "end-of-plan surprise at task 7 validation" into an explicit task-7 pre-commit step — task 5/6 drift becomes detectable before any migration SQL commits. Note: plan §4.1 states 27 as the current best count (28-in-PRD minus `rule_set.active_version_id`); the parametric test accepts any value the implementer reconciles to. |
+| Schema.rs hand-edit conflict on next upstream rebase | MED | MED | The fork already maintains hand-added governance tables in schema.rs; convention is documented at schema.rs:426-428. Weekly rebase catches any upstream auto-regen that would overwrite — triggers `/prp-debug` per CLAUDE.md. |
+| `rule_set.active_version_id` sentinel confusion (if impl forgets advisor edit #2 and adds a `-1` default) | LOW | MED | §4.1 and task 6 GOTCHA both explicitly forbid the sentinel. Parity-test symmetry (metadata ↔ seed ↔ const) makes the omission verifiable: the test passes only when the key is absent from all three compile-time tables. If an implementer adds it anyway "for completeness," clippy-dead-code will complain about the unused const; the DQ escape hatch is documented. |
+| v1-AD-b reader crashes on `rule_set.active_version_id` read before v1-AD-c seeds it | LOW | MED | v1-AD-b plan (written later) must introduce `config::get_int_opt` that treats "no row + no const" as `None`, not an error. Documented as load-bearing constraint in v1-AD-a §4.1 and in the v1-AD-b stub at §20. Not a v1-AD-a code smell; flagged here so the v1-AD-b planner doesn't write a caller that uses the error-returning `get_int` for this key. |
+| Parity test mis-counts under `--workspace --features full` because `full` enables a derive that requires different types | LOW | LOW | Task 6 GOTCHA includes `--features full` validation. If the derive fails, the whole workspace fails to compile — loud, not silent. |
+| v1-AD-a ships before advisor resolves OQ-V1-AD-01/02/03 | LOW | LOW | v1-AD-a doesn't consume any of the three OQ resolutions. They block v1-AD-b/d/e only. v1-AD-a ships, OQs sit open until next sub-phase plans. |
+| `admin_config_changed` payload-shape drift between shell script + future Rust handler breaks NOT5 gate 3 | LOW | MED | v1-AD-b is the owner of this gate, not v1-AD-a. v1-AD-a only adds the const. v1-AD-b plan will include a byte-level payload-equivalence test per NOT5 §8.4 condition 3. |
+| Issue #41 coordination with jury-mechanics-v1 / reputation-tuning-v1 / etc. plans that land later | LOW | MED | The registry file lives under `.claude/rules/` which auto-loads in `-p` mode. Every subsequent v1 plan's impl agent reads it at iteration 1. Each sub-PRD appends its own section on `/prp-plan` run; collision detection is `rg "^pub const ENTRY_KIND_"` count + literal-uniqueness. |
+| Wrapper script bug re-emerges (exit-code masking, flag discard) | LOW | HIGH | Task 0 runs the pre-phase harness audit's four probes including the negative exit-code-propagation probe. Failure blocks task 1. |
+
+---
+
+## 19. Notes
+
+- v1-AD-a is **the lightest of the five sub-phases**. It lands schema + metadata + registry foundation; no handlers, no DTOs, no routes. This is deliberate — it de-risks the heavier sub-phases (v1-AD-b's 8-9 tasks + dry-run + audit endpoint) by giving them a stable substrate to land on.
+- The `EXPECTED_SEED_COUNT_V1_AD` pattern (parametric per-sub-PRD count) means jury-mechanics-v1, reputation-tuning-v1, sponsor-liability-v1, and federation-inbound-v1 each add their own const when they plan. Only the aggregate `SEEDED_KEYS_WITH_CONSTS.len()` drifts; each sub-PRD's contribution stays pinned. This is advisor directive #4's "parametric" instruction materialised.
+- If the task 7 INSERT row count drifts from the task 6 `SEEDED_KEYS_WITH_CONSTS` extension, `config_parity_round_trip` fails loudly at level 4. The parity loop is the single source of truth; PRD §5.2 and §11 counts are descriptive, not normative.
+- Issue #41's entry-kind registry was originally a standalone deliverable scheduled for AFTER Phase 6 merge BEFORE first v1 PRD's `/prp-plan` run. Advisor directive 2026-04-19 reassigns it to v1-AD-a's task 8 — fewer moving parts, one less cross-branch coordination.
+
+---
+
+## 20. Sub-phase stubs (v1-AD-b/c/d/e TOC)
+
+These are planning scaffolds only. Each requires its own `/prp-plan` run against the then-current `governance-v0` HEAD (v1-AD-a merged). Do NOT implement from these stubs.
+
+### v1-AD-b — Write endpoint + audit + dry-run
+
+**Deliverables:**
+- `POST /api/v4/governance/admin/config` single-key write handler (`admin_set_config`)
+- `GET /api/v4/governance/admin/config` full-read + single-key-read handler (`admin_get_config`)
+- `GET /api/v4/governance/admin/config/audit` paginated audit handler (`admin_get_config_audit`)
+- New `config::get_int_opt` / `get_float_opt` / `get_bool_opt` / `get_text_opt` accessors — return `Ok(None)` when both DB row and const default are absent, instead of `Err` or `Ok(Some(fallback))`. **Required for `rule_set.active_version_id` path** (absence-of-row signal per advisor edit #2) AND any future key that follows the same convention.
+  
+  **GOTCHA for v1-AD-b planner (advisor note 1):** when v1-AD-b writes `config::get_int_opt`, the no-row-no-const path MUST return `Ok(None)`, not `Ok(Some(0))`, not `Ok(Some(-1))`, not any other fallback. If the impl agent writes `get_int` (the erroring accessor) and relies on a const fallback, they re-introduce the sentinel advisor edit #2 removed. Required test: `parity::rule_set_active_version_absent_returns_none` must assert `None` pre-v1-AD-c seeding (harness applies all migrations, does NOT seed `rule_set.active_version_id`, calls `get_int_opt(Scope::Instance, "rule_set.active_version_id")`, asserts `Ok(None)`). v1-AD-b plan DoD must include this test.
+- Capability checks (is_admin for instance scope, CommunityModeratorView for community scope)
+- Dry-run impact computation **outside** tx (per OQ-V1-AD-03 lean)
+- Per-key type validation via `CONFIG_KEY_METADATA` lookup
+- Payload byte-identity verification against shell script (NOT5 gate 3)
+
+**Blocked by:** v1-AD-a merged; OQ-V1-AD-03 resolved.
+
+**Task count estimate:** 8-9 (1 extra for `get_*_opt` accessor family).
+
+### v1-AD-c — Rule-set versioning routes + wire-up
+
+**Deliverables:**
+- `GET /api/v4/governance/admin/rule-sets` list handler
+- `POST /api/v4/governance/admin/rule-sets` create handler (appends version)
+- `submit_jury_vote` edit: pin `moderation_case.rule_set_version_id = current_active_version` at decision time
+- `admin_assign_jury` edit: populate `moderation_case.applied_config_snapshot` at panel-assembly time
+- `rule_set.active_version_id = -1 → None` reader conversion
+
+**Blocked by:** v1-AD-a merged.
+
+**Task count estimate:** 4-5.
+
+### v1-AD-d — Dashboard aggregate + SSE audit stream
+
+**Deliverables:**
+- `GET /api/v4/governance/admin/dashboard` aggregate handler (active cases / jury queue / recent config changes / federation status / reputation health)
+- `GET /api/v4/governance/admin/audit/stream` SSE handler bridging Postgres `LISTEN governance_events` to HTTP
+- SSE implementation per OQ-V1-AD-02 resolution (lean: hand-rolled via `async-stream`)
+
+**Blocked by:** v1-AD-a merged; OQ-V1-AD-02 resolved.
+
+**Task count estimate:** 3-4.
+
+### v1-AD-e — Askama HTML pages (DEFERRED)
+
+**Status:** Likely deferred to v1.x / v2 per OQ-V1-AD-01 lean. If user opts to ship: dashboard template, config editor template, audit log template, rule-set manager template.
+
+**Blocked by:** v1-AD-a, b, c, d merged; OQ-V1-AD-01 resolved as "ship, not defer".
+
+**Task count estimate:** 5-7 (if shipped).
+
+---
+
+**END OF v1-AD-a PLAN**

--- a/.claude/PRPs/prds/v1-admin-dashboard.prd.md
+++ b/.claude/PRPs/prds/v1-admin-dashboard.prd.md
@@ -517,11 +517,11 @@ Per OQ-018 lean ("only instance-admin + 24h delay" for rule-set version changes)
 | `add_rule_set_versions` | `rule_set_version` table; `moderation_case.rule_set_version_id` column | First v1 milestone |
 | `add_sponsor_allowlist` | `sponsor_allowlist` table (per OQ-020 `'allowlist'` strategy) | v1.x once strategy is needed |
 | `add_case_applied_config_snapshot` | `moderation_case.applied_config_snapshot` JSONB column | First v1 milestone (supports `requires_re_jury` grandfathering) |
-| `seed_v1_config_keys` | INSERT 28 new v1 keys into `governance_config` | First v1 milestone |
+| `seed_v1_config_keys` | INSERT 27 new v1 keys into `governance_config` (excludes `rule_set.active_version_id` per v1-AD-a §4.1 absence-of-row decision) | First v1 milestone |
 
 All four migrations are idempotent; each `up.sql` uses `ON CONFLICT DO NOTHING` for INSERTs and `IF NOT EXISTS` for CREATE statements (matching the v0 patterns).
 
-### 8.3 Initial seed (28 new keys)
+### 8.3 Initial seed (27 new keys; `rule_set.active_version_id` deliberately un-seeded)
 
 Single `INSERT … ON CONFLICT (scope, key, valid_from) DO NOTHING` per the v0 pattern (`migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78`). Defaults from §5.2.
 
@@ -540,7 +540,7 @@ Single `INSERT … ON CONFLICT (scope, key, valid_from) DO NOTHING` per the v0 p
 ### 8.5 Backwards compatibility
 
 - Hardcoded `DEFAULT_*` consts in `crates/api/api/src/governance/config.rs` remain as the **third-tier fallback** if a `governance_config` row is missing — already documented and tested (`every_seeded_key_has_const_fallback`)
-- v1 adds new `DEFAULT_*` consts for the 28 new keys; the parity test is updated to expect 62 not 34
+- v1 adds new `DEFAULT_*` consts for the 27 new keys; the parity test becomes parametric — `SEEDED_KEYS_WITH_CONSTS.len() == EXPECTED_SEED_COUNT + EXPECTED_SEED_COUNT_V1_AD` (34 + 27 = 61 post-v1-AD-a merge; further sub-PRDs contribute their own `EXPECTED_SEED_COUNT_V1_*` consts per v1-AD-a §19)
 - v0 callers reading config via `get_int`/`get_float`/`get_bool`/`get_text` keep working unchanged
 - v0's `admin_assign_jury` already reads `jury.panel_size` and `jury.fallback_on_small_pool` from config — no code change for the panel-size bump from 5 to 7 beyond the seed value
 

--- a/.claude/PRPs/prds/v1-admin-dashboard.prd.md
+++ b/.claude/PRPs/prds/v1-admin-dashboard.prd.md
@@ -87,6 +87,7 @@ Final 15-namespace registry (this section authoritative; individual-PRD matrices
 | `appeal.*` | 0 | 5 (owned by jury-mechanics-v1 §10: `window_days`, `panel_size_multiplier`, `panel_size_floor_increment`, `threshold_tier_bump`, `auto_select_on_appeal_acceptance`. `original_jurors_excluded` is hard code rule, not a config key — per B1) | jury-mechanics | Appeal mechanics |
 | `federation.*` | 0 | 5 (`inbound_advisory_only`, `peer_attestation_ttl_days`, `signature_required`, `quarantine_recommendation_severity_floor`, `outbound_publish_enabled`; federation-inbound-v1 may add further peer-trust knobs per its §8.0/§10) | admin-dashboard, federation-inbound | Federation policy. Peer-trust knobs live here; see `v1-federation-inbound.prd.md` §10. |
 | `rule_set.*` | 0 | 4 (`active_version_id`, `auto_carry_in_flight_cases`, `text_max_bytes`, `version_propagation_delay_hours`) | admin-dashboard | Rule-set version pointer |
+| `governance.dashboard.*` | 0 | 2 (`html_pages_enabled` bool — §6.1 gates askama HTML pages; `step_up_enforced` bool — §7.2 advisory-vs-blocking toggle for v2 step-up reserved slot) | admin-dashboard | Dashboard-infrastructure toggles. Both are instance-scope; default-false for `step_up_enforced` (log-only in v1), default-true for `html_pages_enabled` (API+HTML by default; operators can go API-only). |
 
 **Namespace-collapse rationale (B3):** v0 establishes `liability.*` and `job.*` as flat namespaces. A dual `cron.*` + `job.*` pair for the same concept (background scheduler cadence) would be a permanent operator tax. Participation-event tuning keys aren't cron knobs semantically — they are reputation deltas conditioned on cron-batch context, so they belong under `deltas.*` (policy) or `participation.*` (context). `bounds.*` is genuinely new (post-clamp snapshot ceilings — distinct from `thresholds.*` capability cutoffs). `feature.*` is prophylactic for growth (every future deferred-enforcement toggle will need one; starting the namespace now avoids later retrofits).
 
@@ -378,9 +379,9 @@ The v0 seed values from `migrations/2026-04-18-000000-0000_add_governance_config
 | `onboarding.sponsor_allowlist_table_name` | "sponsor_allowlist" | (a) | OQ-020 explicit; v1 adds the table additively |
 | `onboarding.provisional_membership_cooldown_days` | 14 | (b) | OQ-016 v1 enforcement; pilot |
 | `founder.founder_seal_visible_in_profile` | true | (a) | OQ-017 lean; admin can flip false |
-| `participation.weekly_active_delta` | 1 | (b) | OQ-019 option (a) |
-| `participation.dormant_threshold_days` | 30 | (a) | OQ-019 |
-| `participation.dormant_delta` | -2 | (b) | OQ-019 |
+| `deltas.participation_weekly_active` | 1 | (b) | OQ-019 option (a); renamed from `participation.weekly_active_delta` per B3 namespace collapse 2026-04-19 — `deltas.*` owns reputation-delta policy knobs (delta values), `participation.*` owns context knobs (thresholds, windows) |
+| `participation.dormancy_window_days` | 30 | (a) | OQ-019; renamed from `participation.dormant_threshold_days` per B3 for consistency with reputation-tuning-v1 PRD §8 |
+| `deltas.participation_dormant` | -2 | (b) | OQ-019; renamed from `participation.dormant_delta` per B3 |
 | `participation.attestation_enabled` | false | (c) | OQ-019 option (c) deferred to v2 unless pilot asks |
 | *(appeal.* namespace owned by jury-mechanics-v1 §10 per B1 resolution 2026-04-19)* | — | — | See v1-jury-mechanics.prd.md §10 for `appeal.window_days`, `appeal.panel_size_multiplier`, `appeal.panel_size_floor_increment`, `appeal.threshold_tier_bump`, `appeal.auto_select_on_appeal_acceptance`. Note: `appeal.original_jurors_excluded` is a hard code rule per [01 §5.7], not a config key. |
 | `federation.inbound_advisory_only` | true | (a) | ADR-006 — locked; admin can flip in v2 only |
@@ -392,6 +393,8 @@ The v0 seed values from `migrations/2026-04-18-000000-0000_add_governance_config
 | `rule_set.auto_carry_in_flight_cases` | true | (a) | Existing cases keep their snapshotted version; new cases use new |
 | `rule_set.text_max_bytes` | 65536 | (a) | 64 KiB Markdown ceiling |
 | `rule_set.version_propagation_delay_hours` | 24 | (b) | OQ-018 lean ("only instance-admin + 24h delay" — generalised to rule-set activation) |
+| `governance.dashboard.html_pages_enabled` | true | (a) | §6.1 — opt-in HTML pages; flipping to false runs dashboard API-only (useful when OQ-V1-AD-01 defers askama). Scope: instance. Type: bool. |
+| `governance.dashboard.step_up_enforced` | false | (a) | §7.2 — v2-reserved step-up enforcement toggle. v1 default is advisory (attempt logged via `admin_config_change_denied` entry kind); v2 flips to blocking once step-up auth ships. Scope: instance. Type: bool. |
 
 **Counts:** 34 v0 keys (32 (a)/(b), 2 (c) — none in v0), ~35 v1-new keys enumerated in this PRD (admin-dashboard-owned + sponsor-liability-owned rows), of which **1 is decide-later (c)**: `participation.attestation_enabled`. Federation peer-trust-state knobs live in `v1-federation-inbound.prd.md` §10 and are not enumerated here. The authoritative v1 cross-PRD total of ~138 keys across 15 namespaces is documented in §3.1; §5.2 lists only the admin-dashboard + sponsor-liability rows, with jury-mechanics-v1, reputation-tuning-v1 and federation-inbound-v1 rows in their own PRDs.
 
@@ -535,7 +538,7 @@ Single `INSERT … ON CONFLICT (scope, key, valid_from) DO NOTHING` per the v0 p
   2. Pilot operator confirms the HTTP API covers every key class the script writes (strings, ints, floats, bools, enums, text blobs).
   3. `governance_log` entries written by both paths are byte-identical (verified via round-trip test: write via HTTP, write via script, diff the two log rows — signatures will differ but payload + `entry_kind` must match).
 - **v1.1 is the target but contingent.** If OQ-018's endpoint ships in v1.0 and conditions 2+3 are met by v1.0 pilot review, v1.1 removes the script. If OQ-018 slips to v1.1 or v1.2, script removal slips with it. The script is harmless to keep shipping; the ops cost is one deprecation warning banner on startup, not runtime load.
-- **governance_log audit-trail continuity.** Both code paths emit `governance_config_changed` entries via the same `governance_log::append` function, so there is no audit-trail discontinuity whether operators use the script or the HTTP API during the side-by-side window.
+- **governance_log audit-trail continuity.** Both code paths emit `admin_config_changed` entries (canonical `entry_kind` per §4.5, §7.4, and v1-AD-a plan task 7; byte-identical to the shell-script emission at `scripts/brehon/admin-config-write.sh:148`) via the same `governance_log::append` function, so there is no audit-trail discontinuity whether operators use the script or the HTTP API during the side-by-side window. Earlier drafts used `governance_config_changed` here — that was drift from the canonical name and has been corrected.
 
 ### 8.5 Backwards compatibility
 

--- a/.claude/PRPs/prds/v1-admin-dashboard.prd.md
+++ b/.claude/PRPs/prds/v1-admin-dashboard.prd.md
@@ -1,0 +1,635 @@
+# v1 Admin Dashboard — Sub-PRD
+
+**Audience:** Backend lead + design (no designer assigned), pilot operator
+**Status:** Draft (v1 design phase, 2026-04-19)
+**Theme:** Community sovereignty via configurable governance — every knob has an instance default and a per-community override
+**Owner:** TBD (backend lead) — keystone v1 deliverable
+**Predecessor v0 surfaces:** `governance_config` table (Phase 5a task 50), `admin-config-write.sh` operator script (Phase 5c task 70), three v0 admin endpoints (`/admin/assign-jury`, `/admin/close-case`, `/admin/reputation-stats`)
+**Resolves / consumes:** OQ-018 (admin HTTP config-write — primary), OQ-002, OQ-005 (partial — operator UX only), OQ-019, OQ-020, OQ-025, OQ-026 (config schema decision)
+**Out of scope:** OQ-009 juror anonymity UX (depends on OQ-005), OQ-010 production signing keys (v2), OQ-011 first-target community (orthogonal), full React frontend (v2/v3 per ADR-010)
+
+---
+
+## 1. Vision & Goals
+
+> **The admin dashboard exists so a community can change how it governs itself without re-deploying the binary.**
+
+Per [01 §3 Core principle](../../../docs/brehon-law-inspired-network/01-vision-and-principles.md), justice is enforced by social trust and mutual obligation. That principle lives in policy parameters (jury size, sponsor liability multipliers, founder seed caps, gate strategies) — and policy must be **discoverable, versioned, auditable, and scoped**. v0's "edit `governance_config` over psql" is operationally sufficient for one solo operator on one instance; the moment a second pilot community asks "can our jury be 7 instead of 5?", the answer must be a JSON write, not a code change.
+
+### 1.1 Goals
+
+| # | Goal | How this PRD achieves it |
+|---|---|---|
+| G1 | Every governance knob has a default + an override path | §3 schema + §5 defaults table |
+| G2 | Every config change is auditable and signed | §4 single-key write writes one `governance_log` entry per change via existing `governance_log::append` |
+| G3 | Per-community sovereignty without breaking instance-wide invariants | §3 merge precedence: community → instance → const |
+| G4 | Operators can preview impact before committing | §4 `dry_run` query parameter on every write |
+| G5 | In-flight juries are not retroactively invalidated by config edits | §3 `requires_re_jury` flag + §4 `apply_at` semantics |
+| G6 | Backend-first, minimal pages — Lemmy-UI plugin / React frontend deferred | §6 server-rendered admin pages (askama or maud); v1.5/v2 React pass |
+
+### 1.2 Non-goals (v1)
+
+- Per-user preference editing (Lemmy-native settings cover this)
+- Moderation case management UI (separate v1 PRD: `v1-jury-mechanics.prd.md`)
+- Federation peer trust state UI (separate v1 PRD: `v1-federation-inbound.prd.md` if extracted)
+- Full React/SPA dashboard (v1.5/v2 frontend pass)
+- Rule-text editor with WYSIWYG (v1 ships JSON + plaintext upload only — see §3.6 `rule_set.*`)
+- Step-up auth implementation (v2 per ADR-010 / `06 §2.1`); this PRD reserves the slot via `requires_step_up` config metadata
+- Multi-tenant federations on one instance (deferred — see §9)
+
+---
+
+## 2. Scope
+
+| In scope | Out of scope |
+|---|---|
+| Instance-config + per-community-config read/write HTTP API | Per-user preferences (Lemmy-native) |
+| Founder/sponsor settings, jury parameters, reputation tuning, federation policy, threshold knobs | Moderation case adjudication UI |
+| Rule-set version management (immutable versions, append history) | Federation operator UX (peer add/remove flows) |
+| Audit log surface for config changes | Step-up auth implementation (v2) |
+| Minimal server-rendered admin pages (Rust templating) | Production OPA/OpenFGA migration (v2) |
+| Capability-gated endpoints (instance_admin, community_admin) | Rich React frontend (v1.5/v2) |
+| Dry-run preview, `apply_at` immediate vs. next-jury-cycle semantics | Bulk import/export (open question §9) |
+
+---
+
+## 3. Configuration Schema (JSON-shaped)
+
+### 3.1 Hierarchical namespaces (v1 inventory)
+
+The v0 seed list (34 keys, `crates/api/api/src/governance/config.rs:463 EXPECTED_SEED_COUNT`) is the starting inventory. v1 adds keys for rule-set versioning, federation policy, appeal windows, sponsor liability grace windows (OQ-025), participation_consistency sources (OQ-019), per-dimension decay/bounds (reputation-tuning-v1), and federation-peer trust controls (federation-inbound-v1). Final v1 inventory — authoritative across all five v1 sub-PRDs — is **~138 keys across 15 namespaces**. Per-PRD contribution breakdown:
+
+| Sub-PRD | Net key additions | Primary namespaces touched |
+|---|---|---|
+| admin-dashboard-v1 (this PRD) | ~24 | `jury.*`, `liability.*`, `report.*`, `onboarding.*`, `founder.*`, `participation.*`, `federation.*`, `rule_set.*` |
+| jury-mechanics-v1 | ~18 | `jury.*` (incl. 9-cell `panel_size.<status>.<severity>` matrix per B2 cascade), `appeal.*` (5 keys — jury-mechanics owns per B1) |
+| reputation-tuning-v1 | 28 | `decay.*` (8 per-dim/per-dir), `bounds.*` (8 floor/ceiling), `deltas.*` (5), `participation.*` (3 context knobs), `job.*` (3 cadence + rollup), `feature.*` (1 v1-decay flag) |
+| sponsor-liability-v1 | 10 | `liability.*` (flat per B4 — grace_window_\*_hours x6, restoration/multi-sponsor x3, revoke rate-limit x1) |
+| federation-inbound-v1 | ~8 | `federation.*` (peer-trust knobs, advisory-only toggle, TTL, quarantine-severity floor) |
+| **TOTAL** | **~88 new v1 keys** (+ 34 v0 keys ≈ 122–138 depending on subtle overlaps) | across 15 namespaces |
+
+Final 15-namespace registry (this section authoritative; individual-PRD matrices are the sources of truth for their own rows):
+
+| Namespace | v0 keys | v1 additions | v1 owner-PRDs | Purpose |
+|---|---|---|---|---|
+| `thresholds.*` | 3 | 0 | admin-dashboard (no changes) | Capability cutoffs (jury_reliability, reporting_accuracy, endorsement_strength) |
+| `jury.*` | 5 | 4 (admin-dashboard: severity-thresholds, diversity, deadline window, + jury-mechanics cascade matrix keys per B2) | admin-dashboard, jury-mechanics | Jury size, quorum, gating, fallback. Bare `jury.panel_size = 7` kept as final fallback per B2 cascade `jury.panel_size.<status>.<severity>` → `jury.panel_size.<severity>` → `jury.panel_size` → const. |
+| `deltas.*` | 9 | +5 (reputation-tuning: participation_weekly_active, participation_dormant, participation_juror_aligned, evidence_cited, evidence_bad_faith) | admin-dashboard, reputation-tuning | Per-event reputation deltas (policy knobs) |
+| `liability.*` | 3 | +10 (flat per B4: grace_window_{minor,moderate,severe,minimum,maximum,alert_threshold}_hours x6, restoration_escapes_liability, restoration_severity_reduction_steps, multi_sponsor_escape_rule, revoke_rate_limit_per_day — all sponsor-liability-owned) | admin-dashboard, sponsor-liability | Sponsor liability tuning — flat namespace per v0 precedent |
+| `report.*` | 5 | 1 (`weighted_report_clamp_ceiling_review_v1` per OQ-006 footnote) | admin-dashboard | Threshold formula |
+| `decay.*` | 1 | +7 (reputation-tuning: 8 per-dim × per-dir half-lives, of which 1 mirrors v0 default so net +7 new keys) | admin-dashboard, reputation-tuning | Per-dimension + per-direction reputation decay tuning |
+| `bounds.*` | 0 | 8 (reputation-tuning: 4 dims × floor+ceiling snapshot clamps) | reputation-tuning | Soft bounds on snapshot dimension sums — distinct from `thresholds.*` (capability cutoffs) |
+| `onboarding.*` | 3 | 4 (admin-dashboard: `sponsor_gate_strategy` enum widened per OQ-020; `sponsor_min_endorsement_strength` for `'reputation'` strategy; `sponsor_allowlist_table_name`; `provisional_membership_cooldown_days`) | admin-dashboard, reputation-tuning (gate strategies) | Onboarding policy |
+| `founder.*` | 3 | 1 (`founder_seal_visible_in_profile` bool per OQ-017) | admin-dashboard | Founder seeding |
+| `job.*` | 2 | +3 (reputation-tuning: participation_interval_days, rollup_interval_days, rollup_equal_weights per B3 namespace collapse) | admin-dashboard, reputation-tuning | Background job cadence + batch-config. `job.*` is the single authoritative cadence namespace — no parallel `cron.*` namespace per B3. |
+| `participation.*` | 0 | +5 (3 reputation-tuning context knobs: activity_threshold_comments, lookback_days, dormancy_window_days; + 2 admin-dashboard OQ-019 knobs. `weekly_active_delta` and `dormant_delta` moved to `deltas.*` per B3; `attestation_enabled` remains here.) | admin-dashboard, reputation-tuning | Participation-context knobs (policy-adjacent; the reputation-delta values live under `deltas.*`) |
+| `feature.*` | 0 | 1 (`feature.reputation_v1_decay_enabled` per B3) | reputation-tuning | Feature-flag namespace. First-class per B3 — future deferred-enforcement toggles extend this. |
+| `appeal.*` | 0 | 5 (owned by jury-mechanics-v1 §10: `window_days`, `panel_size_multiplier`, `panel_size_floor_increment`, `threshold_tier_bump`, `auto_select_on_appeal_acceptance`. `original_jurors_excluded` is hard code rule, not a config key — per B1) | jury-mechanics | Appeal mechanics |
+| `federation.*` | 0 | 5 (`inbound_advisory_only`, `peer_attestation_ttl_days`, `signature_required`, `quarantine_recommendation_severity_floor`, `outbound_publish_enabled`; federation-inbound-v1 may add further peer-trust knobs per its §8.0/§10) | admin-dashboard, federation-inbound | Federation policy. Peer-trust knobs live here; see `v1-federation-inbound.prd.md` §10. |
+| `rule_set.*` | 0 | 4 (`active_version_id`, `auto_carry_in_flight_cases`, `text_max_bytes`, `version_propagation_delay_hours`) | admin-dashboard | Rule-set version pointer |
+
+**Namespace-collapse rationale (B3):** v0 establishes `liability.*` and `job.*` as flat namespaces. A dual `cron.*` + `job.*` pair for the same concept (background scheduler cadence) would be a permanent operator tax. Participation-event tuning keys aren't cron knobs semantically — they are reputation deltas conditioned on cron-batch context, so they belong under `deltas.*` (policy) or `participation.*` (context). `bounds.*` is genuinely new (post-clamp snapshot ceilings — distinct from `thresholds.*` capability cutoffs). `feature.*` is prophylactic for growth (every future deferred-enforcement toggle will need one; starting the namespace now avoids later retrofits).
+
+### 3.2 Per-key metadata (config-key registry)
+
+Each key has compile-time metadata that drives schema-driven UI, validation, and the Watch-1 parity contract (already enforced for v0 keys via `SEEDED_KEYS_WITH_CONSTS`):
+
+```rust
+pub struct ConfigKeyMetadata {
+  pub key: &'static str,                  // "jury.panel_size"
+  pub value_type: ValueType,              // Int | Float | Bool | Text | Enum(&'static [&'static str])
+  pub default: ConstDefault,              // mirrors DEFAULT_* const
+  pub valid_range: Option<NumericRange>,  // for Int/Float
+  pub valid_enum: Option<&'static [&'static str]>, // for Enum
+  pub scope: ConfigScope,                 // Instance | Community | Both
+  pub requires_re_jury: bool,             // §3.4 — does change affect in-flight juries?
+  pub requires_step_up: bool,             // §7 — reserved for v2 step-up auth
+  pub apply_at_default: ApplyAt,          // Immediate | NextJuryCycle | NextSnapshotJob
+  pub description: &'static str,          // shown in /admin/governance/config form
+  pub doc_anchor: &'static str,           // "01#5.6" → links to design doc section
+}
+```
+
+**v1 convention:** every new key added to `SEEDED_KEYS_WITH_CONSTS` MUST also appear in a parallel `CONFIG_KEY_METADATA` table. A new `parity::every_seeded_key_has_metadata` test enforces it (matches the existing `every_seeded_key_has_const_fallback` test pattern at `crates/api/api/src/governance/config.rs:484`).
+
+**Storage commitment (per NOT4 2026-04-19):** `CONFIG_KEY_METADATA` is a **compile-time `&'static [ConfigKeyMetadata]` array** (and NOT a runtime `config_key_metadata` table). Every new key requires a PR-against-Rust-code edit — no DB migration adds metadata rows. This is deliberate: it matches the existing Watch-1 parity contract (`SEEDED_KEYS_WITH_CONSTS` is already compile-time), enforces review of new knob semantics at PR time rather than runtime-seed time, and removes a class of drift ("DB has key with no const, or const with no metadata"). The trade-off is that a new key cannot be hot-shipped without a code rollout — acceptable because governance knobs are rare additions and the parity test would reject a DB-only addition anyway. The `§6.1` `/admin/governance/config` page reads from the compile-time array (`&CONFIG_KEY_METADATA[..]`), not from a DB query.
+
+### 3.3 Merge precedence (already implemented in v0 reader)
+
+Per `crates/api/api/src/governance/config.rs:269 fetch_value`:
+
+```
+1. governance_config row WHERE scope = 'community:<id>' AND key = '<key>'   (most specific)
+2. governance_config row WHERE scope = 'instance' AND key = '<key>'
+3. Rust DEFAULT_* const                                                      (fallback)
+```
+
+v1 dashboard surfaces this provenance in `GET /admin/governance/config` responses — every value carries an `effective_from: "community:42" | "instance" | "default"` field so operators see *why* a value is what it is.
+
+### 3.4 `requires_re_jury` flag (per ADR-010 invariant)
+
+ADR-010 commits that a config edit must not retroactively invalidate in-flight juries. The flag distinguishes:
+
+- **`requires_re_jury = false`** (most keys): change is read at next handler invocation. Examples: `report.case_threshold_micros`, `deltas.juror_aligned`, `onboarding.sponsor_min_account_age_days`.
+- **`requires_re_jury = true`** (panel composition keys): change is read only at `Open | ThresholdMet` → `JurySelection` transition. In-flight cases (`JurySelection | InReview`) keep the panel size + thresholds they were seated under, snapshotted onto `moderation_case.applied_config_snapshot` (new column added in v1 migration). Examples: `jury.panel_size`, `jury.severity_thresholds`, `jury.diversity_constraints`.
+
+`apply_at` semantics on the write endpoint (§4) make this explicit: `apply_at = "next_jury_cycle"` for `requires_re_jury` keys is the safe default.
+
+### 3.5 Status-aware rule extension (OQ-026 resolution)
+
+OQ-026 asked: how do we add status-conditional rules (`jury.panel_size.founder = 7` vs `jury.panel_size.regular = 5`) without a schema migration?
+
+**v1 decision: dotted-namespace + reader-side cascade (OQ-026 option (a)).**
+
+- Status-conditional keys use the form `<namespace>.<param>.<status_tier>` where `status_tier ∈ { regular, founder }` (and is extensible to more tiers in v2).
+- Reader cascade extends naturally: when handler asks for `jury.panel_size` for a founder-targeted case, the reader tries `jury.panel_size.founder` first, then falls back to `jury.panel_size`.
+- No schema migration. No `status_tier` column. Composable with the existing `community:<id>` cascade.
+- v1 ships `liability.founder_multiplier` / `liability.regular_multiplier` (already in v0) as the proof-of-pattern; new status-conditional keys land additively.
+- v2+ migrates composable rules to OPA only if pattern (a) becomes unwieldy (>3 status-conditional variants per rule).
+
+**Rejected alternatives:** option (b) multiplier keys is too implicit for non-multiplicative rules; option (c) schema column is migration cost we don't need yet.
+
+**Reader cascade (per B2 2026-04-19):** for a status-conditional key like `jury.panel_size`, the reader attempts in order: `jury.panel_size.<status>.<severity>` → `jury.panel_size.<severity>` → `jury.panel_size` (the bare key) → Rust const fallback. Bare keys like `jury.panel_size = 7` remain valid as the v1 root default and preserve v0 read sites (e.g. `admin_assign_jury.rs:120`) unchanged during v1 rollout. See jury-mechanics-v1 §3.4 and §4.3 for the cascade helper and the 9-cell matrix.
+
+### 3.6 Rule-set versioning (OQ-002 resolution)
+
+Per OQ-002, community rule sets need versioning so a case decided under rule-set v3 survives a later v4 publish.
+
+**Schema (new v1 migration `add_rule_set_versions`):**
+
+```sql
+CREATE TABLE rule_set_version (
+  id           SERIAL PRIMARY KEY,
+  community_id INTEGER NOT NULL REFERENCES community(id) ON DELETE CASCADE,
+  version      INTEGER NOT NULL,                       -- monotonic per community
+  parent_id    INTEGER REFERENCES rule_set_version(id), -- previous version, NULL for v1
+  text_sha256  BYTEA NOT NULL,                          -- content hash
+  rule_text    TEXT NOT NULL,                           -- full plaintext (markdown)
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by   INTEGER REFERENCES person(id) ON DELETE RESTRICT,
+  UNIQUE (community_id, version)
+);
+
+-- Pin a case to the rule-set version active at decision time.
+ALTER TABLE moderation_case ADD COLUMN rule_set_version_id INTEGER REFERENCES rule_set_version(id);
+```
+
+- `rule_set.active_version_id` config key (per-community scope) points to the live version.
+- New version creation is **append-only** (no UPDATE on rule_set_version rows ever). The pattern matches `governance_config`'s append-history shape.
+- `submit_jury_vote` snapshots `case.rule_set_version_id = current_active_version` at decision time; the public modlog shows the rule text *as it was* when the case was decided.
+- Activating a new version is a config write (`POST /api/v4/governance/admin/config { key: "rule_set.active_version_id", scope: "community:42", value: 7 }`), which produces the standard governance_log audit entry.
+- v1.x: no in-band rule-text editor; ops upload the rule text via a separate `POST /admin/governance/rule-sets` endpoint (§4) that writes both the rule_set_version row AND the config-pointer flip in one transaction.
+
+---
+
+## 4. HTTP API Surface
+
+All routes mount under `/api/v4/governance/admin/` — already a registered scope (`crates/api/routes/src/lib.rs:531-536`). v1 adds five new routes alongside the v0 admin trio.
+
+### 4.1 Endpoint table
+
+| Method | Path | Purpose | Capability | Step-up (v2) |
+|---|---|---|---|---|
+| GET | `/api/v4/governance/admin/config` | Read full effective config + provenance | `instance_admin` (full) or `community_admin(id)` (community-scoped subset) | No |
+| GET | `/api/v4/governance/admin/config?key=<dotted_key>&community_id=<id>` | Read single key (resolved via cascade) | same as above | No |
+| POST | `/api/v4/governance/admin/config` | Single-key write (with `dry_run` + `apply_at` + `community_id`) | `instance_admin` for instance keys; `community_admin(community_id)` for community-scoped keys | Yes for `requires_step_up` keys |
+| GET | `/api/v4/governance/admin/config/audit` | Paginated config-change log (filters by key, scope, actor, date range) | `instance_admin` (instance audit) or `community_admin(id)` (community audit) | No |
+| GET | `/api/v4/governance/admin/rule-sets` | List rule-set versions for a community | `community_admin(id)` or `instance_admin` | No |
+| POST | `/api/v4/governance/admin/rule-sets` | Create new rule-set version (immutable; references parent) | `community_admin(id)` for that community | Yes |
+| GET | `/api/v4/governance/admin/dashboard` | Aggregate dashboard data (active cases, jury queue depth, federation status, recent config changes) | `instance_admin` | No |
+| GET | `/api/v4/governance/admin/audit/stream` | SSE stream of governance_log entries (live) | `instance_admin` | No |
+
+### 4.2 `POST /admin/config` request shape
+
+```jsonc
+{
+  "key": "jury.panel_size",          // dotted key from §3.1
+  "value_type": "int",                // matches §3.2 metadata
+  "value": 7,                         // typed by value_type (i64 | f64 | bool | string | enum-string)
+  "scope": "instance",                // "instance" | "community:<id>"
+  "apply_at": "next_jury_cycle",      // "immediate" (default) | "next_jury_cycle" | "next_snapshot_job"
+  "dry_run": false,                   // if true, no write happens; response includes preview
+  "reason": "Pilot retro: bumping to v1-target panel size"
+}
+```
+
+**Response (success):**
+
+```jsonc
+{
+  "applied": true,
+  "config_id": 12345,                 // governance_config.id of new row
+  "governance_log_id": 67890,         // governance_log.id of audit entry
+  "preview": {                        // populated even on success — the diff that was applied
+    "previous": { "value": 5, "effective_from": "instance" },
+    "new":      { "value": 7, "effective_from": "instance" },
+    "downstream_impact": {
+      "in_flight_cases_grandfathered": 3,    // cases with status ∈ {JurySelection, InReview} whose panel stays at 5
+      "users_losing_jury_eligible": null,    // null if not relevant; integer for threshold-related keys
+      "estimated_first_effect_at": "next jury seating after now()"
+    }
+  },
+  "applied_at": "2026-04-19T15:32:01Z"
+}
+```
+
+**Response (`dry_run = true`):** identical shape, `applied: false`, `config_id: null`, `governance_log_id: null`. The `preview.downstream_impact` block is computed by the same Rust function regardless of dry-run, so what you see is what you get.
+
+### 4.3 `dry_run` impact computation
+
+Per OQ-018's lean ("the whole point of config is that admins iterate on values, and dry-run lets them see downstream effects"). Computed for these key categories:
+
+| Key category | Computed impact |
+|---|---|
+| `thresholds.*` | `users_losing_jury_eligible`, `users_gaining_jury_eligible` (count diff against current `reputation_snapshot`) |
+| `jury.panel_size` | `in_flight_cases_grandfathered` (count of cases in `JurySelection|InReview`) |
+| `jury.max_concurrent_assignments` | `currently_at_or_above_new_cap` (count of users) |
+| `liability.sponsor_liability_floor` | `sponsors_at_floor_today` (count) |
+| `report.case_threshold_micros` | `cases_that_would_have_opened_in_last_30d` (using current report data, recomputed against new threshold) |
+| `decay.*` | (no impact preview — decay is gradual; just acknowledged) |
+| All others | `estimated_first_effect_at` description string |
+
+Impact computation is **a single read-only Diesel query per category**, run inside the same `run_transaction` as the write (with a `SAVEPOINT` rollback when `dry_run = true`).
+
+### 4.4 `apply_at` semantics
+
+| Value | Meaning | Used for |
+|---|---|---|
+| `immediate` (default) | New config row visible to next handler read; cached values invalidated within request | Most keys |
+| `next_jury_cycle` | Row inserted with `valid_from = now() + jury_cycle_window`; alternative: row inserted immediately but flagged so jury-selection logic skips it for 24h | Keys with `requires_re_jury = true` |
+| `next_snapshot_job` | Row inserted; `reputation_snapshot` job refreshes against new value at next scheduled run | Decay/threshold keys that require snapshot recomputation to take effect |
+
+**Implementation note:** `next_jury_cycle` is the simpler-than-it-sounds case. `governance_config_current` view already returns the most-recent row by `valid_from DESC`. We extend it to `WHERE valid_from <= now()`. A "scheduled" config edit becomes an INSERT with `valid_from = now() + duration`; the view auto-promotes it at the right time. No background job needed.
+
+### 4.5 Config audit endpoint shape
+
+`GET /admin/config/audit?key=<key>&scope=<scope>&actor=<pseudonym>&since=<iso8601>&page=1&limit=50`
+
+Response: paginated list of `governance_log` rows where `entry_kind = 'admin_config_changed'`, with payload destructured into `key`, `previous_value`, `new_value`, `actor_pseudonym`, `reason`, `dry_run` (if dry-run was logged as advisory — see §4.6), `created_at`. Source query is on the existing `governance_log` table, which already indexes on `entry_kind` (`migrations/2026-04-15-100500-0000_add_governance_log/up.sql:15`).
+
+### 4.6 Dry-run logging policy
+
+Open question §9 candidate, **PRD decision: dry-runs are NOT logged to `governance_log`**. Rationale: governance_log is for events that *changed state*; logging every dry-run preview pollutes the audit trail and burns hash-chain entries. If a v1.5 user wants "I want to know who keeps previewing this key", we add a separate `dry_run_preview_log` table. Documented as a non-decision-deferred-to-future.
+
+### 4.7 Routes wiring
+
+New file: `crates/api/api/src/governance/admin_config.rs` (handler module). Registered alongside existing `/admin` scope:
+
+```rust
+// crates/api/routes/src/lib.rs (additions)
+.service(
+  scope("/admin")
+    .route("/assign-jury", post().to(admin_assign_jury))
+    .route("/close-case", post().to(admin_close_case))
+    .route("/reputation-stats", get().to(admin_reputation_stats))
+    // v1 additions:
+    .service(
+      scope("/config")
+        .route("", get().to(admin_get_config))
+        .route("", post().to(admin_set_config))
+        .route("/audit", get().to(admin_get_config_audit)),
+    )
+    .service(
+      scope("/rule-sets")
+        .route("", get().to(admin_list_rule_sets))
+        .route("", post().to(admin_create_rule_set)),
+    )
+    .route("/dashboard", get().to(admin_dashboard))
+    .service(
+      scope("/audit")
+        .route("/stream", get().to(admin_audit_stream)),  // SSE endpoint per IMPLEMENTATION-PLAN-v0.md §6.1
+    ),
+),
+```
+
+---
+
+## 5. Default Values
+
+For every config key, this section proposes the v1 default and tags it (a) high-confidence, (b) needs-pilot-data, (c) decide-later.
+
+**Key:** **(a)** = ship as-is; **(b)** = ship default but flag for pilot-retro review; **(c)** = decide-later via decision-queue or new OQ.
+
+### 5.1 v0 keys — defaults already shipped (32 of 34 high-confidence)
+
+The v0 seed values from `migrations/2026-04-18-000000-0000_add_governance_config/up.sql` are reaffirmed for v1. Each line cites its design-doc source.
+
+| Key | Default | Tag | Rationale |
+|---|---|---|---|
+| `thresholds.jury_reliability` | 50 | (b) | [01 §5.4] capability gating; review after first community runs ≥10 juries |
+| `thresholds.reporting_accuracy` | 50 | (b) | Same as above |
+| `thresholds.endorsement_strength` | 25 | (b) | Same as above |
+| `jury.panel_size` | **5** v0 → **7** v1 | (a) | [01 §5.6] v1 target; ADR-007 simplification ends. Per B2 (2026-04-19): this remains a valid cascade-fallback key — reader precedence is `jury.panel_size.<status>.<severity>` → `jury.panel_size.<severity>` → `jury.panel_size` → Rust const. See jury-mechanics-v1 §3.4 for the dotted-namespace matrix. |
+| `jury.quorum` | **3** v0 → **4** v1 | (a) | Per [01 §5.6]: quorum scales with panel; majority of 7 = 4 |
+| `jury.age_requirement_days` | 60 | (a) | [01 §5.4] |
+| `jury.max_concurrent_assignments` | 3 | (a) | OQ-004 resolved |
+| `jury.fallback_on_small_pool` | true | (a) | Bootstrap-friendly; admin can flip false later |
+| `deltas.juror_aligned` | 10 | (b) | Pilot-data tuning |
+| `deltas.juror_outlier` | -5 | (b) | Pilot-data tuning |
+| `deltas.reporter_upheld` | 10 | (b) | Pilot-data tuning |
+| `deltas.reporter_dismissed` | -5 | (b) | Pilot-data tuning |
+| `deltas.endorsement_created_sponsor` | 5 | (a) | OQ-013 resolved |
+| `deltas.endorsement_created_sponsee` | 5 | (a) | OQ-013 resolved |
+| `deltas.sponsor_liability_minor` | -10 | (b) | [01 §5.2] -1% mapped to integer; pilot |
+| `deltas.sponsor_liability_moderate` | -50 | (b) | -5% mapped; pilot |
+| `deltas.sponsor_liability_severe` | -200 | (b) | -10–20% mapped; pilot |
+| `liability.founder_multiplier` | 2.0 | (a) | [01 §5.2 footnote] honour-price principle |
+| `liability.regular_multiplier` | 1.0 | (a) | Identity multiplier baseline |
+| `liability.sponsor_liability_floor` | 0 | (a) | OQ-024 resolved |
+| `report.base_weight` | 1.0 | (a) | OQ-006 resolved |
+| `report.clamp_min` | 0.1 | (a) | OQ-006 resolved |
+| `report.clamp_max` | 2.0 | (b) | OQ-006 ceiling flagged for pilot retro |
+| `report.recency_half_life_hours` | 168.0 | (a) | OQ-006 resolved (1 week) |
+| `report.case_threshold_micros` | 3_000_000 | (b) | OQ-006 resolved; pilot may tighten |
+| `decay.positive_half_life_days` | 90 | (a) | [01 §5.3] −10% per 90 days |
+| `onboarding.default_membership_state` | "member" | (a) | OQ-016 resolved |
+| `onboarding.sponsor_gate_strategy` | "age" | (a) | OQ-014 resolved |
+| `onboarding.sponsor_min_account_age_days` | 30 | (a) | OQ-014 resolved |
+| `founder.max_founders_active` | 20 | (b) | Pilot data driven |
+| `founder.max_expires_days` | 365 | (b) | Pilot data driven |
+| `founder.max_seed_delta` | 200 | (b) | Pilot data driven |
+| `job.snapshot_interval_seconds` | 900 | (a) | Operational; tune as load reveals |
+| `job.snapshot_batch_chunk_size` | 500 | (a) | Operational |
+
+### 5.2 v1 new keys — defaults
+
+| Key | Default | Tag | Rationale |
+|---|---|---|---|
+| `jury.severity_thresholds.minor` | "majority" (enum) | (a) | [01 §5.6] |
+| `jury.severity_thresholds.moderate` | "60%" | (a) | [01 §5.6] |
+| `jury.severity_thresholds.severe` | "75%" | (a) | [01 §5.6] |
+| `jury.diversity_constraints_enabled` | true | (b) | [01 §5.6]; pilot retro reviews enforcement vs. small-community feasibility |
+| `jury.appeal_panel_size_increase` | 2 | (a) | Appeal panel = 7 + 2 = 9 (per [01 §5.7] "larger jury") |
+| `jury.deadline_window_hours` | 72 | (b) | Resolves [04 §4.2] `deadline_at` Phase 2a stub; pilot tunes |
+| `liability.grace_window_minor_hours` | 24 | (a) | OQ-025 lean; sponsor-liability-v1 §4.2 owned |
+| `liability.grace_window_moderate_hours` | 72 | (a) | OQ-025 lean; sponsor-liability-v1 §4.2 owned |
+| `liability.grace_window_severe_hours` | 168 | (a) | OQ-025 lean; sponsor-liability-v1 §4.2 owned |
+| `liability.grace_window_minimum_hours` | 1 | (a) | sponsor-liability-v1 §4.2 instance-wide floor (community cannot go below) |
+| `liability.grace_window_maximum_hours` | 720 | (a) | sponsor-liability-v1 §4.2 instance-wide ceiling (30-day cap) |
+| `liability.grace_window_alert_threshold_hours` | 24 | (a) | sponsor-liability-v1 §4.2 audit alert when community sets any per-tier below this |
+| `liability.restoration_escapes_liability` | true | (a) | sponsor-liability-v1 §7.3 — restoration-completion default-escapes |
+| `liability.restoration_severity_reduction_steps` | 0 | (b) | sponsor-liability-v1 §7.3 — 0 = full escape; non-zero shifts severity tier N steps down |
+| `liability.multi_sponsor_escape_rule` | "any_revocation" (enum) | (b) | sponsor-liability-v1 §13.1 / OQ-V1-SL-01 — `any_revocation` \| `all_revocation` \| `majority_revocation` |
+| `liability.revoke_rate_limit_per_day` | 5 | (b) | sponsor-liability-v1 §12.1 per-user per-rolling-24h cap on revocations |
+| `decay.negative_half_life_days` | 180 | (a) | [01 §5.3] "negative slower" |
+| `decay.endorsement_strength_half_life_days` | 90 | (a) | Default per-dimension half-life inherits positive |
+| `decay.jury_reliability_half_life_days` | 90 | (a) | Same |
+| `onboarding.sponsor_min_endorsement_strength` | 25 | (b) | OQ-020 — read only when `sponsor_gate_strategy = 'reputation'` |
+| `onboarding.sponsor_allowlist_table_name` | "sponsor_allowlist" | (a) | OQ-020 explicit; v1 adds the table additively |
+| `onboarding.provisional_membership_cooldown_days` | 14 | (b) | OQ-016 v1 enforcement; pilot |
+| `founder.founder_seal_visible_in_profile` | true | (a) | OQ-017 lean; admin can flip false |
+| `participation.weekly_active_delta` | 1 | (b) | OQ-019 option (a) |
+| `participation.dormant_threshold_days` | 30 | (a) | OQ-019 |
+| `participation.dormant_delta` | -2 | (b) | OQ-019 |
+| `participation.attestation_enabled` | false | (c) | OQ-019 option (c) deferred to v2 unless pilot asks |
+| *(appeal.* namespace owned by jury-mechanics-v1 §10 per B1 resolution 2026-04-19)* | — | — | See v1-jury-mechanics.prd.md §10 for `appeal.window_days`, `appeal.panel_size_multiplier`, `appeal.panel_size_floor_increment`, `appeal.threshold_tier_bump`, `appeal.auto_select_on_appeal_acceptance`. Note: `appeal.original_jurors_excluded` is a hard code rule per [01 §5.7], not a config key. |
+| `federation.inbound_advisory_only` | true | (a) | ADR-006 — locked; admin can flip in v2 only |
+| `federation.peer_attestation_ttl_days` | 30 | (b) | Pilot |
+| `federation.signature_required` | true | (a) | Security baseline |
+| `federation.quarantine_recommendation_severity_floor` | "moderate" (enum) | (b) | Pilot |
+| `federation.outbound_publish_enabled` | true | (a) | Default-on; admin can disable for emergency |
+| `rule_set.active_version_id` | NULL → set per-community at first rule_set creation | (a) | NULL-safe; reader returns "no rule set defined" |
+| `rule_set.auto_carry_in_flight_cases` | true | (a) | Existing cases keep their snapshotted version; new cases use new |
+| `rule_set.text_max_bytes` | 65536 | (a) | 64 KiB Markdown ceiling |
+| `rule_set.version_propagation_delay_hours` | 24 | (b) | OQ-018 lean ("only instance-admin + 24h delay" — generalised to rule-set activation) |
+
+**Counts:** 34 v0 keys (32 (a)/(b), 2 (c) — none in v0), ~35 v1-new keys enumerated in this PRD (admin-dashboard-owned + sponsor-liability-owned rows), of which **1 is decide-later (c)**: `participation.attestation_enabled`. Federation peer-trust-state knobs live in `v1-federation-inbound.prd.md` §10 and are not enumerated here. The authoritative v1 cross-PRD total of ~138 keys across 15 namespaces is documented in §3.1; §5.2 lists only the admin-dashboard + sponsor-liability rows, with jury-mechanics-v1, reputation-tuning-v1 and federation-inbound-v1 rows in their own PRDs.
+
+### 5.3 Decide-later (c) defaults — escalation
+
+For each (c) key, open a new OQ in `99-decisions-and-open-questions.md`:
+
+| (c) Key | Proposed OQ | Reason |
+|---|---|---|
+| `participation.attestation_enabled` | OQ-V1-AD-04 — admin attestation table for participation | Needs UX design; pilot may not want it |
+
+*(Federation peer-trust-state knobs previously listed here are owned by `v1-federation-inbound.prd.md` §10 and its own OQ-FED-IN-\* register. N1 2026-04-19: removed phantom "4 reserved" entry that inflated the (c) count without corresponding table rows.)*
+
+---
+
+## 6. Pages (minimal server-rendered admin UI)
+
+Per CLAUDE.md "Frontend UI — v0 is backend + API only" and §1.1 G6, v1 ships **server-rendered HTML pages from Rust** — askama or maud (recommend askama: more mature, works with actix-web's `Responder` via the askama-actix-web crate).
+
+| Page | URL | Purpose |
+|---|---|---|
+| Dashboard | `GET /admin/governance/dashboard` | Active cases, jury queue depth, recent config changes, federation status |
+| Config editor | `GET /admin/governance/config` | Schema-driven form (one row per key in `CONFIG_KEY_METADATA`); JSON or HTML mode |
+| Single-key editor | `GET /admin/governance/config/<key>?scope=<scope>` | Detail view: current value, history, preview button |
+| Audit log | `GET /admin/governance/audit` | Searchable log; same data as `/api/v4/governance/admin/config/audit` |
+| Rule-set manager | `GET /admin/governance/rule-sets/<community_id>` | List versions, view diffs, upload new |
+
+### 6.1 Page implementation notes
+
+- Templates in `crates/api/api/templates/governance/*.html.askama`
+- Auth: re-use Lemmy's existing `LocalUserView` extractor; `is_admin()` for instance pages, `CommunityModeratorView::check_is_community_moderator` for community pages
+- No JS frameworks; vanilla HTML + minimal `<script>` for the dry-run preview button (POST to API, render diff inline)
+- Pages are **opt-in** — instance can disable HTML pages and run API-only via `governance.dashboard.html_pages_enabled = true|false` (new key, default `true`)
+
+### 6.2 Dashboard widget data sources
+
+| Widget | Source query | Refresh |
+|---|---|---|
+| Active cases | `SELECT COUNT(*) ... WHERE status NOT IN (Closed)` on `moderation_case` | Per page-load |
+| Jury queue depth | `SELECT COUNT(*) ... WHERE status IN (Selected, Accepted)` on `jury_assignment` | Per page-load |
+| Recent config changes | Last 20 from `/admin/config/audit` | Per page-load + SSE push from `/admin/audit/stream` |
+| Federation status | Per-peer attestation count from `federation_attestation` (Phase 6 table) | Per page-load |
+| Reputation health | Re-uses `admin_reputation_stats` handler output (Phase 5c task 62) | Per page-load |
+
+---
+
+## 7. Security
+
+### 7.1 Capability checks
+
+| Endpoint | Required capability |
+|---|---|
+| `POST /admin/config` with `scope = "instance"` | `is_admin(local_user_view)` |
+| `POST /admin/config` with `scope = "community:<id>"` | `CommunityModeratorView::check_is_community_moderator(pool, community_id, person_id)` AND key.scope ∈ {Community, Both} |
+| `POST /admin/config` with `requires_step_up = true` | (v1) instance_admin only; (v2) instance_admin + step-up token |
+| `POST /admin/rule-sets` | `community_admin(community_id)` for `scope = community`; `is_admin` for instance-level rule sets |
+| `GET /admin/dashboard` | `is_admin(local_user_view)` |
+| `GET /admin/audit/stream` | `is_admin(local_user_view)` |
+
+**Negative test invariant:** any `POST /admin/config` where (a) `scope = "instance"` but caller is not `is_admin`, OR (b) `scope = "community:<id>"` but caller is not a moderator of `<id>`, OR (c) key.scope is `Instance` but the request scope is `Community`, MUST return `403` and emit a `governance_log` entry of `entry_kind = "admin_config_change_denied"` with the attempt details.
+
+### 7.2 Step-up auth (v2 reserved slot)
+
+This PRD does not implement step-up auth (v2 milestone per ADR-010 and `06 §2.1`). It reserves the surface:
+
+- `requires_step_up: bool` field in `ConfigKeyMetadata` (§3.2)
+- `requires_step_up = true` for: `jury.panel_size`, `jury.quorum`, `jury.severity_thresholds.*`, `liability.*`, `rule_set.active_version_id`, `federation.inbound_advisory_only` (the keys that match `06 §2.1` step-up list: closing a case, changing quorum/voting thresholds, federation trust state change, rule-set edit)
+- v1 handler returns 403 with body `{ "error": "step_up_required", "message": "v2: step-up auth not yet implemented; attempt logged" }` only if a future config flag `governance.dashboard.step_up_enforced = true` is set. v1 default is `false` (advisory: log the attempt but allow).
+
+### 7.3 Rate limiting
+
+- Admin endpoints inherit the existing `/governance` scope's `rate_limit.post()` middleware (`crates/api/routes/src/lib.rs:516`)
+- `dry_run = true` requests are NOT rate-limited differently from real writes — the impact computation is the expensive part, and we want to discourage bulk previewing
+- SSE stream `/admin/audit/stream` has its own throttle: max 1 connection per admin user
+
+### 7.4 Governance log entry on every config write
+
+Every successful `POST /admin/config` (with `dry_run = false`) inserts a `governance_log` entry of `entry_kind = "admin_config_changed"` via the existing signed/hash-chained `governance_log::append` helper (`crates/api/api/src/governance/governance_log.rs:87`). Payload schema:
+
+```jsonc
+{
+  "scope": "instance",
+  "key": "jury.panel_size",
+  "value_type": "int",
+  "previous_value": 5,
+  "new_value": 7,
+  "apply_at": "next_jury_cycle",
+  "reason": "Pilot retro: bumping to v1-target panel size",
+  "config_id": 12345,
+  "downstream_impact": { /* same shape as §4.2 preview */ }
+}
+```
+
+This matches the existing `admin-config-write.sh` script's transactional pattern (`scripts/brehon/admin-config-write.sh:140-160`) and reuses the same `entry_kind` string for backwards-compat with v0 audit consumers.
+
+### 7.5 Rule-set version-change delay
+
+Per OQ-018 lean ("only instance-admin + 24h delay" for rule-set version changes):
+
+- `rule_set.active_version_id` defaults to `apply_at = "next_jury_cycle"` in metadata
+- Additionally, the handler enforces a minimum 24h delay configured via `rule_set.version_propagation_delay_hours` (default 24)
+- `dry_run` shows the activation timestamp prominently
+
+### 7.6 Authorization invariants
+
+- A community admin cannot edit instance keys (enforced server-side via `key.scope` check)
+- A community admin can edit community-scoped overrides for keys with `scope ∈ { Community, Both }` only for their own community
+- Instance admin can edit anything; community-scoped writes by instance admin are allowed (operator override)
+- All denied attempts are logged to governance_log with `entry_kind = "admin_config_change_denied"` (new entry_kind)
+
+---
+
+## 8. Migration & Rollout Strategy
+
+### 8.1 Storage layer
+
+`governance_config` is already shipped in v0 (Phase 5a task 50, migration `2026-04-18-000000-0000_add_governance_config`). The append-history shape supports v1 unchanged — no schema migration needed for the table itself.
+
+### 8.2 New v1 migrations
+
+| Migration | Tables/columns | When |
+|---|---|---|
+| `add_rule_set_versions` | `rule_set_version` table; `moderation_case.rule_set_version_id` column | First v1 milestone |
+| `add_sponsor_allowlist` | `sponsor_allowlist` table (per OQ-020 `'allowlist'` strategy) | v1.x once strategy is needed |
+| `add_case_applied_config_snapshot` | `moderation_case.applied_config_snapshot` JSONB column | First v1 milestone (supports `requires_re_jury` grandfathering) |
+| `seed_v1_config_keys` | INSERT 28 new v1 keys into `governance_config` | First v1 milestone |
+
+All four migrations are idempotent; each `up.sql` uses `ON CONFLICT DO NOTHING` for INSERTs and `IF NOT EXISTS` for CREATE statements (matching the v0 patterns).
+
+### 8.3 Initial seed (28 new keys)
+
+Single `INSERT … ON CONFLICT (scope, key, valid_from) DO NOTHING` per the v0 pattern (`migrations/2026-04-18-000000-0000_add_governance_config/up.sql:78`). Defaults from §5.2.
+
+### 8.4 Deprecation path for `admin-config-write.sh` — gated on OQ-018
+
+**Per NOT5 2026-04-19, script deprecation is GATED on the OQ-018 HTTP config-write endpoint actually shipping**, not on a v1.1 milestone alone. Sponsor-liability-v1 introduces 10+ new keys that currently must be set via `admin-config-write.sh` until OQ-018's endpoint lands. Deprecating the script on a v1.1 date-milestone without confirming OQ-018 has shipped would strand pilot operators.
+
+- **v1.0** ships HTTP API (`POST /api/v4/governance/admin/config`) + `admin-config-write.sh` side-by-side. README marks the script deprecated in favour of the HTTP API; the script gains a `--legacy-mode-confirm` flag to require explicit opt-in.
+- **Deprecation condition (NOT a date — a capability test):** script retirement is gated on all three of the following being true simultaneously:
+  1. OQ-018 `POST /api/v4/governance/admin/config` endpoint is live on a shipped release (not just merged to `main`).
+  2. Pilot operator confirms the HTTP API covers every key class the script writes (strings, ints, floats, bools, enums, text blobs).
+  3. `governance_log` entries written by both paths are byte-identical (verified via round-trip test: write via HTTP, write via script, diff the two log rows — signatures will differ but payload + `entry_kind` must match).
+- **v1.1 is the target but contingent.** If OQ-018's endpoint ships in v1.0 and conditions 2+3 are met by v1.0 pilot review, v1.1 removes the script. If OQ-018 slips to v1.1 or v1.2, script removal slips with it. The script is harmless to keep shipping; the ops cost is one deprecation warning banner on startup, not runtime load.
+- **governance_log audit-trail continuity.** Both code paths emit `governance_config_changed` entries via the same `governance_log::append` function, so there is no audit-trail discontinuity whether operators use the script or the HTTP API during the side-by-side window.
+
+### 8.5 Backwards compatibility
+
+- Hardcoded `DEFAULT_*` consts in `crates/api/api/src/governance/config.rs` remain as the **third-tier fallback** if a `governance_config` row is missing — already documented and tested (`every_seeded_key_has_const_fallback`)
+- v1 adds new `DEFAULT_*` consts for the 28 new keys; the parity test is updated to expect 62 not 34
+- v0 callers reading config via `get_int`/`get_float`/`get_bool`/`get_text` keep working unchanged
+- v0's `admin_assign_jury` already reads `jury.panel_size` and `jury.fallback_on_small_pool` from config — no code change for the panel-size bump from 5 to 7 beyond the seed value
+
+### 8.6 Rollout sequencing
+
+1. Land migration `add_rule_set_versions` + `add_case_applied_config_snapshot` + `seed_v1_config_keys` (one PR)
+2. Land HTTP API endpoints (`admin_config.rs`, `admin_rule_sets.rs`, `admin_dashboard.rs`, `admin_audit_stream.rs`) — one PR per endpoint module to keep diffs reviewable
+3. Land server-rendered HTML pages (askama templates) — one PR
+4. Update `INSTALL.md` (v1 self-host packaging deliverable per `05 §7.1`) to reference the dashboard
+5. Pilot operator confirms HTTP API works (all three §8.4 deprecation-condition gates satisfied); `admin-config-write.sh` flagged deprecated
+6. v1.x retires the script — contingent on OQ-018 endpoint having actually shipped, not a date milestone (per NOT5 2026-04-19)
+
+---
+
+## 9. Open Questions for v1 Design Phase
+
+| ID | Question | Lean | Owner |
+|---|---|---|---|
+| OQ-V1-AD-01 (new) | Bulk config import/export format (JSON Lines for diff-friendly Git? YAML for human-readable? Postgres dump?) | JSON Lines, one row per `governance_config` row, with provenance comment per stanza | TBD |
+| OQ-V1-AD-02 (new) | Multi-tenant case: does one Brehon instance host multiple distinct community federations? | Defer to v2; v1 assumes single-tenant per instance per ADR-001 | TBD |
+| OQ-V1-AD-03 (new) | Dashboard for federation peer trust state — separate v1 PRD (`v1-federation-inbound.prd.md`) or merged here? | Separate PRD; this PRD's `federation.*` namespace covers the *config*, the federation PRD covers the operator UX for peer add/remove/quarantine | TBD |
+| OQ-V1-AD-04 (new) | Admin attestation for participation_consistency (OQ-019 option (c)) — UX shape? | Defer; ship config flag (`participation.attestation_enabled = false`) and revisit at pilot retro | TBD |
+| OQ-V1-AD-05 (new) | Should `dry_run` previews be logged to a separate `dry_run_preview_log` table for forensic value? | No, defer; if pilot wants it, add then | TBD |
+
+---
+
+## 10. Cross-References
+
+### 10.1 v1 PRDs that consume this dashboard
+
+| PRD | What it consumes |
+|---|---|
+| `v1-jury-mechanics.prd.md` (sibling) | All `jury.*` keys including new `jury.severity_thresholds.*`, `jury.diversity_constraints_enabled`, `jury.appeal_panel_size_increase`, `jury.deadline_window_hours` |
+| `v1-reputation-tuning.prd.md` (sibling) | `decay.*`, `deltas.*`, `participation.*` namespaces; reuses `admin_reputation_stats` panel |
+| `v1-sponsor-liability.prd.md` (sibling) | `liability.grace_window_*` keys (OQ-025); uses dashboard's `dry_run` to preview sponsor liability changes |
+| `v1-federation-inbound.prd.md` (sibling) | `federation.*` namespace; this PRD's dashboard surfaces *what* — federation PRD surfaces *how* peers are added and managed. **Depends on Phase 6 merge** — see `v1-federation-inbound.prd.md` §8.0 for hard-gate conditions (per B5 resolution 2026-04-19). |
+| `v1-rule-set-versioning.prd.md` (sibling, optional) | Rule-set creation flow; this PRD owns the API, the rule-set PRD owns the editor UX (could be merged into this PRD if a single owner ships both) |
+
+### 10.2 v1 carry-forward issues this PRD resolves or shapes
+
+| Issue | Status |
+|---|---|
+| #16 OQ-018 admin config-write HTTP endpoint | **This PRD is the design.** |
+| #15 formalise appeal window with bounded duration | **Resolved** by `appeal.window_days = 7` (owned by jury-mechanics-v1 §6.5 + §10 per B1 2026-04-19; this PRD surfaces the knob via the config-write API but not the default) |
+| #13 per-community permission filter on `list_cases` | Out of scope (separate PRD), but the `community_admin(id)` capability check pattern this PRD establishes is reused |
+| #12 add `assignee` filter to `list_cases` DTO | Orthogonal |
+| #14 re-jury path for Appealed cases | Out of scope (jury-mechanics PRD); affected by `jury.appeal_panel_size_increase` from this PRD |
+| #11 original-reporter appeals | Orthogonal |
+| #19 community-scope `count_active_sanctions` | Orthogonal but depends on per-community config awareness this PRD codifies |
+| #20 `staleness_check` overflow | Orthogonal |
+| #22 `list_capability_changed_entries_since` limit clamp | Orthogonal |
+| #29 config-flip assertion determinism | Test-only; this PRD's `apply_at = next_jury_cycle` semantics may simplify this test |
+
+### 10.3 Design-doc anchors
+
+- [99 OQ-018](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — primary
+- [99 OQ-002, OQ-005, OQ-019, OQ-020, OQ-025, OQ-026](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)
+- [99 ADR-010 staged releases](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md), [ADR-013 EmergencyRemove](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md), [ADR-015 pseudonyms](../../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)
+- [01 §3 Core principle](../../../docs/brehon-law-inspired-network/01-vision-and-principles.md), [§5 Baseline policy parameters](../../../docs/brehon-law-inspired-network/01-vision-and-principles.md)
+- [04 §3 governance_config / governance_log models](../../../docs/brehon-law-inspired-network/04-data-model-and-api.md), [§7 Routes](../../../docs/brehon-law-inspired-network/04-data-model-and-api.md)
+- [05 §7.1 v1 deliverables](../../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md)
+- [06 §2.1 step-up auth](../../../docs/brehon-law-inspired-network/06-security-and-threat-model.md), [§2.2 governance plane separation](../../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)
+- [V2/messaging.md §3.3 admin config panel pattern](../../../docs/brehon-law-inspired-network/V2/messaging.md) — informs the per-community-with-instance-default schema sketch this PRD adopts
+
+### 10.4 Code anchors (v0 surfaces this PRD extends)
+
+- `crates/api/api/src/governance/config.rs` — v0 reader, `Scope` enum, `ConfigCache`, `SEEDED_KEYS_WITH_CONSTS`, parity tests
+- `crates/db_schema/src/source/governance/governance_config.rs` — Diesel model + `GovernanceConfigInsertForm`
+- `crates/db_schema/src/source/governance/governance_log.rs` — append-only log model
+- `crates/api/api/src/governance/governance_log.rs` — `append()` helper + entry_kind consts
+- `crates/api/api/src/governance/admin_close_case.rs`, `admin_assign_jury.rs`, `admin_reputation_stats.rs` — v0 admin handler patterns to follow
+- `migrations/2026-04-18-000000-0000_add_governance_config/up.sql` — v0 schema + 34-key seed
+- `migrations/2026-04-20-000000-0000_add_governance_log_notify/up.sql` — `pg_notify('governance_events', …)` trigger that powers the SSE audit stream
+- `scripts/brehon/admin-config-write.sh` — operator-tooling pattern this PRD replaces
+
+---
+
+## 11. Resolutions applied (2026-04-19)
+
+v1-planning-session cross-PRD coherence audit applied the following resolutions. Traceable via `.claude/PRPs/v1-planning-queue.json`.
+
+| ID | Resolution | Effect in this PRD |
+|---|---|---|
+| **B1** | jury-mechanics owns `appeal.*` namespace fully | §5.2: 3 `appeal.*` rows deleted + cross-ref line to jury-mechanics-v1 §10. §3.1 `appeal.*` row updated (5 v1 additions, jury-mechanics-owned). §10.2 issue #15 row notes resolution ownership shift to jury-mechanics. |
+| **B2** | Dotted `jury.panel_size.<status>.<severity>` matrix WITH single-key fallback per OQ-026 cascade | §5.1 `jury.panel_size = 7` row kept as v1 root default with cascade-precedence note. §3.5 cascade sentence added (cascade order + v0 compatibility). jury-mechanics-v1 §3.4 owns the 9-cell matrix + cascade helper directive. |
+| **B3** | Collapse `cron.*` → `job.*`/`participation.*`/`deltas.*`; keep `bounds.*` + `feature.*` as new 1st-class namespaces | **Done.** §3.1 prose rewritten to 138-key / 15-namespace authoritative registry with per-PRD contribution sub-table; new rows for `bounds.*` (8 keys, reputation-tuning), `feature.*` (1 key, reputation-tuning); `participation.*` / `deltas.*` / `job.*` / `onboarding.*` rows extended to reflect reputation-tuning renames. Namespace-collapse rationale footnote added. |
+| **B4** | Sponsor-liability `sponsor.*` → flat `liability.*` | **Done.** §3.1 `liability.*` row updated to +10; §5.2 gained 7 new sponsor-liability-owned rows (grace_window minimum/maximum/alert_threshold, restoration_escapes_liability, restoration_severity_reduction_steps, multi_sponsor_escape_rule, revoke_rate_limit_per_day). Cross-reference line added to each new row citing sponsor-liability-v1 sections. |
+| **B5** | federation-inbound hard-gated on Phase 6 merge | **Done.** §10.1 federation-inbound consumer row gains inline "**Depends on Phase 6 merge** — see `v1-federation-inbound.prd.md` §8.0 for hard-gate conditions" sentence. Full §8.0 preconditions list owned by federation-inbound-v1 (its §16 Resolutions documents the new §8.0 / §8.2 preamble / §15.2 prescriptive rewrite). |
+| **N1** (collateral of B4) | Drop phantom 4 reserved federation-peer keys from §5.2 (c)-count | **Done.** §5.2 count line rewritten to drop phantom 4 (now reports 1 decide-later: `participation.attestation_enabled`). §5.3 escalation table dropped the `(4 reserved federation-peer keys)` row with a footnote pointing federation-peer knobs to `v1-federation-inbound.prd.md` §10. |
+| **NOT1** | OQ prefixed-namespace convention (collision resolution) | **Done.** admin-dashboard's five `OQ-027..031` renumbered to `OQ-V1-AD-01..05` via mechanical replace-all across §5.3 table, §9 Open Questions table, §11 Sources list, and the (c)-key escalation footer. No substantive text changed; only the identifier prefix shifts to match reputation-tuning / sponsor-liability / federation-inbound's pre-existing `OQ-V1-*` convention. Jury-mechanics OQ-027..032 renamed separately to OQ-V1-JM-01..06 (see `v1-jury-mechanics.prd.md` §15 Resolutions). |
+| **NOT4** | §3.2 `CONFIG_KEY_METADATA` storage: commit to compile-time | **Done.** §3.2 convention paragraph followed by a new explicit storage-commitment paragraph: `CONFIG_KEY_METADATA` is a `&'static [ConfigKeyMetadata]` compile-time array (NOT a runtime DB table). Every new key requires a PR-against-Rust-code edit. Matches the Watch-1 parity contract with `SEEDED_KEYS_WITH_CONSTS` (also compile-time). §6.1 reference already reads "one row per key in `CONFIG_KEY_METADATA`" which is consistent with the compile-time commitment. |
+| **NOT5** | §8.4 `admin-config-write.sh` deprecation gated on OQ-018 | **Done.** §8.4 rewritten: deprecation is gated on three conditions simultaneously (OQ-018 endpoint shipped, pilot operator confirms all key classes covered, `governance_log` entries byte-identical), not on a v1.1 date milestone. v1.1 is the target but contingent on OQ-018 actually shipping. §8.6 rollout sequencing bullet updated to reflect the capability-gate semantics. |

--- a/.claude/PRPs/prds/v1-federation-inbound.prd.md
+++ b/.claude/PRPs/prds/v1-federation-inbound.prd.md
@@ -1,0 +1,966 @@
+# V1 — Federation Inbound Advisory
+
+**Status:** Sub-PRD (v1 scope, post-v0 / post-Phase 6). Not a v0 deviation.
+**Scheduling:** **Hard-gated on Phase 6 PR merge to `governance-v0`**; no implementation before gate satisfied (see §8.0). Plan-level review (this PRD) can proceed in parallel with Phase 6 implementation. Per B5 resolution 2026-04-19.
+**Scope boundary:** This PRD adds **inbound HTTP federation processing** for governance signals on top of Phase 6's outbound + direct-call inbound foundation. **Auto-apply remains forbidden per ADR-006** — every inbound signal lands as advisory, surfaced in admin review, cross-link/dismiss only on explicit admin action.
+**Date:** 2026-04-19
+**Predecessor:** Phase 6 (`brehon-fork-advisor-phase6/.claude/PRPs/plans/phase-6-federation.plan.md`) — outbound publish + AP types + direct-call receive functions for the round-trip test only. v1 inbound takes Phase 6's `receive_remote_*` functions and wires them into the live HTTP inbox dispatcher with peer-trust gating, rate limits, abuse defences, and an admin review surface.
+**Naming note:** This is **v1-federation-inbound**, distinct from any "Phase 6.x" or "Phase 7" naming. Per ADR-010, v1 is the "production-grade governance" milestone; full inbound processing is v1 scope per [05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md). v3 unlocks **acting on** inbound signals (per [05 §7.3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md): "Full federation inbound processing (beyond stored-advisory)") — v1 only **stores and surfaces** them.
+
+---
+
+## 1. Vision and goals
+
+The Brehon principle this PRD encodes: **an external honour judgment is data, not a command.** A peer's sanction notice describes what their jury decided about an actor; it does not bind our jury, our admins, or our local truth. ADR-006 formalises this — "a federated instance getting compromised must not cascade its compromise through our moderation." v1 inbound carries this principle into live HTTP processing: every signed activity that reaches our inbox is verified, validated, persisted, surfaced, and **stops there** until a local admin decides it's worth citing or dismissing.
+
+The user framing for v1 is: *"The admin dashboard will allow community groups to experiment with how they configure a lot of these settings, although defaults might have to be decided on."* That reframes inbound federation policy from a hard-coded global default into a **dashboard-configurable surface**. Which peers are trusted, which signals are surfaced, which ones drop silently — all become knobs the dashboard exposes. v1 ships a sane default policy and the surface to change it.
+
+### 1.1 Maturity ladder
+
+| Stage | What ships | Reach | Decision authority |
+|---|---|---|---|
+| **v0 (Phase 6 in flight)** | Outbound publish; inbound exists only as a direct test-call into `PublishSanctionNotice::receive` from `tests/e2e.rs` | Local-only; no live HTTP path | Phase 6 plan §11 explicitly defers HTTP routing |
+| **v1 (this PRD)** | Inbound HTTP path live; signals stored advisory; surfaced in admin dashboard for review; peer-trust state model; rate limiting; abuse defences | Live federation receive | Local admin (cross-link / dismiss); local jury (cite as evidence) |
+| **v2 (security hardening per ADR-010)** | SSRF-isolated federation fetch worker; OPA policy engine wires federation policy decisions; signed log outside runtime | Same shape, harder boundary | Same — local admin / jury |
+| **v3 (per [05 §7.3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md))** | Policy-driven auto-apply (still subject to community-defined acceptance rules; never silent) | Live federation receive + policy-driven action | Policy + admin (still no silent action) |
+
+v1's job is to make inbound federation operationally usable — admins can see what's coming in, can curate which peers we listen to, can cite remote evidence in local cases — without ever giving up local sovereignty. v3's job is to add a policy layer; v1 deliberately does not pre-empt it.
+
+### 1.2 Goals
+
+- **G1.** Live HTTP inbox handlers for the three governance AP types Phase 6 defines (`SanctionNoticeObject`, `TrustAttestationObject`, `ModerationLabelObject`).
+- **G2.** Per-peer trust state model (`Unknown`/`Allowlisted`/`Blocklisted`/`Untrusted-Receive`) with admin-dashboard configurability.
+- **G3.** Admin review surface — paginated list, filters, cross-link to local case, dismiss-as-reviewed.
+- **G4.** Per-peer and per-actor rate limits with dashboard-tunable defaults.
+- **G5.** Storage caps + drop-log so a hostile peer cannot fill our DB with advisory rows.
+- **G6.** Replay-protection (nonce table + configurable window).
+- **G7.** Every inbound — accepted, dropped, blocked — emits a governance_log entry for audit.
+
+### 1.3 Non-goals
+
+- **NG1.** Auto-apply — explicitly v3 (§13 OQ-FED-IN-1).
+- **NG2.** Cross-instance reputation portability — v2/v3.
+- **NG3.** Cross-instance jury (a juror on instance A serving on a case from instance B) — v3.
+- **NG4.** Per-community-per-peer trust (peer X trusted for community A but not B) — v2.
+- **NG5.** Federation discovery beyond what Lemmy already provides — v2.
+- **NG6.** SSRF-isolated media fetch worker — v2 per ADR-010.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (v1)
+
+| Area | What v1 ships |
+|---|---|
+| HTTP inbox routing | Governance type variants registered in Lemmy's existing `SharedInboxActivities` dispatcher (Phase 6 already does this); v1 wires the dispatcher's `receive` calls through trust-check + rate-limit + persist + log |
+| Signature verification | Delegated to `activitypub_federation`'s existing HTTP-signature check (Lemmy code, trusted as-is per ADR-012); v1 adds **schema validation + size limits** on the activity payload after signature passes |
+| Peer-trust state | New `federation_peer` table; four trust states (`Unknown` / `Allowlisted` / `Blocklisted` / `Untrusted-Receive`); admin-dashboard CRUD via the v1 admin config endpoint surface (OQ-018) |
+| Inbound classify-and-route | Each AP type → its `receive_remote_*` handler (Phase 6 ships these as direct functions; v1 plumbs them behind the inbox dispatcher) |
+| Storage isolation | All inbound rows carry `local_case_id = NULL` per ADR-006; new columns capture peer trust at receipt, admin review state |
+| Admin review surface | 3 new REST endpoints — list, cross-link, dismiss — under `/api/v4/governance/admin/federation/*` |
+| Rate limiting | Per-peer (default 100/h) and per-actor-across-peers (default 10/h on attestations); dashboard-tunable |
+| Abuse defences | Storage cap with oldest-drop policy; replay nonce table; malformed-payload reject at boundary |
+| Audit | New `federation_inbox_dropped_log` table + governance_log entries for accept/drop/block events |
+
+### 2.2 Out of scope (deferred)
+
+| Area | Deferred to | Why |
+|---|---|---|
+| Auto-apply of received sanctions | v3 | ADR-006; user-confirmed framing 2026-04-19 |
+| Reputation portability across instances | v2/v3 | New attestation type + cross-instance pseudonym mapping; out of v1's "store + surface" scope |
+| Cross-instance jury participation | v3 | Requires identity bridging beyond `actor_pseudonym` |
+| Per-community-per-peer trust | v2 | Schema cost (composite key) + dashboard UX cost; v1 keeps it per-instance |
+| OPA-driven federation policy | v2 (per [05 §7.2](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md)) | OPA replaces hardcoded checks instance-wide; federation joins that migration |
+| SSRF-isolated fetch worker | v2 (per [06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)) | Separate process is its own work-stream |
+| Federation discovery | v2 | Lemmy's existing instance discovery covers content; governance discovery layered on top |
+| Vanilla Lemmy `Announce`-wrapped governance gateway | v2/v3 | Vanilla peers will never send these types per ADR-014; degraded-mode is a separate design |
+
+---
+
+## 3. AP types accepted on the inbox
+
+### 3.1 What Phase 6 ships (verify before v1 implementation)
+
+Per the Phase 6 plan §"Files to Change" and tasks 72/73, Phase 6 ships:
+
+| Type | Phase 6 outbound | Phase 6 receive function | Phase 6 inbox wiring |
+|---|---|---|---|
+| `SanctionNoticeObject` (wrapped in `PublishSanctionNotice` Create activity) | YES (`send_local_sanction_notice` task 74) | YES (`receive_remote_sanction_notice` task 75) called from `Activity::receive` impl | Registered in `SharedInboxActivities` enum (task 73) — **so HTTP inbox already dispatches to it once Phase 6 lands** |
+| `TrustAttestationObject` (wrapped in `PublishTrustAttestation`) | YES (`send_local_trust_attestation` task 74; not wired to any v0 endpoint) | YES (`receive_remote_trust_attestation` task 75) | Registered in `SharedInboxActivities` |
+| `ModerationLabelObject` (wrapped in `PublishLabel`) | Stub in v0 (no outbound caller); type defined per task 73 | **Stub `receive` returning `Ok(())`** per Phase 6 task 75 GOTCHA | Registered in `SharedInboxActivities`; receive is a no-op |
+
+**v1 alignment note (§15):** Phase 6's plan §11 "NOT Building" item #4 says "Federation rate-limiting per source" is v1 — confirming v1 owns the rate-limit work. Item #6 says "HTTP route for admin review of `remote_sanction_notice`" is v1 — confirming v1 owns the admin endpoints. **Phase 6 already wires HTTP dispatch via `SharedInboxActivities`**; v1 does *not* re-route — v1 wraps the existing `receive` calls in trust-check + rate-limit + log + admin-review surface.
+
+### 3.2 What v1 changes per type
+
+**SanctionNotice (live HTTP path, v1):**
+1. Lemmy's `shared_inbox` (`crates/apub/apub/src/http/mod.rs:44-60`) receives the POST.
+2. `receive_activity_with_hook::<SharedInboxActivities, …>` runs HTTP-signature verification (Lemmy's existing path, no v1 change).
+3. Dummy hook fires (`ReceivedActivity::create` already dedupes by `activity.id()` — Phase 6 task 75 GOTCHA confirmed).
+4. Activity is dispatched by serde-untagged match to `PublishSanctionNotice::receive`.
+5. **NEW v1 wrapper inside `receive`:**
+   - Call `federation_inbox_check_peer_trust(activity.actor.domain(), &mut conn)` → returns trust state (or `Unknown` for first-seen).
+   - If `Blocklisted`: write `federation_inbox_dropped_log` row + governance_log `federation_inbound_blocked`; return `LemmyResult::Err` so the inbox returns 403.
+   - Call `federation_inbox_check_rate_limit(peer, "sanction_notice", &context)` → 429 on exceeded.
+   - Call `federation_inbox_check_replay(activity.id(), &mut conn)` → 409 on duplicate within nonce window.
+   - Call Phase 6's `receive_remote_sanction_notice` (unchanged from Phase 6).
+   - The handler now writes `peer_trust_level_at_receipt` into the new column on `remote_sanction_notice` (v1 column addition).
+   - governance_log: `federation_sanction_received` (Phase 6 already writes this).
+6. Return 202 Accepted (advisory store, no immediate action promised).
+
+**TrustAttestation (live HTTP path, v1):** identical wrapping; per-actor rate limit (default 10/h) applies *in addition to* per-peer rate limit because attestation spam from many peers about a single target is the abuse vector ([06 §4.7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)).
+
+**ModerationLabel (NEW handler in v1):** Phase 6 ships `PublishLabel::receive` as a stub (`Ok(())`). v1 fills it with a `receive_remote_moderation_label` function mirroring `receive_remote_sanction_notice`'s shape, writing into a v1-new advisory table (see §8). `local_case_id = NULL`. governance_log: `federation_label_received` (new entry kind; const string in `governance_log.rs`).
+
+### 3.3 Per-handler invariants
+
+For all three handlers v1 enforces:
+
+- **No call into local sanction/removal code paths.** ADR-006. Verified by lint pattern in §12 ("no auto-apply guard").
+- **`local_case_id = NULL` at insert.** Cross-link is admin-driven (§6).
+- **Schema validation rejects unknown enum variants.** `SanctionAction`, `SanctionScope`, `AttestationType` use `diesel-derive-enum`; deserialisation fails closed if a peer sends a variant we don't recognise. Returns 400.
+- **Size limit on payload.** Enforce `serde_json::Value` size cap (default 64 KiB for sanction notices, 8 KiB for attestations) before persist. Reject 413.
+- **Pseudonym = None on log entry.** Phase 6 task 75 confirms: actor is remote, no local pseudonym exists, so `actor_pseudonym = None` in `governance_log::append`. v1 keeps this.
+
+---
+
+## 4. Peer trust state model
+
+### 4.1 Schema
+
+New table `federation_peer` (migration in §8):
+
+```sql
+CREATE TABLE federation_peer (
+  instance_id     INT PRIMARY KEY REFERENCES instance(id) ON DELETE CASCADE,
+  trust_level     federation_peer_trust_enum NOT NULL DEFAULT 'unknown',
+  added_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  added_by_actor  TEXT,                                    -- pseudonym of admin who set the state, NULL for system-set
+  notes           JSONB NOT NULL DEFAULT '{}',
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TYPE federation_peer_trust_enum AS ENUM (
+  'unknown',
+  'allowlisted',
+  'untrusted_receive',
+  'blocklisted'
+);
+
+CREATE INDEX idx_federation_peer_trust ON federation_peer (trust_level);
+```
+
+`instance_id` is Lemmy's existing `instance.id` newtype — every federated peer Lemmy has ever heard of already gets a row in `instance` (created via `Instance::read_or_create`). v1's `federation_peer` is a **governance overlay** on that table — one row per peer the governance plane has formed an opinion about. Peers Lemmy knows about but governance hasn't seen yet have no `federation_peer` row; the trust-check helper treats absent rows as `Unknown`.
+
+### 4.2 Trust states
+
+| State | Meaning | Inbound governance signals | Outbound governance signals (Phase 6 already ships outbound; v1 leaves it `to_all_instances`) | Default for new peers |
+|---|---|---|---|---|
+| `Unknown` | Lemmy has seen this peer (instance row exists), governance hasn't formed an opinion yet | Accepted; `peer_trust_level_at_receipt = unknown` recorded; surfaced in admin review with prominent "first contact" flag | Sent (v1 keeps Phase 6's `to_all_instances`; v2 narrows) | **DEFAULT** unless dashboard sets a different `federation.inbound.default_trust_for_new_peers` |
+| `Allowlisted` | Admin has explicitly trusted this peer | Accepted; standard surfacing in admin review | Sent | Set by admin only |
+| `Untrusted-Receive` | Admin allows inbound for visibility but flags as low-trust | Accepted but flagged in admin review with `requires_admin_attention = true` | Sent | Optional dashboard default for new peers in tighter postures |
+| `Blocklisted` | Admin has decided this peer is hostile | **Rejected — HTTP 403 + log to `federation_inbox_dropped_log`** | Sent (v1; v2 may add per-peer outbound block) | Set by admin only |
+
+**v0/Phase 6 alignment (§15):** Phase 6 §11 NOT-Building item #1 — "v0 treats every federated peer as `Allow`" — translates to `Unknown` in v1's terminology. The trust-check helper returning `Unknown` for absent rows produces v0-equivalent behaviour by default (accept everything), which means **v1 inbound is not breaking anything Phase 6 establishes** even if no admin ever touches the peer table.
+
+### 4.3 Configurability
+
+The dashboard knob `federation.inbound.default_trust_for_new_peers` (`enum: 'unknown' | 'untrusted_receive' | 'blocklisted'`, default `'unknown'`) is read by the trust-check helper when it encounters a peer with no `federation_peer` row. Per the user's framing, community groups can experiment — open communities default `'unknown'` (accept-and-surface), tighter communities default `'untrusted_receive'` or `'blocklisted'`.
+
+`federation_peer` rows are CRUD-ed via the v1 admin config endpoint surface (OQ-018) under a federation-specific sub-path: `POST /api/v4/governance/admin/federation/peers/{instance_id}/trust { trust_level, notes }`. Each change emits a governance_log entry `federation_peer_trust_changed` per [06 §2.4](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) "trust state change" — high-risk action, behind the standard step-up-auth gate v1 introduces alongside OQ-018.
+
+### 4.4 Per-instance only in v1
+
+v1 keeps trust **per-peer-instance**, not per-peer-per-community. Per-community trust is v2 because:
+
+- Schema cost (composite key on `federation_peer`).
+- Dashboard UX cost (matrix instead of list).
+- v1 needs operator data to know whether per-community is even desired before locking the schema.
+
+If a community wants to opt out of receiving from a peer the instance is `Allowlisting`, they can flag inbound rows in their community's review queue as ignored — surfaced via the `admin_action` enum (§8) — but the peer-level trust remains instance-wide.
+
+---
+
+## 5. HTTP inbox routing
+
+### 5.1 What exists pre-v1
+
+Phase 6 task 73 registers the three governance variants in `SharedInboxActivities`:
+
+```rust
+// crates/apub/activities/src/activity_lists.rs (post-Phase 6)
+pub enum SharedInboxActivities {
+    Follow(Follow),
+    // ... existing variants ...
+    PublishSanctionNotice(PublishSanctionNotice),     // Phase 6 task 73
+    PublishTrustAttestation(PublishTrustAttestation), // Phase 6 task 73
+    PublishLabel(PublishLabel),                        // Phase 6 task 73 (stub receive)
+    RawAnnouncableActivities(RawAnnouncableActivities),  // catch-all, must remain last
+}
+```
+
+`shared_inbox` (`crates/apub/apub/src/http/mod.rs:44-60`) calls `receive_activity_with_hook::<SharedInboxActivities, …>` which: (a) runs HTTP-signature verification, (b) parses the body via untagged serde dispatch, (c) calls the matched variant's `Activity::verify` then `Activity::receive`, (d) writes `ReceivedActivity` for dedup. **Lemmy's HTTP plumbing is unchanged in v1.**
+
+### 5.2 What v1 adds
+
+A thin **inbound wrapper** invoked from each governance `Activity::receive` impl, layered as:
+
+```
+shared_inbox HTTP entry
+    │
+    ├─ activitypub_federation: HTTP signature verify (Lemmy code; v1 unchanged)
+    ├─ Dummy::hook → ReceivedActivity::create (dedup; v1 unchanged)
+    │
+    └─ untagged serde dispatch → Activity::receive (governance variant)
+            │
+            └─ NEW v1: wrap_governance_inbound(activity, context, |a, c| {
+                    federation_inbox_check_peer_trust(a, c)?       // 403 on Blocklisted
+                    federation_inbox_check_size(a, c)?             // 413 on oversize
+                    federation_inbox_check_schema(a, c)?           // 400 on schema fail
+                    federation_inbox_check_rate_limit(a, c)?       // 429 on exceeded
+                    federation_inbox_check_replay(a, c)?           // 409 on replay
+                    Phase6::receive_remote_<type>(a, c).await?     // Phase 6 inserts row + logs
+                    Ok(())
+                }).await
+```
+
+**File location for the wrapper:** `crates/apub/apub/src/governance/inbox.rs` (Phase 6 task 75 already creates this file). v1 adds the wrapper alongside Phase 6's `receive_remote_*` functions in the same file.
+
+**The Activity::receive impls (one per governance variant) call into the wrapper** — they remain in `crates/apub/activities/src/governance/publish_*.rs` per Phase 6's layout but their body becomes a single `wrap_governance_inbound` call.
+
+### 5.3 Failure modes and HTTP responses
+
+| Stage | Failure mode | HTTP response | Audit |
+|---|---|---|---|
+| Sig verify (Lemmy code) | Bad signature | 401 (Lemmy default) | Lemmy logs; no governance_log entry |
+| `wrap_governance_inbound` peer-trust | `Blocklisted` peer | 403 | `federation_inbox_dropped_log` row + governance_log `federation_inbound_blocked` |
+| `wrap_governance_inbound` size | Payload > cap | 413 | `federation_inbox_dropped_log` row + governance_log `federation_inbound_dropped_oversize` |
+| `wrap_governance_inbound` schema | Unknown enum / missing field | 400 | `federation_inbox_dropped_log` row + governance_log `federation_inbound_dropped_schema` |
+| `wrap_governance_inbound` rate-limit | Per-peer or per-actor exceeded | 429 | `federation_inbox_dropped_log` row + governance_log `federation_inbound_dropped_rate_limit` |
+| `wrap_governance_inbound` replay | Activity ID already seen in nonce window | 409 | (Lemmy's `ReceivedActivity` dedup catches most replays at HTTP layer; v1's check is the application-level safeguard for cases where activity-id is reused with different content) |
+| Phase 6's `receive_remote_*` | DB error during insert | 500 | Standard Lemmy error path; governance_log `federation_inbound_persist_failed` (new entry kind) |
+| Success | Row inserted, log written | 202 Accepted | governance_log `federation_*_received` (Phase 6 entry kinds) |
+
+**Why 202, not 200:** Per HTTP semantics, 202 means "accepted for processing, no commitment to action." This communicates the v1 advisory-only contract to peers. ActivityPub spec accepts any 2xx; 202 is informational.
+
+### 5.4 Backward compatibility with Phase 6's direct-call test
+
+Phase 6's `tests/e2e.rs::sanction_notice_round_trip` calls `PublishSanctionNotice::receive(activity, &context_b).await` **directly** (not through HTTP). After v1's wrapper lands, this call now goes through the trust/rate/replay checks. v1 must update the test (or provide a `receive_remote_sanction_notice_unchecked` for tests) so the existing round-trip test continues to pass — likely by setting `instance-a.test` to `Allowlisted` in the test fixture before calling receive. v1 chooses the fixture-update path; do not introduce an unchecked variant (it's a footgun).
+
+---
+
+## 6. Admin review surface
+
+Three new REST endpoints under `/api/v4/governance/admin/federation/*`. Authz: instance admin only in v1 (matching OQ-018's v1 scope: "instance-admin-only in v1, ... community-scoped admin writes are v1+").
+
+### 6.1 `GET /api/v4/governance/admin/federation/inbox`
+
+Paginated list of advisory inbound rows across all three types.
+
+Request:
+```
+GET /api/v4/governance/admin/federation/inbox?type=sanction_notice&peer=peer.example&trust_level=untrusted_receive&age_days=7&page=1&limit=50
+```
+
+Filters (all optional, query params):
+- `type`: `sanction_notice` | `trust_attestation` | `moderation_label` | (omit for all)
+- `peer`: instance domain or `instance_id`
+- `trust_level`: `unknown` | `allowlisted` | `untrusted_receive` | `blocklisted` (filters by `peer_trust_level_at_receipt`)
+- `age_days`: `i32` (0 = today only, 7 = last week, etc.)
+- `admin_action`: `unreviewed` | `cross_linked` | `dismissed` (default `unreviewed`)
+- `page`, `limit` (match Phase 4's `list_modlog` pagination pattern)
+
+Response (DTO `ListFederationInboxResponse` in `api_common`):
+```rust
+pub struct FederationInboxRow {
+    pub kind: FederationInboxKind,                    // sanction | attestation | label
+    pub row_id: i32,                                   // FK to remote_sanction_notice / federation_attestation / remote_moderation_label
+    pub peer_instance: String,
+    pub peer_trust_level_at_receipt: FederationPeerTrust,
+    pub current_peer_trust_level: FederationPeerTrust, // may differ if admin re-trusted post-receipt
+    pub target_url: String,
+    pub action: Option<SanctionAction>,                // Some only for sanction_notice
+    pub scope: Option<SanctionScope>,                  // Some only for sanction_notice
+    pub attestation_type: Option<AttestationType>,     // Some only for trust_attestation
+    pub label: Option<String>,                         // Some only for moderation_label
+    pub summary_redacted: String,                      // truncated for list view; full payload via separate endpoint if needed
+    pub published_at: DateTime<Utc>,
+    pub received_at: DateTime<Utc>,
+    pub admin_reviewed_at: Option<DateTime<Utc>>,
+    pub admin_action: Option<FederationInboxAdminAction>,  // None | CrossLinked(case_id) | Dismissed
+    pub local_case_id: Option<i32>,                    // populated only after cross-link
+    pub requires_admin_attention: bool,                // computed: trust_level in (unknown, untrusted_receive) AND admin_reviewed_at IS NULL
+}
+
+pub struct ListFederationInboxResponse {
+    pub rows: Vec<FederationInboxRow>,
+    pub total_unreviewed: i64,
+    pub total_pending_attention: i64,
+}
+```
+
+**View crate:** `crates/db_views/federation_inbox/` (new) — UNION query across the three advisory tables, projecting into the unified `FederationInboxRow` shape. Per Phase 2a's `view-crate-selectable-template.md` precedent: each backing table has its own `Selectable` derive; the view assembles them via 3 separate queries into a `Vec<FederationInboxRow>` (UNION-ALL in SQL is also acceptable but harder to debug — start with three separate queries).
+
+### 6.2 `POST /api/v4/governance/admin/federation/inbox/{kind}/{id}/cross-link`
+
+Admin links an advisory row to a local case.
+
+Request:
+```json
+{
+  "local_case_id": 1234,
+  "rationale": "Same target user; their peer's jury reached the same finding."
+}
+```
+
+Behaviour:
+- Validate `local_case_id` exists and admin has access.
+- `UPDATE remote_sanction_notice SET local_case_id = $1, admin_reviewed_at = NOW(), admin_action = 'cross_linked' WHERE id = $2` (and analogues for the other two types).
+- Insert a `case_evidence` row (per [04 §3](../../docs/brehon-law-inspired-network/04-data-model-and-api.md)) linking the case to the advisory notice with `visibility = JuryOnly` (default; admin can set `PublicRedacted` if appropriate).
+- governance_log: `federation_inbound_cross_linked` (new entry kind).
+- Step-up auth: NOT required in v1 — cross-linking advisory evidence to a case is lower-risk than trust-state change (the jury still decides). Document in §12 security row.
+
+### 6.3 `POST /api/v4/governance/admin/federation/inbox/{kind}/{id}/dismiss`
+
+Admin marks the advisory row as reviewed-no-action.
+
+Request:
+```json
+{
+  "rationale": "Peer is known low-trust; this notice does not warrant action."
+}
+```
+
+Behaviour:
+- `UPDATE … SET admin_reviewed_at = NOW(), admin_action = 'dismissed', dismissal_rationale = $1`.
+- governance_log: `federation_inbound_dismissed` (new entry kind).
+- Row is **not deleted** — audit trail preserved. Filtered out of default `unreviewed` list view.
+
+### 6.4 What v1 does NOT ship (UI)
+
+The dashboard UI for the admin review surface is **out of v1 scope** per ADR-010 v3 ("Admin dashboard UX"). v1 ships only the REST endpoints + DTOs. The user's framing — "the admin dashboard will allow community groups to experiment" — is satisfied by **the API existing and being callable**; the dashboard frontend is v3 (or whenever the dashboard track ships, which is parallel to v1/v2/v3 per v0's CLAUDE.md "no UI in v0/v1 backend slice" rule).
+
+---
+
+## 7. Rate limiting and abuse defence
+
+### 7.1 Per-peer rate limit
+
+**Default:** 100 inbound governance activities per hour per peer instance (sliding window).
+
+**Storage:** in-memory rolling counter keyed by `(instance_id, hour_bucket)` with periodic flush to a `federation_inbox_rate_log` derived table for observability. Use the same in-process rate-limit pattern Lemmy already has at `crates/api_utils/src/rate_limit/*` — extend rather than fork.
+
+**Tunable via dashboard:** `federation.inbound.per_peer_rate_per_hour` (`int`, range `[1, 100000]`, default `100`).
+
+**Trigger:** at the 101st inbound from the same peer in a sliding hour, return HTTP 429, write `federation_inbox_dropped_log` row + governance_log `federation_inbound_dropped_rate_limit`.
+
+### 7.2 Per-actor rate limit on attestations
+
+**Why:** [06 §4.7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) — fake federated attestations are a named threat. The vector isn't one peer flooding (caught by §7.1); it's **many peers each sending one attestation about the same target actor** (e.g. 50 peers say "user X is trusted" in a coordinated push to influence our jury pool).
+
+**Default:** 10 attestations per hour about the same `subject_url`, summed across all peers.
+
+**Storage:** in-memory keyed by `(subject_url_hash, hour_bucket)`. `subject_url_hash` because keying by raw URL leaks pseudonym structure into the rate-limit table (small concern, but cheap to avoid).
+
+**Tunable:** `federation.inbound.per_actor_attestation_rate_per_hour` (`int`, range `[1, 10000]`, default `10`).
+
+**Trigger:** 11th attestation about same subject in window → 429, log `federation_inbound_dropped_actor_rate_limit`.
+
+### 7.3 Storage cap
+
+**Why:** even a peer below the rate limit can fill our DB over months (100/h × 24 × 30 = 72,000 rows/peer/month). Need a backstop.
+
+**Default cap:** 10,000 rows per peer per advisory table (`remote_sanction_notice`, `federation_attestation`, `remote_moderation_label`).
+
+**Mechanism:** at insert time, check `SELECT COUNT(*) FROM remote_sanction_notice WHERE source_instance = $1 AND admin_reviewed_at IS NULL`. If ≥ cap, drop the oldest unreviewed row for that peer with a `federation_inbox_dropped_log` entry + governance_log `federation_inbound_storage_cap_evicted`. Reviewed rows (cross-linked or dismissed) are not counted toward the cap — they're audit-preserved.
+
+**Tunable:** `federation.inbound.per_peer_storage_cap` (`int`, range `[100, 1000000]`, default `10000`).
+
+**Why oldest-drop, not reject:** rejecting at the cap means a hostile peer can prevent us from ever seeing newer notices from a legitimate peer once we're at cap. Oldest-drop with eviction log preserves recency at the cost of historical depth.
+
+### 7.4 Schema-fuzzing defence
+
+- **Payload size cap** (per §3.3): default 64 KiB for sanction notices, 8 KiB for attestations/labels. Configurable via `federation.inbound.max_payload_bytes_<type>`.
+- **Strict deserialisation:** per Phase 6 task 75, schema validation happens at the serde layer; unknown enum variants for `SanctionAction`/`SanctionScope`/`AttestationType` cause `serde_json::from_value` to fail. v1 adds `#[serde(deny_unknown_fields)]` on the protocol structs in `crates/apub/objects/src/protocol/governance/*.rs` to reject hostile field injections.
+- **String length caps** on `summary` fields: 8000 chars per Phase 6's existing convention; oversize → 413.
+
+### 7.5 Replay protection
+
+**Why:** ActivityPub HTTP signatures don't include a nonce by default. A peer can replay a signed activity verbatim. Lemmy's `ReceivedActivity::create` (called by Phase 6's `Dummy::hook` at `crates/apub/apub/src/http/mod.rs:73-74`) already dedupes by `activity.id()` for the lifetime of the row, but — depending on retention — old IDs could be replayed after eviction.
+
+**v1 mechanism:** dedicated `federation_inbox_nonce` table (migration in §8) with `(peer_instance, activity_id)` UNIQUE constraint and `seen_at` timestamp. Window: configurable, default 7 days. A periodic cron (every hour) deletes rows older than the window. Within window, duplicate insert returns 409 Conflict.
+
+**Tunable:** `federation.inbound.replay_window_days` (`int`, range `[1, 30]`, default `7`).
+
+---
+
+## 8. Dependencies, database & migration changes
+
+### 8.0 Dependencies (hard gate — Phase 6 merge)
+
+**Per B5 resolution 2026-04-19**, v1-federation-inbound implementation is hard-gated on Phase 6 PR merge to `governance-v0`. Plan-level review (this PRD) can proceed in parallel, but no v1 migration, handler, or route change lands until all preconditions below are satisfied. This makes the ordering fail-loud (the §8.2 SQL `DO` preamble `RAISE EXCEPTION`s if the migration runs first).
+
+**Preconditions — all must be true at v1 `/prp-plan` time:**
+
+1. **Phase 6 PR merged to `governance-v0`.** Verify via `git log governance-v0` or by checking that Phase 6's commit SHA is an ancestor of the current `governance-v0` HEAD.
+2. **Phase 6 tables exist.** `federation_attestation` and `remote_sanction_notice` must be present with all columns Phase 6 creates (task 70). The §8.2 DO block asserts this.
+3. **Phase 6 `received_at` column on `remote_sanction_notice`.** Carry-forward DQ-6.1 must be resolved by landing `received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`. v1 relies on this column for §6.1 admin-review queries' `age_days` filter. If DQ-6.1 landed differently, v1 must re-plan.
+4. **Phase 6 enum types registered.** `attestation_type_enum`, `sanction_action_enum`, `sanction_scope_enum` must exist as Postgres types (Phase 6 task 70 creates them). v1 extends `federation_attestation`'s shape by adding columns, but the enum columns Phase 6 defines are assumed present.
+5. **Phase 6 `governance_log::append` constants present.** String literals `"federation_sanction_received"` and `"federation_attestation_received"` must exist in `crates/api/api/src/governance/governance_log.rs` (Phase 6 task 75). v1 adds further constants on top of these (see §15.1 deliverable table).
+6. **Schema assumption — `remote_sanction_notice.source_instance` is TEXT (peer domain).** Phase 6's design choice is a TEXT column holding the peer's domain; it is NOT an FK to `instance.id`. v1's `federation_peer` overlay table joins to it via `JOIN instance ON instance.domain = remote_sanction_notice.source_instance`. Case-sensitivity of this join must be verified on the first v1 integration test. If Phase 6 ships `source_instance` as an FK instead, v1 §4.1 + §8.2 need re-planning.
+7. **Migration timestamp invariant.** The v1 migration (`add_federation_inbound_v1`) must sort **after** Phase 6's `add_federation_attestations` (i.e. a later ISO-timestamp prefix). The specific timestamp slot is assigned at v1 implementation time, not reserved here.
+
+**If ANY precondition is not satisfied at v1 `/prp-plan` time, stop.** Do not run the §8.2 migration against an unmet preconditions state — the DO block preamble will `RAISE EXCEPTION` and the migration will abort cleanly, but re-planning is still required to adjust to whatever Phase 6 actually shipped.
+
+**Partial-collateral:** this preconditions list graduates N5 (the FK-vs-domain-string mismatch first surfaced in the §15.3 alignment notes) from "noted — revisit at v1-impl" to "resolved at v1-impl time via explicit precondition #6." A reviewer who disagrees with the TEXT-not-FK assumption must push back at PR review, not silently at migration-time.
+
+### 8.1 Tables Phase 6 creates (verified before v1)
+
+Per Phase 6 task 70:
+
+```sql
+-- Phase 6 ships:
+CREATE TABLE federation_attestation (
+    id SERIAL PRIMARY KEY,
+    actor_url TEXT NOT NULL,
+    subject_url TEXT NOT NULL,
+    attestation_type attestation_type_enum NOT NULL,
+    valid_until TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    signature TEXT NOT NULL
+);
+
+CREATE TABLE remote_sanction_notice (
+    id SERIAL PRIMARY KEY,
+    source_instance TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    action sanction_action_enum NOT NULL,
+    scope sanction_scope_enum NOT NULL,
+    summary TEXT NOT NULL,
+    published_at TIMESTAMPTZ NOT NULL,
+    signature TEXT NOT NULL,
+    local_case_id INT REFERENCES moderation_case(id) ON DELETE SET NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+`source_instance` on `remote_sanction_notice` is TEXT (peer domain), not an FK to `instance.id`. **v1 alignment note (§15):** this is a Phase 6 design choice that simplifies the inbound path (no need to resolve domain → instance_id at receive time) but means v1's `federation_peer` join needs `JOIN instance ON instance.domain = remote_sanction_notice.source_instance` — verify on first v1 test that Lemmy's `instance.domain` matches AP-actor host case-sensitivity.
+
+### 8.2 v1 migration: `add_federation_inbound_v1`
+
+**Timestamp:** must sort after Phase 6's `add_federation_attestations`. The specific timestamp slot is assigned at v1 implementation time (do NOT pre-reserve it here — Phase 6's ordering within `governance-v0` is still in flight at PRD time).
+
+**Preamble — fail-loud Phase 6 precondition check (per §8.0 hard gate).** The DO block below `RAISE EXCEPTION`s if Phase 6's tables or the DQ-6.1 `received_at` column are not present. This makes accidental out-of-order execution abort cleanly instead of silently creating columns on tables the handler path will never read.
+
+```sql
+-- Preamble: verify Phase 6 preconditions present before ALTER.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'federation_attestation'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 federation_attestation table (not present)';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'remote_sanction_notice'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 remote_sanction_notice table (not present)';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'remote_sanction_notice' AND column_name = 'received_at'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 assumes Phase 6 DQ-6.1 resolved with remote_sanction_notice.received_at column (not present)';
+  END IF;
+END
+$$;
+
+-- New trust-state enum
+CREATE TYPE federation_peer_trust_enum AS ENUM (
+  'unknown',
+  'allowlisted',
+  'untrusted_receive',
+  'blocklisted'
+);
+
+-- New admin-action enum for advisory-row review state
+CREATE TYPE federation_inbox_admin_action_enum AS ENUM (
+  'unreviewed',
+  'cross_linked',
+  'dismissed'
+);
+
+-- 1. Peer-trust overlay table
+CREATE TABLE federation_peer (
+  instance_id     INT PRIMARY KEY REFERENCES instance(id) ON DELETE CASCADE,
+  trust_level     federation_peer_trust_enum NOT NULL DEFAULT 'unknown',
+  added_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  added_by_actor  TEXT,
+  notes           JSONB NOT NULL DEFAULT '{}'::JSONB,
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_federation_peer_trust ON federation_peer (trust_level);
+
+-- 2. Drop-log for audit
+CREATE TABLE federation_inbox_dropped_log (
+  id              BIGSERIAL PRIMARY KEY,
+  source_instance TEXT NOT NULL,
+  activity_id     TEXT,
+  drop_reason     TEXT NOT NULL,                  -- 'blocklisted' | 'oversize' | 'schema' | 'rate_limit_peer' | 'rate_limit_actor' | 'replay' | 'storage_cap_evicted'
+  payload_excerpt TEXT,                            -- first 256 chars of body for diagnostic; NULL on auto-evict
+  dropped_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_fil_drop_source ON federation_inbox_dropped_log (source_instance, dropped_at DESC);
+CREATE INDEX idx_fil_drop_reason ON federation_inbox_dropped_log (drop_reason, dropped_at DESC);
+
+-- 3. Replay-protection nonce table
+CREATE TABLE federation_inbox_nonce (
+  peer_instance   TEXT NOT NULL,
+  activity_id     TEXT NOT NULL,
+  seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (peer_instance, activity_id)
+);
+CREATE INDEX idx_fin_nonce_seen_at ON federation_inbox_nonce (seen_at);
+
+-- 4. ModerationLabel advisory table (Phase 6 ships type but no table; v1 adds it)
+CREATE TABLE remote_moderation_label (
+  id              SERIAL PRIMARY KEY,
+  source_instance TEXT NOT NULL,
+  actor_url       TEXT NOT NULL,
+  target_url      TEXT NOT NULL,
+  label           TEXT NOT NULL,
+  summary         TEXT,
+  published_at    TIMESTAMPTZ NOT NULL,
+  signature       TEXT NOT NULL,
+  local_case_id   INT REFERENCES moderation_case(id) ON DELETE SET NULL,
+  received_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  peer_trust_level_at_receipt federation_peer_trust_enum NOT NULL DEFAULT 'unknown',
+  admin_reviewed_at TIMESTAMPTZ,
+  admin_action    federation_inbox_admin_action_enum NOT NULL DEFAULT 'unreviewed',
+  dismissal_rationale TEXT
+);
+CREATE INDEX idx_rml_target ON remote_moderation_label (target_url);
+CREATE INDEX idx_rml_source ON remote_moderation_label (source_instance, received_at DESC);
+CREATE INDEX idx_rml_admin_action ON remote_moderation_label (admin_action) WHERE admin_action = 'unreviewed';
+
+-- 5. Add v1 columns to Phase 6's tables
+ALTER TABLE remote_sanction_notice
+  ADD COLUMN peer_trust_level_at_receipt federation_peer_trust_enum NOT NULL DEFAULT 'unknown',
+  ADD COLUMN admin_reviewed_at TIMESTAMPTZ,
+  ADD COLUMN admin_action federation_inbox_admin_action_enum NOT NULL DEFAULT 'unreviewed',
+  ADD COLUMN dismissal_rationale TEXT;
+CREATE INDEX idx_rsn_admin_action ON remote_sanction_notice (admin_action) WHERE admin_action = 'unreviewed';
+
+ALTER TABLE federation_attestation
+  ADD COLUMN source_instance TEXT,                 -- nullable: outbound rows have NULL; inbound rows populated
+  ADD COLUMN received_at TIMESTAMPTZ,              -- nullable: outbound rows have NULL
+  ADD COLUMN peer_trust_level_at_receipt federation_peer_trust_enum,
+  ADD COLUMN admin_reviewed_at TIMESTAMPTZ,
+  ADD COLUMN admin_action federation_inbox_admin_action_enum NOT NULL DEFAULT 'unreviewed',
+  ADD COLUMN dismissal_rationale TEXT;
+CREATE INDEX idx_fa_admin_action ON federation_attestation (admin_action) WHERE admin_action = 'unreviewed';
+CREATE INDEX idx_fa_source ON federation_attestation (source_instance, received_at DESC) WHERE source_instance IS NOT NULL;
+```
+
+**down.sql:** Drop in reverse order. The columns added to `federation_attestation` and `remote_sanction_notice` are reversible because Phase 6's tables are empty pre-v1 (no production data yet), so column-drop is safe.
+
+### 8.3 Backfill
+
+Phase 6's tables are empty pre-v1 (the round-trip test inserts and tears down). No data backfill needed. New columns default to `'unknown'` / `'unreviewed'` so any Phase 6 test rows that survive into v1 land in a consistent state.
+
+### 8.4 Diesel models
+
+Per Phase 6's pattern, mirror the existing `crates/db_schema/src/source/governance/sanction.rs` shape:
+
+| New model file | Purpose |
+|---|---|
+| `crates/db_schema/src/source/governance/federation_peer.rs` | `FederationPeer`, `FederationPeerInsertForm`, `FederationPeerUpdateForm` |
+| `crates/db_schema/src/source/governance/federation_inbox_dropped_log.rs` | Insert-only model |
+| `crates/db_schema/src/source/governance/federation_inbox_nonce.rs` | Insert-only + period-cleanup query |
+| `crates/db_schema/src/source/governance/remote_moderation_label.rs` | `RemoteModerationLabel`, `RemoteModerationLabelInsertForm`, `RemoteModerationLabelUpdateForm` |
+
+Plus extending Phase 6's models in `remote_sanction_notice.rs` and `federation_attestation.rs` with new columns + an `UpdateForm` (Phase 6 ships insert-only forms).
+
+Newtypes in `crates/db_schema/src/newtypes.rs`: `FederationPeerId(pub i32)` (just `instance_id` reuse acceptable; create newtype only if Diesel benefits), `FederationInboxDroppedLogId(pub i64)`, `RemoteModerationLabelId(pub i32)`.
+
+---
+
+## 9. Handler shape
+
+### 9.1 Module layout (extending Phase 6's `crates/apub/apub/src/governance/`)
+
+```
+crates/apub/apub/src/governance/
+├── mod.rs                  (Phase 6; re-export wiring)
+├── inbox.rs                (Phase 6: receive_remote_*; v1 ADDS: wrap_governance_inbound, peer-trust + rate-limit + replay helpers)
+├── outbox.rs               (Phase 6; v1 unchanged in scope, may consume federation_peer.trust_level for v2-prep)
+├── verify.rs               (Phase 6 stub; v1 unchanged)
+└── inbox_admin.rs          (NEW v1: handlers for the 3 admin endpoints)
+```
+
+The 3 admin endpoints are NOT in `crates/apub/`; they're standard governance handlers in `crates/api/api/src/governance/federation_inbox/`:
+
+```
+crates/api/api/src/governance/federation_inbox/
+├── mod.rs
+├── list_inbox.rs
+├── cross_link.rs
+└── dismiss.rs
+```
+
+`crates/api/routes/src/governance.rs` adds the 3 routes.
+
+### 9.2 Wrapper signature
+
+```rust
+// crates/apub/apub/src/governance/inbox.rs (v1 addition)
+
+pub(crate) async fn wrap_governance_inbound<F, Fut, A>(
+    activity: A,
+    context: &Data<LemmyContext>,
+    inner: F,
+) -> LemmyResult<()>
+where
+    F: FnOnce(A, &Data<LemmyContext>) -> Fut,
+    Fut: Future<Output = LemmyResult<()>>,
+    A: GovernanceInboundActivity,                  // trait that exposes activity_id, actor_domain, payload_size_bytes
+{
+    let pool = &mut context.pool();
+    let peer_domain = activity.actor_domain()?;
+    let activity_id = activity.activity_id()?;
+
+    // 1. Peer trust gate
+    let trust = federation_inbox_check_peer_trust(&peer_domain, pool).await?;
+    if trust == FederationPeerTrust::Blocklisted {
+        log_inbox_drop(&peer_domain, &activity_id, "blocklisted", None, pool).await?;
+        return Err(LemmyErrorType::FederationPeerBlocklisted.into());  // → HTTP 403
+    }
+
+    // 2. Size cap (per type)
+    let size_cap = activity.payload_size_cap_bytes(&context.settings()?);
+    if activity.payload_size_bytes()? > size_cap {
+        log_inbox_drop(&peer_domain, &activity_id, "oversize", None, pool).await?;
+        return Err(LemmyErrorType::FederationPayloadTooLarge.into());  // → HTTP 413
+    }
+
+    // 3. Schema validation happens at serde layer; serialise re-check is unnecessary
+
+    // 4. Rate limit per peer
+    federation_inbox_check_peer_rate_limit(&peer_domain, context).await?;
+
+    // 5. Per-actor rate limit (only for attestations)
+    activity.check_per_actor_rate_limit(context).await?;
+
+    // 6. Replay protection
+    federation_inbox_check_replay(&peer_domain, &activity_id, context).await?;
+
+    // 7. Phase 6's domain handler
+    inner(activity, context).await?;
+
+    Ok(())
+}
+```
+
+**Failure modes are exposed via new `LemmyErrorType` variants:**
+- `FederationPeerBlocklisted` (403)
+- `FederationPayloadTooLarge` (413)
+- `FederationSchemaInvalid` (400)
+- `FederationPeerRateLimitExceeded` (429)
+- `FederationActorRateLimitExceeded` (429)
+- `FederationActivityReplayed` (409)
+
+These map to HTTP status codes via the existing Lemmy error → response mapper (extend the mapping if needed).
+
+### 9.3 Per-handler patches
+
+Each Phase 6 `Activity::receive` impl becomes:
+
+```rust
+// crates/apub/activities/src/governance/publish_sanction_notice.rs
+async fn receive(self, context: &Data<Self::DataType>) -> LemmyResult<()> {
+    wrap_governance_inbound(self, context, |activity, ctx| async move {
+        crate::governance::inbox::receive_remote_sanction_notice(activity, ctx).await
+    }).await
+}
+```
+
+(Same shape for `PublishTrustAttestation` and `PublishLabel`.)
+
+### 9.4 New handler for `ModerationLabel`
+
+```rust
+// crates/apub/apub/src/governance/inbox.rs (v1 addition)
+pub async fn receive_remote_moderation_label(
+    activity: PublishLabel,
+    context: &Data<LemmyContext>,
+) -> LemmyResult<()> {
+    let form = RemoteModerationLabelInsertForm {
+        source_instance: activity.actor.inner().domain().unwrap_or_default().to_string(),
+        actor_url: activity.actor.inner().to_string(),
+        target_url: activity.object.target.to_string(),
+        label: activity.object.label.clone(),
+        summary: activity.object.summary.clone(),
+        published_at: activity.object.published,
+        signature: String::new(),  // DQ-FED-IN-1 carry-forward from Phase 6 task 75
+        local_case_id: None,                                  // ADR-006
+        peer_trust_level_at_receipt: /* from wrap_governance_inbound context */,
+    };
+    RemoteModerationLabel::create(&mut context.pool(), &form).await?;
+    governance_log::append(
+        &mut context.pool(),
+        ENTRY_KIND_FEDERATION_LABEL_RECEIVED,
+        json!({
+            "source_instance": form.source_instance,
+            "target_url": form.target_url,
+            "label": form.label,
+        }),
+        None,
+    ).await?;
+    Ok(())
+}
+```
+
+---
+
+## 10. Defaults matrix
+
+All knobs read from `governance_config` (Phase 5a's typed-column config table; OQ-018 ships the v1 admin write endpoint). Per the user framing — "defaults might have to be decided on" — the following are v1 starting points; communities can change them via the dashboard once OQ-018 ships, or via direct `UPDATE governance_config` until then.
+
+| Knob | Namespace | Default | Range | Per-instance? | Citation |
+|---|---|---|---|---|---|
+| `federation.inbound.default_trust_for_new_peers` | `federation.inbound` | `'unknown'` | enum {unknown, untrusted_receive, blocklisted} | yes | §4.3 |
+| `federation.inbound.per_peer_rate_per_hour` | `federation.inbound` | `100` | `[1, 100000]` | yes | §7.1 |
+| `federation.inbound.per_actor_attestation_rate_per_hour` | `federation.inbound` | `10` | `[1, 10000]` | yes | §7.2 |
+| `federation.inbound.per_peer_storage_cap` | `federation.inbound` | `10000` | `[100, 1000000]` | yes | §7.3 |
+| `federation.inbound.max_payload_bytes_sanction_notice` | `federation.inbound` | `65536` | `[1024, 1048576]` | yes | §3.3 |
+| `federation.inbound.max_payload_bytes_trust_attestation` | `federation.inbound` | `8192` | `[1024, 65536]` | yes | §3.3 |
+| `federation.inbound.max_payload_bytes_moderation_label` | `federation.inbound` | `8192` | `[1024, 65536]` | yes | §3.3 |
+| `federation.inbound.replay_window_days` | `federation.inbound` | `7` | `[1, 30]` | yes | §7.5 |
+| `federation.inbound.replay_cleanup_cron_interval_minutes` | `federation.inbound` | `60` | `[5, 1440]` | yes | §7.5 |
+| `federation.inbound.summary_max_chars` | `federation.inbound` | `8000` | `[256, 32000]` | yes | §7.4 |
+| `federation.inbound.admin_review_default_filter_days` | `federation.inbound` | `7` | `[0, 365]` | yes | §6.1 |
+
+Seed these rows in the migration alongside the schema changes per Phase 5a task 50's pattern (insert into `governance_config` with `scope = 'instance'`).
+
+---
+
+## 11. Backwards compatibility
+
+### 11.1 Phase 6 outbound
+
+**Unchanged in v1.** Outbound publish (`send_local_sanction_notice`, `send_local_trust_attestation`) continues to use `ActivitySendTargets::to_all_instances()` per Phase 6 task 74. v1 does not narrow outbound by `federation_peer.trust_level` — that's v2 work (it would require a new outbound-side filter pass that's a separate design discussion).
+
+### 11.2 Existing peers
+
+There are no existing federation peers as of pre-v1 — Phase 6 is in flight, no production deployment with governance-federation peers exists yet. If by v1 ship-date a Brehon instance has federated peers, they'll all be `Unknown` until an admin classifies them (see §4.2 default behaviour).
+
+### 11.3 Vanilla Lemmy peers
+
+Per ADR-014, vanilla Lemmy:
+- **Sends** content activities only (posts, comments, votes, follows, etc.). They never send `PublishSanctionNotice` / `PublishTrustAttestation` / `PublishLabel` because they don't know about these types.
+- **Receives** governance activities from us but ignores them (untagged serde dispatch falls through to `RawAnnouncableActivities` catch-all per Phase 6 task 73 GOTCHA).
+
+**v1 implication:** a vanilla Lemmy peer never appears in `federation_peer` because the only path to creating a row is admin action (no first-contact governance activity from them ever fires). Content federation continues unchanged. The trust-check helper has no opinion about vanilla peers — they simply don't trigger governance-inbound code.
+
+### 11.4 Phase 6's `sanction_notice_round_trip` test
+
+v1's wrapper means the existing direct-call test now goes through trust-check + rate-limit + replay. v1 must update the test fixture to:
+1. Insert `federation_peer` row for `instance-a.test` with `trust_level = 'allowlisted'` before calling receive.
+2. Confirm test still passes.
+
+This is a test-only change; no production code regression.
+
+---
+
+## 12. Security
+
+### 12.1 Signature verification
+
+Delegated to `activitypub_federation::actix_web::inbox::receive_activity_with_hook` (Lemmy's existing path). v1 does not modify signature verification. Per Phase 6 task 75 GOTCHA, the raw signature header value is not trivially available inside `Activity::receive` — Phase 6 stores an empty string with a `// TODO(v1): plumb actual HTTP signature through activitypub_federation hook`. **v1 carries this TODO forward** as DQ-FED-IN-1; resolving it requires a hook extension in `activitypub_federation` upstream or a fork-local wrapper. v1 ships without resolving (signature was already verified before reaching `receive`; storing the header value is for future re-verify, not v1 enforcement).
+
+### 12.2 Schema validation strictness
+
+Per §7.4: `#[serde(deny_unknown_fields)]` on protocol structs. Reject 400 on unknown variants of `SanctionAction`, `SanctionScope`, `AttestationType`. Per [06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md): "Strict validation of remote objects (schema + size limits)."
+
+### 12.3 Storage isolation
+
+All advisory rows have `local_case_id = NULL` at insert. Cross-link is admin-driven and emits a governance_log entry. No code path inserts an advisory row with a non-NULL `local_case_id` directly. Lint pattern (§12.6) catches drift.
+
+### 12.4 Audit
+
+Every inbound — accepted, dropped, or blocked — produces either a `governance_log` entry or a `federation_inbox_dropped_log` row (or both). Per [06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) "Federation inbound rate limiting" and [06 §7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) row "Federation inbox" mitigation.
+
+### 12.5 Step-up auth
+
+Per [06 §2.4](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md), federation trust-state changes are high-risk actions requiring step-up auth + quorum + delay. v1 ships:
+- **Step-up:** YES on `POST /api/v4/governance/admin/federation/peers/{id}/trust` (if step-up infrastructure ships in v1; otherwise gate this endpoint behind `webauthn-rs` MFA per ADR-010 v0/v1 simplification).
+- **Quorum + delay:** Deferred. v1's admin model is single-admin. Quorum + delay is v2 alongside the broader OPA migration.
+- **Cross-link / dismiss:** No step-up — admins act on advisory evidence frequently; step-up here would friction the workflow without commensurate security benefit.
+
+### 12.6 Reserved slot for v2
+
+Per [06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md): "Isolate media fetching from the main app network path — use a separate fetch worker with no access to the app DB (SSRF containment)." If a v1 inbound activity references remote media (e.g. evidence URL inside `summary`), v1 does NOT fetch it — the URL is stored as text only. Fetching is v2's SSRF-isolated worker.
+
+### 12.7 New threat-model rows for [06 §7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)
+
+v1 should append the following rows when this PRD lands:
+
+| Asset | Threat | Mitigation | Reference |
+|---|---|---|---|
+| Federation inbox advisory storage | Hostile peer floods to fill DB | Per-peer rate limit (§7.1), per-peer storage cap (§7.3) with oldest-drop, admin can `Blocklist` peer | §7, §4.2 |
+| Trust-attestation aggregate signal | Many peers attest the same target to influence local jury | Per-actor rate limit (§7.2), advisory-only (no auto-apply) | §7.2, ADR-006 |
+| Federation inbox replay | Peer replays signed activity | Lemmy's `ReceivedActivity` dedup + v1 nonce table with sliding window | §7.5 |
+| Advisory→local-case link | Compromised admin cross-links false notice to a real case | Cross-link emits governance_log entry; jury still decides; admin's cross-link history visible in modlog | §6.2 |
+| `federation_peer` trust state | Compromised admin silently flips peer to `Allowlisted` | Step-up auth on trust-change endpoint; governance_log entry per change; v2 adds quorum + delay | §4.3, §12.5 |
+
+### 12.8 Lint guards
+
+Recommended fork-local lint patterns (in `.claude/rules/` or similar) to prevent future drift:
+
+```
+# No-auto-apply guard
+rg -A 5 "RemoteSanctionNotice::|RemoteModerationLabel::|FederationAttestation::" crates/api/api/ crates/api/api_crud/
+# Look for any insert with local_case_id = Some(_) NOT in the cross_link.rs handler
+# Look for any call chain reaching Sanction::create from inbox handler
+
+# No bypass of wrap_governance_inbound
+rg "receive_remote_(sanction_notice|trust_attestation|moderation_label)" crates/apub/activities/
+# Every match must be inside wrap_governance_inbound or in tests
+```
+
+---
+
+## 13. Open questions for v1 design phase
+
+### 13.1 OQ-FED-IN-1 — Cross-instance actor pseudonyms
+
+**Question:** When peer B sends a `SanctionNoticeObject` about user X (identified by `target_url = https://b.example/u/x`), does X have a stable cross-instance pseudonym we can show in our admin review surface?
+
+**Proposed resolution:** Each instance maintains its own `actor_pseudonym` table per ADR-015. Cross-instance attestations include `ap_id` of the attestee. At admin review time, the admin sees the raw `target_url`. If the admin cross-links to a local case where the same person has a local `actor_pseudonym`, the cross-linked view renders as `<local-pseudonym> ≈ <peer-domain>` ("locally known as X, peer claims is Y"). No automatic mapping — admin judgment.
+
+**Status:** Open; resolve before v1 implementation.
+
+### 13.2 OQ-FED-IN-2 — Vanilla Lemmy actor as TrustAttestation target
+
+**Question:** If peer B (a Brehon fork) sends us a `TrustAttestationObject` about user X who lives on `lemmy.world` (vanilla Lemmy, no governance), can we accept it?
+
+**Proposed resolution:** Yes — it's advisory-only. The target's home instance type doesn't matter; we store the attestation, surface it in admin review, and a local jury or admin can cite it if it's relevant to a case targeting the same actor's local activity. Never auto-apply (ADR-006 covers this regardless of target's instance type).
+
+**Status:** Resolved as proposed; document in PRD body and proceed.
+
+### 13.3 OQ-FED-IN-3 — Replay window default
+
+**Question:** Is 7 days the right default for the nonce window (§7.5)?
+
+**Proposed resolution:** 7 days is conservative (longer than a typical retry storm; short enough to bound the nonce table size: 100/h × 24 × 7 × N peers ≈ 17K rows for 1 peer at peak rate, 170K for 10 peers — well within Postgres comfort zone for an indexed lookup table). Configurable, so an instance with high-volume governance traffic can shorten it.
+
+**Status:** Resolved as proposed; configurable.
+
+### 13.4 OQ-FED-IN-4 — Federation discovery
+
+**Question:** How do new Brehon instances find each other in v1?
+
+**Proposed resolution:** **Defer to v2.** Lemmy's existing instance discovery (admin-curated allowlist, content federation handshakes) covers content-level discovery. Governance discovery as a separate concern (e.g. a `.well-known/brehon-governance` endpoint that announces governance-AP-type support) is v2 alongside the broader federation-policy-engine work.
+
+**Status:** Resolved as deferred to v2.
+
+### 13.5 OQ-FED-IN-5 — Admin notification on first-contact
+
+**Question:** When a peer with `trust_level = unknown` (no `federation_peer` row) sends its first inbound governance activity, should the admin get a notification?
+
+**Proposed resolution:** YES, but as a derived signal — the admin review surface already filters `requires_admin_attention = true` (§6.1) which includes `unknown` peers. v1 does not push notifications (no notification infrastructure in v0/v1). v3's notification UX (per ADR-010) picks this up.
+
+**Status:** Resolved; covered by §6.1's filter.
+
+---
+
+## 14. Cross-references
+
+- **Phase 6 plan** — `brehon-fork-advisor-phase6/.claude/PRPs/plans/phase-6-federation.plan.md` (foundation; v1 builds on; do not duplicate AP type definitions or outbound publisher).
+- **admin-dashboard-v1 PRD** (sibling) — v1 dashboard wraps the §6 endpoints and the federation_peer CRUD.
+- **OQ-018** ([99-decisions-and-open-questions.md](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)) — admin config write endpoint shape; v1 federation policy knobs (§10) ride on this. The `federation.inbound.*` namespace must be supported by OQ-018's per-key write endpoint.
+- **ADR-006** — advisory-only federation; v1's hard rule.
+- **ADR-014** — vanilla Lemmy interop; v1 unaffected (vanilla peers never send governance types).
+- **[05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md)** — v1 scope; "Full inbound + outbound" federation under "v1 production-grade governance" milestone.
+- **[05 §7.3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md)** — v3 scope; "Full federation inbound processing (beyond stored-advisory)" — confirms v1 is store + surface only, v3 is the auto-apply milestone.
+- **[06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)** — federation boundary hardening; v1 implements rate-limiting and schema validation lines.
+- **[06 §4.7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md)** — fake federated attestations; v1 §7.2 is the per-actor rate-limit defence.
+- **[07 §5.2](../../docs/brehon-law-inspired-network/07-operations-and-federation.md)** — operator runbook for receiving sanction notices; v1's §6 endpoints are the API behind step 5 of that runbook.
+- **v1 carry-forward issues:** none directly federation-tagged but **issue #16 (admin config endpoint, OQ-018)** is the surface federation policy knobs ride on.
+
+---
+
+## 15. Phase 6 alignment notes
+
+### 15.1 What Phase 6 ships that v1 builds on
+
+| Phase 6 deliverable | v1 dependency |
+|---|---|
+| `SharedInboxActivities` enum with three governance variants (task 73) | v1 wraps the `Activity::receive` impls; does not re-route |
+| `receive_remote_sanction_notice`, `receive_remote_trust_attestation` (task 75) | v1 calls these from the wrapper unchanged |
+| `governance_log::append` const strings `federation_sanction_received`, `federation_attestation_received` (task 75) | v1 keeps these; adds `federation_label_received`, `federation_inbound_blocked`, `federation_inbound_dropped_*`, `federation_inbox_cross_linked`, `federation_inbox_dismissed`, `federation_peer_trust_changed`, `federation_inbound_storage_cap_evicted` |
+| `RemoteSanctionNotice`, `FederationAttestation` Diesel models with insert forms (task 71) | v1 extends with new columns + UpdateForm |
+| `ApubModerationLabel` AP object + protocol struct (task 72) | v1 implements the receive function (Phase 6 left it stubbed) |
+| HTTP signature verification via `activitypub_federation` (Lemmy code, trusted as-is per ADR-012) | v1 unchanged |
+
+### 15.2 Divergence between Phase 6 plan and v1 assumptions
+
+**Canonical preconditions list:** see §8.0. Any divergence the reviewer disagrees with must be pushed back before v1 migration runs. The DQ-6.1 and DQ-6.2 items below are now prescriptive — v1 assumes these landings; §8.0 lists them as preconditions #3 and (implicitly) as part of #2's "with all columns Phase 6 creates."
+
+| Item | Phase 6 design | v1 design | Why |
+|---|---|---|---|
+| `local_case_id` column | `INT REFERENCES moderation_case(id) ON DELETE SET NULL` (Phase 6 task 70) | Same; v1 does NOT change | Compatible |
+| `received_at` column on `remote_sanction_notice` | **Per §8.0 precondition #3**: Phase 6 ships `received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` resolving DQ-6.1. v1 assumes this landed. | v1 relies on it for admin review queries (§6.1 `age_days` filter) | Prescriptive — if DQ-6.1 landed differently, the §8.2 DO block aborts the migration and v1 re-plans. |
+| `signature` column | TEXT NOT NULL; Phase 6 stores empty string per task 75 GOTCHA (DQ-6.2) | v1 accepts the empty-string-for-now state; does not require resolving DQ-6.2 at v1 schedule time | DQ-6.2 carries forward — v1 stores signatures but does not depend on them being non-empty until v2 |
+| Idempotency / dedup | Phase 6 relies on Lemmy's `ReceivedActivity::create` dedup (DQ-6.3) | v1 adds a dedicated `federation_inbox_nonce` table for governance-specific replay window control | v1's nonce window is configurable; Lemmy's `ReceivedActivity` retention is separately controlled. Both fire — defence in depth |
+| Outbound peer targeting | `to_all_instances()` (Phase 6 task 74) | v1 leaves unchanged; `Blocklisted` peers still receive outbound (asymmetric) | v1 design choice: blocklisting an inbound peer doesn't necessarily mean we want to stop telling them about our decisions. v2 may add per-peer outbound block as a separate knob |
+| Test pattern | Direct-call into `Activity::receive` (Phase 6 task 77) | v1's wrapper changes the direct-call's behaviour — test must seed `federation_peer` with `Allowlisted` before calling | Test fixture update only |
+| HTTP route registration | None — Phase 6 says "No new REST route" | v1 adds 3 new REST routes for admin review | v1 explicitly adds the admin surface that Phase 6 §11 NOT-Building item #6 defers |
+
+### 15.3 Phase 6 design choices that limit v1 inbound design space
+
+1. **`source_instance` is TEXT, not FK to `instance.id`** on `remote_sanction_notice`. v1 must JOIN by domain string. Workable but case-sensitivity must be tested.
+2. **Outbound uses `to_all_instances()`.** v1 does not narrow this — v2 work. So a `Blocklisted` peer still receives our outbound activities; if this is a concern, the `Blocklisted` admin should know that asymmetry exists.
+3. **`PublishLabel::receive` is stubbed.** v1 fills it with the new handler; this is additive, not breaking.
+4. **No HTTP route layer changes in Phase 6.** v1 adds the admin endpoints but does NOT touch the inbound HTTP route — Phase 6's `SharedInboxActivities` registration already provides HTTP entry; v1 just wraps the receive impls.
+5. **`activitypub_federation` v0.7.0-beta.10** is the workspace pin per Phase 6. Replay-protection nonce table and HTTP-signature plumbing (DQ-FED-IN-1) work within this version's hooks. Upgrade is out of v1 scope.
+
+### 15.4 What Phase 6 explicitly defers to v1 (and v1 honours)
+
+From Phase 6 plan §"NOT Building":
+- ✅ Peer/instance allowlist table → v1 ships `federation_peer`
+- ✅ Federation rate-limiting per source → v1 ships §7
+- ✅ HTTP route for admin review → v1 ships §6
+- ✅ Undo activities → **NOT in v1 either** — deferred further (v1 ships only the v1 inbound surface; Undo wire-up is its own work, picked up in v1 follow-up or v2)
+- ✅ Outbound retry UX → unchanged (Lemmy's `sent_activity` queue retries)
+- ✅ SSRF-isolated media fetch worker → v2 (per [06 §2.5](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) and ADR-010)
+- ✅ Signed build artefacts → v2 (ADR-010)
+- ✅ Auto-apply of remote sanctions → v3 (ADR-006 + [05 §7.3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md))
+
+---
+
+## 16. Resolutions applied (2026-04-19)
+
+Cross-PRD coherence-audit edits applied during v1-PRD edit pass (see `.claude/PRPs/v1-planning-queue.json`):
+
+| ID | Severity | Scope | Status |
+|---|---|---|---|
+| **B5** | blocking | Phase 6 dependency formalised as **hard gate** + verify-before-migrate preamble SQL `DO` block. Migration timestamp invariant: "must sort after Phase 6's `add_federation_attestations`" — no specific date reserved. Prescriptive DQ-6.1 / DQ-6.2 references in §15.2. §1 frontmatter + §8 heading + §8.0 new subsection capture the gate. | done |
+| **N5** (collateral of B5) | non-blocking | §4.1 FK-shape vs §8.1 TEXT domain-string mismatch graduated from "noted, revisit at v1-impl" to "resolved at v1-impl time via explicit §8.0 precondition #6." Reviewer who disagrees with the TEXT-not-FK assumption must push back at PR review. | done |
+
+### Edits applied
+
+- **§1 frontmatter** — new `Scheduling:` line declaring the hard gate explicitly.
+- **§8 heading** renamed from `Database & migration changes` → `Dependencies, database & migration changes`.
+- **§8.0 Dependencies** — new subsection listing 7 preconditions (Phase 6 PR merged, 2 tables present, `received_at` column, enum types, entry_kind consts, TEXT-not-FK `source_instance`, timestamp invariant). Explicit STOP directive on unmet preconditions.
+- **§8.2 SQL preamble** — `DO $$ … $$;` block checks `federation_attestation` table presence, `remote_sanction_notice` table presence, `remote_sanction_notice.received_at` column presence; `RAISE EXCEPTION` on any missing element.
+- **§15.2 divergence table** — DQ-6.1 row rewritten to prescriptive tone ("per §8.0 precondition #3"); DQ-6.2 row tightened (v1 stores signatures but does not gate on non-empty until v2). Preamble note added pointing reviewers at §8.0 as canonical preconditions.
+- **Migration timestamp** — invariant ("must sort after Phase 6's `add_federation_attestations`") stated in §8.2; no specific 2026-04-22-style slot reserved, per user direction 2026-04-19.
+- **admin-dashboard-v1 §10.1** — cross-reference line added under the federation-inbound consumer row citing this hard gate (see admin-dashboard-v1 §11 Resolutions).
+
+---
+
+*Generated: 2026-04-19. Status: DRAFT — review before running `/prp-plan` against this PRD.*

--- a/.claude/PRPs/prds/v1-federation-inbound.prd.md
+++ b/.claude/PRPs/prds/v1-federation-inbound.prd.md
@@ -206,7 +206,7 @@ pub enum SharedInboxActivities {
 
 A thin **inbound wrapper** invoked from each governance `Activity::receive` impl, layered as:
 
-```
+```text
 shared_inbox HTTP entry
     │
     ├─ activitypub_federation: HTTP signature verify (Lemmy code; v1 unchanged)
@@ -259,7 +259,7 @@ Three new REST endpoints under `/api/v4/governance/admin/federation/*`. Authz: i
 Paginated list of advisory inbound rows across all three types.
 
 Request:
-```
+```http
 GET /api/v4/governance/admin/federation/inbox?type=sanction_notice&peer=peer.example&trust_level=untrusted_receive&age_days=7&page=1&limit=50
 ```
 
@@ -592,7 +592,7 @@ Newtypes in `crates/db_schema/src/newtypes.rs`: `FederationPeerId(pub i32)` (jus
 
 ### 9.1 Module layout (extending Phase 6's `crates/apub/apub/src/governance/`)
 
-```
+```text
 crates/apub/apub/src/governance/
 ├── mod.rs                  (Phase 6; re-export wiring)
 ├── inbox.rs                (Phase 6: receive_remote_*; v1 ADDS: wrap_governance_inbound, peer-trust + rate-limit + replay helpers)
@@ -603,7 +603,7 @@ crates/apub/apub/src/governance/
 
 The 3 admin endpoints are NOT in `crates/apub/`; they're standard governance handlers in `crates/api/api/src/governance/federation_inbox/`:
 
-```
+```text
 crates/api/api/src/governance/federation_inbox/
 ├── mod.rs
 ├── list_inbox.rs
@@ -820,7 +820,7 @@ v1 should append the following rows when this PRD lands:
 
 Recommended fork-local lint patterns (in `.claude/rules/` or similar) to prevent future drift:
 
-```
+```bash
 # No-auto-apply guard
 rg -A 5 "RemoteSanctionNotice::|RemoteModerationLabel::|FederationAttestation::" crates/api/api/ crates/api/api_crud/
 # Look for any insert with local_case_id = Some(_) NOT in the cross_link.rs handler
@@ -901,7 +901,7 @@ rg "receive_remote_(sanction_notice|trust_attestation|moderation_label)" crates/
 |---|---|
 | `SharedInboxActivities` enum with three governance variants (task 73) | v1 wraps the `Activity::receive` impls; does not re-route |
 | `receive_remote_sanction_notice`, `receive_remote_trust_attestation` (task 75) | v1 calls these from the wrapper unchanged |
-| `governance_log::append` const strings `federation_sanction_received`, `federation_attestation_received` (task 75) | v1 keeps these; adds `federation_label_received`, `federation_inbound_blocked`, `federation_inbound_dropped_*`, `federation_inbox_cross_linked`, `federation_inbox_dismissed`, `federation_peer_trust_changed`, `federation_inbound_storage_cap_evicted` |
+| `governance_log::append` const strings `federation_sanction_received`, `federation_attestation_received` (task 75) | v1 keeps these; adds `federation_label_received`, `federation_inbound_blocked`, `federation_inbound_dropped_*`, `federation_inbound_cross_linked`, `federation_inbound_dismissed`, `federation_peer_trust_changed`, `federation_inbound_storage_cap_evicted`. **Canonical prefix for all new governance-log `entry_kind` strings is `federation_inbound_*`** — matches §6.1 (cross-link) and §6.2 (dismiss). The `federation_inbox_*` prefix in this PRD is reserved for code identifiers (functions `federation_inbox_check_*`, tables `federation_inbox_dropped_log` / `federation_inbox_nonce`, enum `federation_inbox_admin_action_enum`) and must NOT be used as an `entry_kind` string literal. |
 | `RemoteSanctionNotice`, `FederationAttestation` Diesel models with insert forms (task 71) | v1 extends with new columns + UpdateForm |
 | `ApubModerationLabel` AP object + protocol struct (task 72) | v1 implements the receive function (Phase 6 left it stubbed) |
 | HTTP signature verification via `activitypub_federation` (Lemmy code, trusted as-is per ADR-012) | v1 unchanged |

--- a/.claude/PRPs/prds/v1-federation-inbound.prd.md
+++ b/.claude/PRPs/prds/v1-federation-inbound.prd.md
@@ -455,8 +455,19 @@ CREATE TABLE remote_sanction_notice (
 
 ```sql
 -- Preamble: verify Phase 6 preconditions present before ALTER.
+-- This DO block enforces preconditions #2, #3, #4, #6 from §8.0.
+-- Preconditions #1 (Phase 6 merge) and #7 (migration timestamp ordering) are
+-- NOT SQL-enforceable — #1 is a `git log` check run at `/prp-plan` time and #7
+-- is verified by the implementer naming the migration directory with a
+-- timestamp prefix that sorts after `add_federation_attestations`. Migration
+-- ordering inside a single `diesel migration run` is by directory-name sort,
+-- so a correct timestamp prefix guarantees Phase 6's tables exist when this
+-- DO block runs. Precondition #5 (`governance_log::append` const strings) is
+-- Rust-only and is enforced at compile time by `use` statements in the v1
+-- handler source — there is nothing to check in SQL.
 DO $$
 BEGIN
+  -- Precondition #2: Phase 6 base tables
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.tables
     WHERE table_name = 'federation_attestation'
@@ -469,11 +480,39 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 remote_sanction_notice table (not present)';
   END IF;
+  -- Precondition #3: DQ-6.1 received_at column on remote_sanction_notice
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name = 'remote_sanction_notice' AND column_name = 'received_at'
   ) THEN
     RAISE EXCEPTION 'federation-inbound-v1 assumes Phase 6 DQ-6.1 resolved with remote_sanction_notice.received_at column (not present)';
+  END IF;
+  -- Precondition #4: Phase 6 enum types registered
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'attestation_type_enum'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 attestation_type_enum (not registered)';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'sanction_action_enum'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 sanction_action_enum (not registered)';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'sanction_scope_enum'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 requires Phase 6 sanction_scope_enum (not registered)';
+  END IF;
+  -- Precondition #6: remote_sanction_notice.source_instance is TEXT (not FK).
+  -- v1's federation_peer JOIN requires this — if Phase 6 ships it as an INT
+  -- FK to instance(id), v1 §4.1 + §8.2 need re-planning.
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'remote_sanction_notice'
+      AND column_name = 'source_instance'
+      AND data_type = 'text'
+  ) THEN
+    RAISE EXCEPTION 'federation-inbound-v1 assumes remote_sanction_notice.source_instance is TEXT (peer domain); found different type. See §8.0 precondition #6 and §15.3.';
   END IF;
 END
 $$;

--- a/.claude/PRPs/prds/v1-jury-mechanics.prd.md
+++ b/.claude/PRPs/prds/v1-jury-mechanics.prd.md
@@ -114,7 +114,7 @@ Translated to v1 jury mechanics:
   - `geographic_diversity_preferred` (ON-effort by default; soft constraint).
   - `no_recent_juror_repeat` (ON by default; default cooldown 7 days, configurable).
 - Appeal jury — different + larger + original-jurors-excluded + higher-threshold-tier.
-- Original-reporter appeal-rights for `NoAction` / `Label` decisions (issue #11, scoped per OQ-V1-JM-06).
+- Original-reporter appeal-rights for `JuryDecision::NoAction` / `JuryDecision::AdvisoryLabel` decisions (issue #11, scoped per OQ-V1-JM-06). **Terminology note:** `AdvisoryLabel` is the `JuryDecision` enum variant (see `crates/db_schema_file/src/enums.rs:502`); `Label` is the `SanctionAction` it maps to (see `crates/api/api/src/governance/submit_jury_vote.rs:441`). Throughout this PRD, `AdvisoryLabel` refers to the decision; `Label` refers to the downstream sanction action.
 - Bounded appeal window (issue #15) with explicit `appeal_window_expires_at` column.
 - Re-jury path for `Appealed` cases (issue #14) — admin-triggered with default auto-select-on-appeal-acceptance.
 - Per-community concurrent-cap override + optional per-juror cap.
@@ -188,7 +188,7 @@ These defaults map directly onto [01 §5.6](../../docs/brehon-law-inspired-netwo
 
 Every tier × parameter combination is a config key in `governance_config`. The dotted namespace per OQ-026 / Phase 5a precedent:
 
-```
+```text
 jury.panel_size.regular.minor       (int, default 5)
 jury.panel_size.regular.moderate    (int, default 5)
 jury.panel_size.regular.severe      (int, default 7)
@@ -289,7 +289,7 @@ Each constraint is a per-community boolean toggle in `governance_config`. Select
 
 Extends `select_eligible_jurors` in `crates/api/api/src/governance/admin_assign_jury.rs:215-274`. The current strict-eligibility query at `:300-338` gets a two-phase wrapper. **Each constraint applies at a specific phase** (pool-build filter vs. panel-sample check vs. soft score) — the phase determines the relaxation semantics, so the distinction is load-bearing.
 
-```
+```text
 PHASE 1 — pool build (filter)
   build base eligible pool (existing v0 reputation gate + concurrent cap)
     ↓
@@ -525,7 +525,7 @@ These are TEXT additions only — no schema migration needed because `governance
 
 **9-step pseudocode** (user-provided 2026-04-19, B6 resolution):
 
-```
+```text
 submit_jury_vote(vote, context):
   1. Load case row (FOR UPDATE per v0 concurrency guard).
   2. Validate juror is assigned + hasn't already voted + case is in InReview.

--- a/.claude/PRPs/prds/v1-jury-mechanics.prd.md
+++ b/.claude/PRPs/prds/v1-jury-mechanics.prd.md
@@ -1,0 +1,802 @@
+# Sub-PRD: V1 Jury Mechanics — Configurable, Severity-Aware, Diversity-Constrained
+
+**Scope**: V1 release per [ADR-010](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md). Expands the v0 simplifications (5-juror panels, quorum 3, simple majority, no diversity, no severity thresholds) into a configurable, principled jury system. Adds appeal-jury, status-aware sizing, diversity constraints, and the severity tier mapping.
+**Created**: 2026-04-19
+**Status**: DRAFT
+**Scheduled**: V1 release per ADR-010 §7.1 (Governance mechanics block). Sequenced after v0 ships (`docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md` §7.1).
+**Predecessor**: v0 implementation in `crates/api/api/src/governance/{submit_jury_vote,admin_assign_jury,accept_jury_assignment,decline_jury_assignment}.rs`. v0 simplifications enumerated at [05 §3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md). v1 targets at [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) and [05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md).
+
+---
+
+## Problem Statement
+
+v0 ships a 5-juror, quorum-3, simple-majority jury that decides every case identically regardless of how serious the alleged offence is. That was deliberate (ADR-007) — the v0 question was *does the mechanic work?*, not *is it production-grade governance?*. v0 also has no diversity constraints, no juror cooldown, no appeal jury, and no notion of "founder" cases needing larger panels. Every case gets a 5-person random-weighted panel from the eligible pool.
+
+For v1 (production-grade governance), four real failure modes show up:
+
+1. **Severity blindness.** A `Label` sanction and an `InstanceSuspension` are decided by the same 3-of-5 simple majority. There is no proportionality to the consequence — a brigading minority of three jurors can land an instance suspension on the same threshold as a content label.
+2. **Cluster capture.** v0 has a one-hop sponsor-cluster conflict check on individual jurors but no panel-level diversity constraint — five jurors who all share the same sponsor are a perfectly valid panel.
+3. **Appeals are toothless.** v0's appeal flips the case to `Appealed` and waits for `admin_close_case`. There is no second jury, no larger panel, no original-juror exclusion, and no bounded window. Issues #11, #14, #15 carry these forward.
+4. **Hardcoded constants.** Panel size, quorum, deltas, cooldowns are partly config-driven (`jury.panel_size`, `jury.quorum`, `jury.max_concurrent_assignments`, etc.) but the *shape* of the jury (severity buckets, status awareness, diversity rules) is not configurable at all.
+
+V1 transforms these from "hardcoded mechanic" into "configurable mechanic with sensible Brehon-derived defaults" — communities tune within a safe envelope per the user framing 2026-04-19. The admin dashboard surfaces every knob; defaults inherit Brehon-honour-price intent (severity proportionality, kin-group diversity, status-aware procedure).
+
+**Primary actor** ([02 §2](../../docs/brehon-law-inspired-network/02-domain-model.md)): **Juror Eligible / Juror**, plus the **Defendant** (whose case severity determines panel shape) and the **Instance Admin** (whose dashboard knobs decide community defaults).
+
+---
+
+## Evidence
+
+- **v0 simplifications enumerated** at [05 §3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md) explicitly list every v0 deferral with the v1 target alongside it. The four v1 jury items appear verbatim at [05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md): jury size 5→7, severity-based voting thresholds, jury diversity constraints in selection, appeals with larger different jury (original jurors excluded).
+- **Brehon honour-price origin** of severity tiers at [01 §3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) principle 1: "Honor price — every person had a 'status value' they could lose" → "high-trust users suffer bigger consequences when wrong." [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) tabulates the v1 voting thresholds: Minor=simple majority, Moderate=60%, Severe=75% supermajority. [01 §5.7](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) tabulates appeals: one guaranteed appeal, larger jury, previous jurors excluded.
+- **OQ-026 status-aware extension pattern** at [99 OQ-026](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) explicitly anticipates the v1 use case: `jury.panel_size.founder vs jury.panel_size.regular`. Current lean: option (a) keyed-by-status rows with dotted namespace + reader-side cascade; v0 schema unchanged.
+- **OQ-004 resolved 2026-04-17** at [99 OQ-004](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md): concurrent cap = 3 instance-wide via `config.jury.max_concurrent_assignments`. v1 makes this per-community-overrideable and adds an optional per-juror cap.
+- **OQ-009 juror anonymity** at [99 OQ-009](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md): current lean is "anonymous to target/public always; revealed to each other after accepting; aggregate count public." v1 must address this concretely.
+- **GitHub issues** carry forward the four appeal/jury items from the Phase 5c carry-forward triage:
+  - #11 — original-reporter appeals (`request_appeal` rejects anyone except the sanction target).
+  - #14 — re-jury path for `Appealed` cases (v0 has no re-jury; case sits until admin closes).
+  - #15 — formalise appeal window with bounded duration (v0 defines window as `case.closed_at IS NULL`).
+  - #19 — community-scope `count_active_sanctions` in `get_my_reputation` (intersects with reputation-tuning v1, not jury-mechanics v1; cross-referenced).
+  - #29 — config-flip determinism when eligible pool > panel size (intersects with diversity selection algorithm).
+- **v0 implementation truth** verified in `crates/api/api/src/governance/`:
+  - `admin_assign_jury.rs:120` reads `jury.panel_size` from `governance_config` (already config-driven per Phase 5b task 57). The reputation gate at `:215-274` (`select_eligible_jurors`) reads `jury.max_concurrent_assignments` and `jury.fallback_on_small_pool`. v1 extends this surface, does not rewrite it.
+  - `submit_jury_vote.rs:85,87` hardcodes `QUORUM = 3` and `APPEAL_WINDOW_DAYS = 7` as Rust consts. v1 promotes both to config + per-case-snapshot semantics per ADR-010 (no retroactive invalidation).
+  - `request_appeal.rs:108` checks `case.closed_at.is_some()` as the appeal-window guard. v1 introduces explicit `appeal_window_expires_at`.
+  - `accept_jury_assignment.rs:120` uses `shares_active_sponsor` from `jury_common.rs` (one-hop only). v1 adds panel-level diversity (no-majority-from-same-sponsor-cluster).
+  - `sponsor_liability.rs:112-124` already has a `severity_for_action` mapping (Minor/Moderate/Severe) for sponsor-liability-delta lookup. **v1 reuses this mapping** for jury voting thresholds (single source of truth).
+
+---
+
+## ADRs That Govern This
+
+| ADR | Summary | How it constrains us |
+|---|---|---|
+| [ADR-005](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Reputation is multi-dimensional, event-sourced | Jury-eligibility weighting reads `jury_reliability` per existing `reputation_snapshot.jury_eligible` flag. v1 jury-selection extension adds NO new reputation dimensions. |
+| [ADR-007](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | MVP uses 5-juror, quorum-3, simple-majority | v1 supersedes ADR-007's *defaults*; the *machinery* (config-driven panel size) is preserved. v0 cases in flight when v1 ships still complete under ADR-007 rules — **see §11 backwards-compat**. |
+| [ADR-008](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Append-only signed governance log | Every config-relaxation (constraint relaxed because pool too small), severity reassignment (case-open time only), appeal-window decision, and appeal-rejury action emits a `governance_log` entry. |
+| [ADR-010](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Staged releases v0 → v1 → v2 → v3 | **Hard rule**: config changes MUST NOT retroactively invalidate in-flight juries. v1 panel size / quorum / threshold are snapshotted onto the case at jury-pick time, NOT re-read from config at vote-time. See §8 schema and §9 handler changes. |
+| [ADR-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Illegal-content emergency-remove | The post-facto jury for `EmergencyRemove` cases sizes and tiers per the same v1 machinery; severity = `Severe` by default (admin override is a mid-case status change, disallowed by ADR-010). |
+| [ADR-015](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Pseudonymised actor IDs | All `governance_log` entries from this PRD use `pseudonym`, never `person_id` / username — same discipline as `submit_jury_vote.rs` and `sponsor_liability.rs` today. |
+
+**Contradiction check**: None found. The v1 jury parameters are explicitly the upgrade path foreshadowed by ADR-007 → ADR-010 §7.1. Backwards-compat with in-flight v0 cases is enforced at the schema level (§8 panel-size snapshot column) per ADR-010.
+
+---
+
+## Open Questions Carried Forward & Newly Opened
+
+**Resolved by this PRD (proposed):**
+
+| OQ | Resolution proposed here | Migration path if accepted |
+|---|---|---|
+| **OQ-009** (juror anonymity in decision phase) | v1 commits: anonymous to target + public always; revealed to each other after accepting (matches the current lean). Concrete rendering: jury-room participant identifier = `Juror-<actor_pseudonym 4-char suffix>`. Aggregate count public per [02 §9](../../docs/brehon-law-inspired-network/02-domain-model.md). | Add to [02 §9 transparency boundary](../../docs/brehon-law-inspired-network/02-domain-model.md) at v1 ship; no schema change. |
+| **OQ-026** (status-aware rule extension) | Accept Option (a) — keyed-by-status dotted namespace `jury.panel_size.<status>.<severity>` in `governance_config`. v1 schema unchanged for `governance_config`; new keys only. | New rows in the Phase 5a config-seed migration; new `pub const` fallbacks in `crates/api/api/src/governance/config.rs`. |
+
+**Newly opened (this PRD):**
+
+| OQ | Question | v1 / v1.5 / parked |
+|---|---|---|
+| **OQ-V1-JM-01** — Severity tier inference | Who/what determines a case's severity tier — the reporter (capability-tagged), the alleged sanction shape, an admin overrider, or a content classifier? | v1 lean: reporter-suggested + admin-overridable at case-open time. Frozen on transition to `JurySelection`. See §3.2. |
+| **OQ-V1-JM-02** — Geographic diversity heuristic | Which signal proxies "geographic diversity" — `actor.timezone`, IP-region inference, declared community, or none? | v1 lean: declared community for cross-community jurors (where multi-community); IP-region inference rejected as PII surface; timezone deferred to v1.5 pending UX research. Constraint default = ON-effort (best-effort, not hard fail). |
+| **OQ-V1-JM-03** — Founder-status threshold for case-status determination | Does "founder case" mean the *defendant* is a founder, the *case-class* is founder-class, or both? | v1 lean: defendant status — a case with `target_person_id` of a founder (per `reputation_event.reason='founder_seed'` unexpired) gets `case_status_tier = Founder`. Case-class is a v1.5 question pending pilot data. |
+| **OQ-V1-JM-04** — Cross-instance juror eligibility | Can a juror on instance A serve on a case on instance B? | **Parked, v2 territory** per ADR-014 (federation interop limits). Flag don't decide. v1 commits: jurors are per-community; per-community is bounded to a single instance for v1. |
+| **OQ-V1-JM-05** — Re-jury auto vs admin trigger | When a case enters `Appealed`, does the appeal panel get auto-selected, or wait for admin trigger? | v1 lean: admin-triggered with default `appeal.auto_select_on_appeal_acceptance = true`. Communities can flip the bool to require manual admin assembly. See §6. |
+| **OQ-V1-JM-06** — Original-reporter appeal-rights scope | Issue #11 says original-reporter appeals; what is the scope? Reporter who appeals a `NoAction` decision? Reporter who appeals a too-light sanction? Both? | v1 lean: reporter-of-record can appeal **only** if decision was `NoAction` or `Label` (the lightest two outcomes), and only within the same appeal window as the defendant. Stricter scopes are v2. |
+
+---
+
+## §1 — Vision and goals
+
+**Brehon honour-price → severity tier mapping** (cite [01 §3 principle 1](../../docs/brehon-law-inspired-network/01-vision-and-principles.md)):
+
+> Every person had a "status value" they could lose. High-trust users suffer bigger consequences when wrong.
+
+Translated to v1 jury mechanics:
+
+- **Severity tiers** mirror the magnitude of the consequence the jury can impose. A `Label` is an annotation; an `InstanceSuspension` excludes the user from the platform. The procedural threshold for the latter must be higher.
+- **Status awareness** mirrors that the same offence by a high-trust user (founder, long-tenured Trusted Member) carries a larger reputation hit per [01 §5.2 honour-price floor footnote](../../docs/brehon-law-inspired-network/01-vision-and-principles.md). Cases against founders are higher-stakes; v1 sizes their panels accordingly.
+- **Diversity constraints** mirror the kin-group (`fine`) principle from [01 §4 principle 3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) — moderation starts local but must not concentrate in a single kin/sponsor cluster.
+
+**Configurable but principled** — defaults in this PRD are **starting points**, not gospel. The admin dashboard (cross-referenced) lets community groups experiment within a safe envelope: panel-size range 3–11, quorum 50%–100% of panel, threshold 50%–100% of votes. Defaults inherit Brehon-derived intent; communities tune within these bounds.
+
+**No retroactive invalidation** — ADR-010 hard rule. Once a jury is picked, that case's panel-size/quorum/threshold are *snapshotted* onto the case row. Subsequent config changes cannot retroactively change the rules under which a vote will be counted. This is critical for procedural legitimacy: a jury that began deliberating under a 60% threshold cannot have its threshold raised to 75% by a mid-case admin config change.
+
+---
+
+## §2 — Scope (in / out)
+
+**IN scope for v1:**
+
+- Severity-tier enum (`Minor | Moderate | Severe`) and a `severity_for_action(SanctionAction) → SeverityTier` mapping (extending the v0 `severity_for_action` already in `sponsor_liability.rs:112-124`).
+- Per-tier panel size, quorum, and voting threshold — all configurable, all defaulted from this PRD.
+- Status-aware panel sizing (`Founder | Regular | Probation`) using OQ-026's dotted namespace.
+- Jury diversity constraints in the `select_eligible_jurors` selection algorithm:
+  - `no_majority_from_same_sponsor_cluster` (ON by default).
+  - `geographic_diversity_preferred` (ON-effort by default; soft constraint).
+  - `no_recent_juror_repeat` (ON by default; default cooldown 7 days, configurable).
+- Appeal jury — different + larger + original-jurors-excluded + higher-threshold-tier.
+- Original-reporter appeal-rights for `NoAction` / `Label` decisions (issue #11, scoped per OQ-V1-JM-06).
+- Bounded appeal window (issue #15) with explicit `appeal_window_expires_at` column.
+- Re-jury path for `Appealed` cases (issue #14) — admin-triggered with default auto-select-on-appeal-acceptance.
+- Per-community concurrent-cap override + optional per-juror cap.
+- Constraint-relaxation audit log (which constraint was relaxed and why, when pool was too small).
+
+**OUT of scope for v1 (deferred):**
+
+- **Instance-wide juries** — always per-community. No "instance jury pool" sampled across communities. v0 reputation snapshot already supports both per-community (`community_id IS NOT NULL`) and instance-wide (`community_id IS NULL`); v1 keeps jury selection at the community level. Cross-community pool is v2.
+- **Cross-instance jury** (federated jury). v2 territory per ADR-014; OQ-V1-JM-04 flags don't decide.
+- **Juror identity reveal post-decision.** v0/v1 keeps jurors pseudonymous to the public always per ADR-015. v2/governance-research can revisit if pilot communities request it.
+- **Composable diversity constraints.** `no_majority_from_same_sponsor_cluster AND no_majority_from_same_endorsement_chain AND geographic_diversity_preferred AND ...` is a v1.5 composition surface. v1 ships each constraint as an independent boolean toggle; v1.5 may compose.
+- **Severity tier mid-case change.** Disallowed by ADR-010 (would effectively invalidate an in-flight jury). Severity is set at case-open time and frozen on transition to `JurySelection`.
+- **`no_same_endorsement_chain`** constraint. Default OFF in v1; needs deeper graph analysis (multi-hop endorsement traversal). v1.5.
+- **Severity-aware jury notification UX** (separate notification-routing PRD; OQ-005 territory).
+
+---
+
+## §3 — Severity tiers and thresholds
+
+### §3.1 Tier enum and mapping
+
+Three tiers, defined as a new Diesel-backed enum in `crates/db_schema_file/src/enums.rs`:
+
+```rust
+pub enum SeverityTier {
+    Minor,
+    Moderate,
+    Severe,
+}
+```
+
+The mapping `severity_for(sanction: &SanctionAction) -> SeverityTier` extends the existing function in `crates/api/api/src/governance/sponsor_liability.rs:112-124`. The two callers (sponsor-liability deltas and v1 jury thresholds) share the same source-of-truth function.
+
+| `SanctionAction` | Severity tier |
+|---|---|
+| `Label` | Minor |
+| `VisibilityReduction` | Minor |
+| `Restoration` | Minor (per OQ-003 amendment 2026-04-17 — restorative actions reserved as Minor) |
+| `TemporaryRestriction` | Moderate |
+| `ContentRemoval` | Moderate |
+| `CommunityExclusion` | Severe |
+| `InstanceSuspension` | Severe |
+| `FederationQuarantineRecommendation` | Severe |
+
+This is the v0 mapping; v1 does not change it. v1 *adds* the per-tier panel/quorum/threshold semantics on top of the existing severity bucket.
+
+### §3.2 Severity assignment timing — the "case severity is known before sanction shape" problem
+
+**Tension**: The jury is *picked* at case-open time, but the *sanction action* (which determines severity per §3.1) is only chosen by the jury at vote-tally time. So the panel must be sized *before* the severity is fully knowable.
+
+**v1 resolution**: Severity is a property of the **case**, set at case-open time, independent of which sanction the jury eventually picks. Two parallel resolutions, with the PRD picking the first:
+
+1. **(Chosen)** Severity is reporter-suggested + admin-overridable at case-open time. The reporter's `reason_code` carries an implicit severity (e.g. `harassment_severe` → Severe; `off_topic` → Minor). An admin or capability-tagged moderator can override. Once the case transitions to `JurySelection` (admin_assign_jury fires), the severity tier is **frozen** and snapshotted onto `moderation_case.severity_tier_snapshot` (see §8). This matches the OQ-V1-JM-01 lean.
+2. **(Rejected)** Panel sized for max-severity-possible. Always pick a Severe-tier panel; if jury votes for a Minor sanction, the threshold drops to Minor. Rejected because it inflates panel sizes (and juror cooldown depletion) for cases where the actual outcome turns out to be a `Label`.
+
+**Edge case — emergency-remove**: `admin_emergency_remove` (existing `crates/api/api/src/governance/admin_emergency_remove.rs:154`) opens a case with `severity = CaseSeverity::default()` (Medium) today. v1 sets `severity_tier_snapshot = Severe` for emergency-remove cases by default, with the rationale that the admin's invocation already constitutes a Severe-level action. The post-facto jury reviews under Severe-tier rules.
+
+### §3.3 Per-tier defaults
+
+Defaults are **starting points** — every value is configurable per-community via the dashboard.
+
+| Tier | Default panel size (regular) | Default quorum | Default threshold |
+|---|---|---|---|
+| Minor | 5 | 3 (60% of panel) | Simple majority (>50%) |
+| Moderate | 5 | 3 (60% of panel) | 60% supermajority |
+| Severe | 7 | 5 (~71% of panel) | 75% supermajority |
+
+These defaults map directly onto [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) which is the canonical v1 target table.
+
+### §3.4 Configurability surface
+
+Every tier × parameter combination is a config key in `governance_config`. The dotted namespace per OQ-026 / Phase 5a precedent:
+
+```
+jury.panel_size.regular.minor       (int, default 5)
+jury.panel_size.regular.moderate    (int, default 5)
+jury.panel_size.regular.severe      (int, default 7)
+jury.panel_size.founder.minor       (int, default 5)
+jury.panel_size.founder.moderate    (int, default 7)
+jury.panel_size.founder.severe      (int, default 9)
+jury.panel_size.probation.minor     (int, default 3)
+jury.panel_size.probation.moderate  (int, default 5)
+jury.panel_size.probation.severe    (int, default 5)
+
+jury.quorum_fraction.minor          (float, default 0.6)
+jury.quorum_fraction.moderate       (float, default 0.6)
+jury.quorum_fraction.severe         (float, default 0.71)
+
+jury.threshold_fraction.minor       (float, default 0.5001)   // simple majority — strict >50%
+jury.threshold_fraction.moderate    (float, default 0.6)
+jury.threshold_fraction.severe      (float, default 0.75)
+```
+
+**Bounds enforcement** (admin-dashboard PRD must enforce these on write):
+
+- `panel_size`: integer in `[3, 11]`, must be odd (avoids deadlocks).
+- `quorum_fraction`: float in `[0.5, 1.0]`, computed `quorum = ceil(panel_size * quorum_fraction)`.
+- `threshold_fraction`: float in `[0.5001, 1.0]`. `0.5001` is the canonical "simple majority" representation.
+
+Quorum and threshold are stored as **fractions** in config but **resolved to integer counts** at jury-pick time by `ceil(panel_size * fraction)`, then snapshotted onto the case row (see §8).
+
+### §3.5 Cascade fallback (per B2 2026-04-19)
+
+The 9-cell matrix coexists with v0's bare `jury.panel_size` key — the reader cascade operates in this order:
+
+1. `jury.panel_size.<status>.<severity>` — most specific (this PRD's new keys)
+2. `jury.panel_size.<severity>` — per-severity fallback (reserved; not seeded in v1)
+3. `jury.panel_size` — v0-compatible bare key (admin-dashboard-v1 §5.1 default = 7)
+4. Rust const `DEFAULT_JURY_PANEL_SIZE` — hardcoded final fallback
+
+This preserves v0 behaviour for existing call sites (e.g. `admin_assign_jury.rs:120`) during v1 rollout — communities can set a single number for everything (write `jury.panel_size = 9`) or tune per status × severity. Provenance on reads returns the full matched-key path so dashboard UX can show which cell in the cascade resolved the value (extends admin-dashboard §3.3's `effective_from` field).
+
+---
+
+## §4 — Jury sizing and status awareness
+
+### §4.1 Status enum
+
+Define `CaseStatusTier` (named to disambiguate from `CaseStatus` enum already at `crates/db_schema_file/src/enums.rs`):
+
+```rust
+pub enum CaseStatusTier {
+    Founder,
+    Regular,
+    Probation,
+}
+```
+
+### §4.2 Status determination
+
+Per OQ-V1-JM-03 lean:
+
+- **Founder**: `target_person_id` has at least one unexpired `reputation_event WHERE reason = 'founder_seed' AND expires_at > now()` (matches the existing `is_founder` check in `sponsor_liability.rs:217-228`).
+- **Probation**: `target_person_id` has `person.membership_state = 'provisional'` (per the Phase 5a `MembershipState` enum already shipped).
+- **Regular**: neither of the above.
+
+For cases with no `target_person_id` (post/comment/community-targeted), default to **Regular**.
+
+### §4.3 Status × severity sizing
+
+Resolution order for `panel_size`:
+
+1. Read `jury.panel_size.<status>.<severity>` from `governance_config` (community scope first, instance scope second per OQ-026 cascade).
+2. Fall back to Rust const default (declared in `crates/api/api/src/governance/config.rs`).
+
+**Probation cases use smaller panels by default** to enable faster turnaround for low-stakes provisional-member cases. **Founder cases use larger panels by default** because the consequences of getting it wrong (sanctioning a founder) are higher per [01 §5.2 honour-price footnote](../../docs/brehon-law-inspired-network/01-vision-and-principles.md).
+
+### §4.4 Quorum and threshold inherit severity, not status
+
+To bound the configuration combinatorics, **quorum and threshold are functions of severity only, not status**. A founder Severe case uses a 9-juror panel with quorum=`ceil(9*0.71)=7` and threshold=`ceil(7*0.75)=6`. A regular Severe case uses a 7-juror panel with quorum=5 and threshold=4.
+
+---
+
+## §5 — Diversity constraints
+
+### §5.1 Constraint catalog
+
+Each constraint is a per-community boolean toggle in `governance_config`. Selection algorithm (§5.3) consults each enabled constraint.
+
+| Constraint key | Default | Hard / Soft | Rationale |
+|---|---|---|---|
+| `jury.constraints.no_majority_from_same_sponsor_cluster` | ON | Hard (re-roll if violated) | Trace via `surety` table; >50% of panel sharing a sponsor would replicate v0's per-juror cluster check at the panel level. Maps to [01 §4 principle 3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) kin-group diversity. |
+| `jury.constraints.geographic_diversity_preferred` | ON-effort | Soft (best-effort, not hard fail) | Uses `community_id` declared affiliation; multi-community jurors preferred. Per OQ-V1-JM-02 lean — IP region rejected, timezone deferred. |
+| `jury.constraints.no_recent_juror_repeat` | ON | Hard | Prevents a small set of jurors from dominating community moderation. Default cooldown 7 days, configurable as `jury.constraints.juror_cooldown_days` (int, default 7). |
+| `jury.constraints.no_same_endorsement_chain` | OFF | Hard (when ON) | v1.5 — needs multi-hop graph analysis. Schema is in place (`endorsement` table) but query cost untested. |
+
+### §5.2 Cooldown semantics
+
+`no_recent_juror_repeat` excludes jurors who have a `jury_assignment` row with `responded_at > now() - cooldown_days * INTERVAL '1 day'` AND `status IN (Accepted, Submitted)` — i.e. they actively served (not declined) recently. The cooldown is per-community by default.
+
+### §5.3 Selection algorithm
+
+Extends `select_eligible_jurors` in `crates/api/api/src/governance/admin_assign_jury.rs:215-274`. The current strict-eligibility query at `:300-338` gets a two-phase wrapper. **Each constraint applies at a specific phase** (pool-build filter vs. panel-sample check vs. soft score) — the phase determines the relaxation semantics, so the distinction is load-bearing.
+
+```
+PHASE 1 — pool build (filter)
+  build base eligible pool (existing v0 reputation gate + concurrent cap)
+    ↓
+  apply `no_recent_juror_repeat` as SQL WHERE clause
+    (EXCLUDES recent jurors from the pool; the pool's size is the post-filter size)
+    ↓
+  IF pool_size < panel_size:
+    → relaxation step R1 (see cascade below); re-run pool build.
+
+PHASE 2 — panel sample (re-roll)
+  weighted-random sample `panel_size` candidates from the pool
+    ↓
+  check `no_majority_from_same_sponsor_cluster` on the SAMPLE:
+    ├── violated → re-roll (up to N_RETRIES, default 5)
+    └── satisfied → continue
+    ↓
+  IF still violated after N_RETRIES:
+    → relaxation step R2 (see cascade below).
+
+PHASE 3 — panel score (soft)
+  score the panel on `geographic_diversity_preferred` (weighted sum of unique countries)
+    ↓
+  bias sampling towards higher-scoring panels in Phase 2's re-roll loop
+    (soft — a panel with low diversity still returns; it just lost the coin toss against
+     a higher-diversity alternative during re-roll)
+```
+
+**Relaxation cascade (clearer intent than v0's "drop in priority order"):**
+
+| Step | Trigger | Action | Audit |
+|---|---|---|---|
+| **R1** | Phase 1: pool is too small post-cooldown to fill `panel_size`. | Drop `no_recent_juror_repeat` (expand the pool by lifting the cooldown WHERE clause) and re-run pool build. This is the cheapest relaxation — it expands the pool without compromising sponsor-cluster independence. | Emit `jury_constraint_relaxed` with `(case_id, constraint_dropped='no_recent_juror_repeat', reason='small_pool', phase='pool_build')`. |
+| **R2** | Phase 2: after N_RETRIES re-rolls the sample still violates `no_majority_from_same_sponsor_cluster`. | Drop `geographic_diversity_preferred` as a soft scoring input (so re-rolls become purely random rather than diversity-biased, which often helps break cluster ties) and re-try N_RETRIES re-rolls. | Emit `jury_constraint_relaxed` with `(case_id, constraint_dropped='geographic_diversity_preferred', reason='cluster_pressure', phase='panel_sample')`. |
+| **R3** | Phase 2 still fails after R2. | Drop `no_majority_from_same_sponsor_cluster` entirely and return the best-effort sample. This is the **last resort** because sponsor-cluster is the most Brehon-essential constraint. | Emit `jury_constraint_relaxed` with `(case_id, constraint_dropped='no_majority_from_same_sponsor_cluster', reason='cluster_pressure_exhausted', phase='panel_sample')` **AND** `tracing::warn!("jury selection dropped sponsor-cluster constraint on case {case_id}")`. |
+
+**Rationale for the order:** cooldown at pool-build is a per-user exclusion (lifting it just adds users); geographic diversity is already declared soft so removing its bias is a natural intermediate step; sponsor-cluster is the only constraint that prevents structural capture of the jury by a single sponsor network, so it sits at the bottom of the relaxation stack and its removal is both logged and `warn!`-surfaced.
+
+Each relaxation writes both a `governance_log` entry of kind `jury_constraint_relaxed` AND a `jury_constraint_violation_log` row (separate audit table per §9.2). Both are audit-visible to community admin via the modlog query; transparency replaces strict enforcement when the pool cannot support the constraint stack.
+
+If after R3 the pool is still smaller than `panel_size` and `jury.fallback_on_small_pool = true` (existing config), fall through to the v0 unfiltered legacy path at `admin_assign_jury.rs:349-370` (already implemented). If `fallback_on_small_pool = false`, return `NotFound` so the admin learns the pool is too small.
+
+### §5.4 Determinism note (cross-ref issue #29)
+
+Selection randomness is `ORDER BY random()` (existing `:328`). Issue #29 flags non-determinism when `eligible_pool_size > panel_size` makes config-flip assertions flaky. v1 does **not** make selection deterministic (random selection is the principle), but the v1 audit-log shape (which jurors were excluded, which constraints were relaxed) makes test assertions checkable on stable derived properties.
+
+---
+
+## §6 — Appeals (v1 first-class)
+
+### §6.1 Appeal panel sizing
+
+Default: appeal panel is **1.5× original panel size, rounded up**, with a minimum of `original_panel_size + 2`. So a 5-panel original gets a 7-juror appeal panel; a 7-panel original gets an 11-juror appeal panel (capped at the bounds in §3.4 = 11).
+
+Configurable as `appeal.panel_size_multiplier` (float, default 1.5) and `appeal.panel_size_floor_increment` (int, default 2).
+
+### §6.2 Original jurors excluded — hard rule, no override
+
+[01 §5.7](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) explicitly mandates: "Previous jurors are excluded from the appeal panel." This is **not configurable**. The `select_eligible_jurors` call for the appeal panel adds every original juror (every `jury_assignment` row for the case) to the `exclude_person_ids` list passed in. This is a hard rule in code, not in config.
+
+### §6.3 Appeal threshold — bump up one tier
+
+The appeal panel uses a **one-tier-higher threshold** than the original. So a Minor original (simple majority) appeals at 60%; a Moderate original appeals at 75%; a Severe original appeals at 75% (already at the top — no further bump). This is the "appeal raises the bar" principle.
+
+Configurable as `appeal.threshold_tier_bump` (int, default 1; range 0–2). Setting to 0 disables the bump.
+
+### §6.4 Original-reporter appeal-rights (issue #11)
+
+Per OQ-V1-JM-06 lean:
+
+- **Defendant** can always appeal (current v0 behaviour preserved).
+- **Original reporter** (the case `creator_id`) can appeal **only if** the decision was `JuryDecision::NoAction` or sanction `Label`. Rationale: a reporter has a legitimate grievance only when the system effectively dismissed their report.
+
+`request_appeal` extension in `crates/api/api_crud/src/governance/request_appeal.rs:108`:
+
+- Add `request_appeal.requester_role` field on the `Appeal` row (enum `Defendant | OriginalReporter`).
+- Eligibility check: defendant always; reporter only if `winning_decision IN (NoAction, AdvisoryLabel)`.
+- Both follow the same appeal window (§6.5).
+
+### §6.5 Appeal window (issue #15)
+
+v0 defines the window as `case.closed_at IS NULL` — implicit and unbounded. v1 introduces an **explicit, bounded window**:
+
+- New column `moderation_case.appeal_window_expires_at TIMESTAMPTZ` (NULL until decided).
+- On case decision (`submit_jury_vote.rs:272-280`), set `appeal_window_expires_at = decided_at + appeal.window_days * INTERVAL '1 day'`. Default 7 days (matches v0 `APPEAL_WINDOW_DAYS = 7`).
+- `request_appeal` checks `appeal_window_expires_at > now()` instead of `closed_at IS NULL`.
+- Configurable as `appeal.window_days` (int, default 7).
+
+**Interaction with sponsor-liability grace window (OQ-025)**: OQ-025 proposes a sponsor-liability grace window between `Decided` and the actual reputation_event write. v1 jury-mechanics reserves the appeal window column shape; sponsor-liability-v1 PRD (cross-referenced) decides how the two windows compose. Conservative interpretation: sponsor-liability grace runs in parallel to the appeal window with `min(appeal.window_days, sponsor_grace_days)` as the effective sponsor-grace duration, so a successful appeal can void the liability before grace expires.
+
+### §6.6 Re-jury path on appeal (issue #14)
+
+Currently `request_appeal` flips `Decided → Appealed` and the case sits until `admin_close_case` runs. v1 introduces auto re-jury:
+
+- New config key `appeal.auto_select_on_appeal_acceptance` (bool, default `true`).
+- When `true` and an appeal is filed, the same `request_appeal` transaction also calls `select_eligible_jurors` with the original-jurors-excluded list and seats the appeal panel as `JuryAssignmentStatus::Selected` (mirroring `admin_assign_jury`'s seating shape).
+- When `false`, the case sits in `Appealed` status until an admin runs the new `admin_trigger_appeal_rejury` handler (see §9.4).
+
+### §6.7 Appeal status state machine
+
+Existing `AppealStatus` enum already has `Requested | Accepted | Rejected | Decided`. v1 adds clarity:
+
+- `Requested` — appeal just filed, panel not yet seated.
+- `Accepted` — admin (or auto) accepted the appeal; panel is seated.
+- `Decided` — appeal panel returned a verdict.
+- `Rejected` — admin denied the appeal request (rare; logged with reason).
+
+The case `status` flow becomes `Decided → Appealed → Decided (again, with appeal verdict) → Closed` for accepted appeals; `Decided → Appealed → Closed` (no re-decision) for rejected appeals.
+
+---
+
+## §7 — Concurrent jury cap
+
+### §7.1 v0 baseline preserved
+
+OQ-004 resolved at instance-wide cap = 3 via `config.jury.max_concurrent_assignments`. This stays as the **instance default**.
+
+### §7.2 v1 extensions
+
+- **Per-community override**: `jury.max_concurrent_assignments` is already config-cascade-capable (community → instance → const). v1 adds no new key; communities can set the per-community row via the admin dashboard (admin-dashboard-v1 PRD §3 surface).
+- **Per-juror cap (optional)**: New key `jury.max_concurrent_assignments_per_juror_total` (int, default 2). This is the cross-community cap — a juror cannot be on more than N active assignments **total** across all communities. Default 2 because a juror serving on 3 simultaneous panels in different communities is plausibly overcommitted.
+  - When NULL/unset, no cross-community cap is applied (preserves v0 behaviour).
+  - When set, the eligibility query in `select_eligible_jurors` adds an additional NOT IN subquery counting all-communities active assignments for the candidate juror.
+- **Instance-admin can set instance-wide cap separately from per-community cap**. The cascade resolution in `config::get_int` already does this — no extra machinery.
+
+### §7.3 Cross-community jury load balancing
+
+Communities with high case volume can raise their per-community cap (e.g. to 5) while the instance-wide cap stays at 3. The per-juror cross-community cap (`per_juror_total = 2`) prevents a single juror from absorbing the higher load — they'd get distributed across the eligible pool.
+
+---
+
+## §8 — Database & migration changes
+
+### §8.1 New columns on `moderation_case`
+
+Per ADR-010 (no retroactive invalidation), the panel-size / quorum / threshold / severity must be **snapshotted** at jury-pick time, not re-read from config at vote-time.
+
+```sql
+ALTER TABLE moderation_case
+  ADD COLUMN severity_tier severity_tier NOT NULL DEFAULT 'Minor',
+  ADD COLUMN status_tier case_status_tier NOT NULL DEFAULT 'Regular',
+  ADD COLUMN panel_size_snapshot INTEGER,             -- snapshot at admin_assign_jury time
+  ADD COLUMN quorum_snapshot INTEGER,                 -- snapshot at admin_assign_jury time
+  ADD COLUMN threshold_count_snapshot INTEGER,        -- snapshot at admin_assign_jury time
+  ADD COLUMN appeal_window_expires_at TIMESTAMPTZ;    -- set at submit_jury_vote time
+```
+
+Where `severity_tier` and `case_status_tier` are new Postgres enums, mirrored as `diesel-derive-enum` types in `crates/db_schema_file/src/enums.rs`.
+
+`panel_size_snapshot`, `quorum_snapshot`, `threshold_count_snapshot` are NULL until `admin_assign_jury` seats the panel; from that moment they are immutable.
+
+`appeal_window_expires_at` is NULL until the case is decided; from that moment the appeal window is bounded.
+
+### §8.2 New columns on `jury_assignment`
+
+```sql
+ALTER TABLE jury_assignment
+  ADD COLUMN selected_under_constraints JSONB,        -- which constraints were applied at pick
+  ADD COLUMN role jury_assignment_role NOT NULL DEFAULT 'Original'; -- enum: Original | Appeal
+```
+
+`selected_under_constraints` example payload (Watch 10 PII discipline — no person_ids, only constraint names):
+
+```json
+{
+  "no_majority_from_same_sponsor_cluster": "applied",
+  "geographic_diversity_preferred": "applied_soft",
+  "no_recent_juror_repeat": "relaxed_small_pool",
+  "no_same_endorsement_chain": "disabled"
+}
+```
+
+`role` distinguishes original-jury rows from appeal-jury rows on the same case (since both reference the same `case_id`). Used by the appeal-panel exclusion logic in §6.2.
+
+### §8.3 New table — `jury_constraint_violation_log`
+
+```sql
+CREATE TABLE jury_constraint_violation_log (
+  id SERIAL PRIMARY KEY,
+  case_id INTEGER NOT NULL REFERENCES moderation_case (id) ON DELETE CASCADE,
+  constraint_name TEXT NOT NULL,
+  relaxation_reason TEXT NOT NULL,                 -- 'small_pool', 'admin_override', etc.
+  pool_size_at_relax INTEGER NOT NULL,
+  panel_size_target INTEGER NOT NULL,
+  relaxed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_jcvl_case_id ON jury_constraint_violation_log (case_id);
+```
+
+Persisted alongside the `governance_log` `jury_constraint_relaxed` entry — the `governance_log` is the tamper-evident record; this table is the queryable index for the admin dashboard's "show constraint relaxations" view.
+
+### §8.4 Backfill migration for v0 → v1
+
+In-flight v0 cases (status `Open | ThresholdMet | JurySelection | InReview | Decided | Appealed`) at the moment of v1 ship MUST complete under v0 rules per ADR-010. The backfill migration:
+
+```sql
+UPDATE moderation_case
+SET severity_tier = 'Minor',
+    status_tier = 'Regular',
+    panel_size_snapshot = 5,
+    quorum_snapshot = 3,
+    threshold_count_snapshot = 3,    -- 3-of-5 simple majority
+    appeal_window_expires_at = COALESCE(closed_at, decided_at + INTERVAL '7 days')
+WHERE severity_tier IS NULL OR panel_size_snapshot IS NULL;
+```
+
+After the backfill, every existing case has a v0-equivalent snapshot. The handlers (§9) will read these snapshots, not the new config, so v0 cases continue to behave as if v1 hadn't shipped. New cases post-v1-ship use the new config-driven snapshot at admin_assign_jury time.
+
+### §8.5 New `governance_log` entry kinds
+
+Add to `crates/api/api/src/governance/governance_log.rs:50-68`:
+
+```rust
+pub const ENTRY_KIND_JURY_CONSTRAINT_RELAXED: &str = "jury_constraint_relaxed";
+pub const ENTRY_KIND_APPEAL_PANEL_ASSEMBLED: &str = "appeal_panel_assembled";
+pub const ENTRY_KIND_APPEAL_DECIDED: &str = "appeal_decided";
+pub const ENTRY_KIND_APPEAL_REJECTED: &str = "appeal_rejected";
+pub const ENTRY_KIND_APPEAL_WINDOW_EXPIRED: &str = "appeal_window_expired";
+pub const ENTRY_KIND_SEVERITY_TIER_FROZEN: &str = "severity_tier_frozen";
+```
+
+These are TEXT additions only — no schema migration needed because `governance_log.entry_kind` is `String` per `crates/db_schema/src/source/governance/governance_log.rs:23-44` (V2 messaging PRD verified this property; v1 jury-mechanics inherits it).
+
+---
+
+## §9 — Handler changes
+
+### §9.1 `submit_jury_vote` — combined 9-step handler (jury-mechanics + sponsor-liability integrated)
+
+`crates/api/api/src/governance/submit_jury_vote.rs`:
+
+**Why this section owns the combined shape.** v1 jury-mechanics changes the decision point itself (quorum snapshot, threshold vs simple-majority, deadlock-to-AdminReview), and v1 sponsor-liability adds a post-decision lifecycle branch (`SponsorLiabilityPending` status, grace-window compute, deferred public_log + juror rep events) on top. Fragmenting the integrated pseudocode across two PRDs left five unanswered cross-cutting questions (see `.claude/PRPs/v1-planning-queue.json` B6 `context`). This section owns the combined 9-step shape; the sponsor-liability-v1 PRD §9.3 reduces to a pointer. The compute/fire split (§9.1 of sponsor-liability-v1) and the grace-window scheduler helper module (§9.4 of sponsor-liability-v1) remain sponsor-liability's concerns — this section just declares **when** the compute fires and **what status transitions follow**.
+
+**9-step pseudocode** (user-provided 2026-04-19, B6 resolution):
+
+```
+submit_jury_vote(vote, context):
+  1. Load case row (FOR UPDATE per v0 concurrency guard).
+  2. Validate juror is assigned + hasn't already voted + case is in InReview.
+  3. Insert jury_vote row.
+  4. Tally: read all jury_vote rows for this case.
+  5. Threshold check (v1 new):
+     - quorum      = case.quorum_snapshot             (set at admin_assign_jury time per §9.2)
+     - threshold   = case.threshold_count_snapshot    (set at admin_assign_jury time per §9.2)
+     - if any decision has >= threshold votes:
+         winning_decision = that decision; continue to step 6.
+     - elif all jurors have voted AND no decision reached threshold (deadlock):
+         flip case.status to CaseStatus::AdminReview;
+         emit governance_log entry jury_deadlock;
+         return SubmitJuryVoteResponse { vote_recorded: true, case_decided: false, decision: None }.
+     - else (partial tally, no threshold met yet):
+         return SubmitJuryVoteResponse { vote_recorded: true, case_decided: false, decision: None };
+         case stays InReview.
+  6. Winning decision reached. Insert sanction rows per winning_decision
+     (one or more sanction rows via the existing sanction-insert helper).
+  7. Sponsor-liability branch (per sponsor-liability-v1 §9.3 semantics):
+     - if sanction has liability implications (winning_decision != NoAction AND
+       severity-tier maps to a sponsor-liability grade) AND target has active sponsors:
+         deltas = sponsor_liability::compute_sponsor_liability(conn, target, case_id, …);
+         (compute/fire split per sponsor-liability-v1 §9.1 — compute only, no event rows yet)
+         grace_expires_at = now() + grace_window_for_severity(severity);
+         update moderation_case
+           SET status = CaseStatus::SponsorLiabilityPending,
+               grace_expires_at = grace_expires_at,
+               decided_at = now();
+         emit governance_log entry sponsor_liability_pending
+           { case_id, grace_expires_at, sponsor_count: deltas.len(), severity };
+         for delta in deltas: notify_sponsor_of_pending_liability(conn, delta, case_id, grace_expires_at);
+         // DEFERRED to scheduler fire/escape time (per sponsor-liability-v1 §11.4):
+         //   - public_case_log entry
+         //   - juror reputation_events (aligned/outlier)
+         //   - reporter reputation_event (upheld/dismissed)
+         //   - case_decided governance_log entry
+         // jump to step 9 for appeal_window_expires_at bound.
+         return SubmitJuryVoteResponse { vote_recorded: true, case_decided: true, decision: Some(winning_decision) }.
+  8. No-sponsor / NoAction path (v0 lifecycle preserved):
+     - update moderation_case
+         SET status = CaseStatus::Decided,
+             decided_at = now(),
+             closed_at = now();
+     - write public_case_log entry (immediate, not deferred);
+     - write juror reputation_events (aligned/outlier) and reporter reputation_event;
+     - emit case_decided governance_log entry;
+     - jump to step 9.
+  9. Appeal window bound (v1 new — per appeal.window_days):
+     - window_days = config::get_int(..., "appeal.window_days").await?;   // read at decision time
+     - appeal_window_expires_at = decided_at + Duration::days(window_days);
+     - update moderation_case SET appeal_window_expires_at = appeal_window_expires_at;
+     - (This step fires on BOTH the SponsorLiabilityPending path AND the no-sponsor Decided
+        path. It composes with sponsor-liability §6.5 min(appeal_window_expires_at, grace_expires_at)
+        semantics: the sponsor can be pulled back by revocation during the grace window OR an
+        admin/defendant can lodge an appeal during the appeal window — whichever comes first in
+        the timeline.)
+     - return SubmitJuryVoteResponse as per the branch taken above.
+```
+
+**Golden-path-test impact (test-strategy sub-note):** the v0 `report_to_modlog_golden_path` integration test uses an unsponsored target → step 8 no-sponsor path → public_case_log fires immediately → existing test assertions preserved. The v1 sponsored-target test is a **v1-impl follow-up** (new test, not a modification of the golden path): it asserts that for a sponsored target, (a) the case transitions to `SponsorLiabilityPending` with `grace_expires_at` set, (b) `public_case_log` does NOT fire at vote-tally time, (c) `case_decided` governance_log entry does NOT fire at vote-tally time, and (d) both fire at the scheduler's fire-or-escape transition.
+
+**Cross-references within v1:**
+- **SponsorLiabilityPending branch semantics** are specified in detail by `v1-sponsor-liability.prd.md` §9.3 (which now points here for the combined handler shape) and §6 (grace-window scheduler `run_grace_check_batch`).
+- **`compute_sponsor_liability` vs `fire_sponsor_liability`** (the compute/fire split) is specified by `v1-sponsor-liability.prd.md` §9.1; this §9.1 only declares when the compute phase fires (step 7).
+- **`grace_window_for_severity` helper module** is specified by `v1-sponsor-liability.prd.md` §9.4.
+- **`appeal.window_days` knob** is owned by this PRD (§10); read at decision time (step 9), NOT snapshotted, per ADR-010's no-retroactive-invalidation-of-procedural-rules-of-the-*past*-vote reading. Changing `appeal.window_days` mid-flight affects windows for cases decided after the change, not cases already decided.
+- **`quorum_snapshot` / `threshold_count_snapshot`** are set by `admin_assign_jury` at the moment of jury assembly (per §9.2); they are fixed for the life of the case per ADR-010. Admin retuning of `jury.panel_size` or `jury.*_fraction` mid-flight does NOT affect cases already in `InReview`.
+
+**Status transitions summary** (v0 → v1 reshape):
+- `InReview` → `Decided` (no-sponsor branch, step 8) — unchanged from v0.
+- `InReview` → `SponsorLiabilityPending` (sponsor branch, step 7) — new in v1.
+- `InReview` → `AdminReview` (deadlock, step 5) — new in v1 (reactivates existing dead `CaseStatus::AdminReview` enum variant per V2 messaging PRD §Q3 finding).
+- (Scheduler then transitions `SponsorLiabilityPending` → `SponsorLiabilityFired` | `SponsorLiabilityEscaped` per sponsor-liability-v1 §6.1 / §6.2; those are out of this handler's scope but in-scope for the combined lifecycle shape.)
+
+### §9.2 `admin_assign_jury` — size, snapshot, and apply diversity
+
+`crates/api/api/src/governance/admin_assign_jury.rs`:
+
+- **Read** `case.severity_tier` and `case.status_tier` at line 119 (replacing the singular `jury.panel_size` read).
+- **Compute** `panel_size` via a new cascade helper `config::get_int_cascade(&["jury.panel_size", &status_str, &severity_str])` (per §3.5) that walks the cascade `jury.panel_size.<status>.<severity>` → `jury.panel_size.<severity>` → `jury.panel_size` → Rust const. Same pattern for `quorum_fraction` and `threshold_fraction`. Resolve `quorum = ceil(panel_size * quorum_fraction)`, `threshold_count = ceil(panel_size * threshold_fraction)`. Do NOT call `get_int("jury.panel_size.<status>.<severity>")` directly — that skips the cascade and returns Err on partial seeding.
+- **Snapshot** these onto the case: `update(moderation_case::table)... .set((moderation_case::panel_size_snapshot.eq(panel_size_i32), ...))`.
+- **Pass** the active diversity-constraint set into `select_eligible_jurors` as a new parameter.
+- **Emit** `governance_log` entry `severity_tier_frozen` at the moment of snapshot (audit trail).
+
+`select_eligible_jurors` (same file, `:215-274`) gains:
+
+- A new `constraints: ConstraintSet` parameter.
+- The constraint application logic per §5.3 (cooldown filter, sponsor-cluster panel-level check with re-roll, soft geographic diversity scoring).
+- The relaxation cascade per §5.3, with each relaxation writing both a `governance_log` entry (`jury_constraint_relaxed`) and a `jury_constraint_violation_log` row.
+
+### §9.3 `request_appeal` — bounded window, reporter-rights, auto re-jury
+
+`crates/api/api_crud/src/governance/request_appeal.rs`:
+
+- **Replace** `if case.closed_at.is_some()` (line 105) with `if case.appeal_window_expires_at.is_none() || case.appeal_window_expires_at.unwrap() < now()`.
+- **Extend** caller eligibility (line 110): defendant always; reporter only if `case_decision IN (NoAction, AdvisoryLabel)`. Reporter eligibility requires loading the winning decision from the latest `jury_vote` rows OR adding a `winning_decision` column to `moderation_case` for queryability. **Recommendation**: add `moderation_case.winning_decision JuryDecision NULL` set by `submit_jury_vote` at line 272 (cross-references issue #19 / GovernanceModlogView Phase 2b drift resolutions).
+- **On appeal accepted** and `appeal.auto_select_on_appeal_acceptance = true`: in the same transaction, call a new helper `select_appeal_panel(case, original_jurors)` that re-runs `select_eligible_jurors` with the original jurors added to `exclude_person_ids` and the **next-tier** threshold/panel size per §6. Snapshot the appeal panel's parameters onto a new column or row (TBD — see §8.2 `jury_assignment.role = 'Appeal'`).
+- **Emit** `governance_log` entry `appeal_panel_assembled` with the new panel pseudonyms.
+
+### §9.4 New handler — `admin_trigger_appeal_rejury`
+
+For the `appeal.auto_select_on_appeal_acceptance = false` configuration path. New file `crates/api/api/src/governance/admin_trigger_appeal_rejury.rs`:
+
+- Admin-only (`is_admin` check).
+- Input: `AdminTriggerAppealRejury { case_id }`.
+- Loads the case; verifies status is `Appealed` and no Appeal-role jury_assignment rows exist yet.
+- Calls the same `select_appeal_panel` helper as §9.3.
+- Emits `appeal_panel_assembled` log entry attributed to the admin.
+
+Route: `POST /api/v4/governance/admin/trigger-appeal-rejury`.
+
+### §9.5 New background job — appeal-window expiry
+
+A periodic job (mirrors the existing `expired sanction cleanup` job pattern in `crates/server/src/governance.rs`) that:
+
+- Finds cases where `status = Decided AND appeal_window_expires_at < now()`.
+- Flips them to `Closed`.
+- Emits `appeal_window_expired` log entry.
+
+### §9.6 `admin_emergency_remove` — Severe by default
+
+`crates/api/api/src/governance/admin_emergency_remove.rs:153`:
+
+- **Set** `severity_tier = SeverityTier::Severe` (matches §3.2 edge case).
+- The post-facto jury then gets sized per `jury.panel_size.regular.severe` (default 7) automatically via `admin_assign_jury` reuse pattern.
+
+---
+
+## §10 — Default values matrix
+
+Every knob introduced or modified by this PRD. Source-doc citations point to where the default is justified.
+
+| Knob | Namespace key | Type | Default | Range / Bounds | Per-community? | Requires re-jury? | Source citation |
+|---|---|---|---|---|---|---|---|
+| Panel size — Regular Minor | `jury.panel_size.regular.minor` | int | 5 | [3, 11] odd | yes | no (snapshotted) | [05 §3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md) v0 baseline preserved |
+| Panel size — Regular Moderate | `jury.panel_size.regular.moderate` | int | 5 | [3, 11] odd | yes | no | [05 §3](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md), v0 baseline |
+| Panel size — Regular Severe | `jury.panel_size.regular.severe` | int | 7 | [3, 11] odd | yes | no | [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) v1 target |
+| Panel size — Founder Minor | `jury.panel_size.founder.minor` | int | 5 | [3, 11] odd | yes | no | OQ-026 status-aware extension |
+| Panel size — Founder Moderate | `jury.panel_size.founder.moderate` | int | 7 | [3, 11] odd | yes | no | OQ-026; founder cases higher-stakes |
+| Panel size — Founder Severe | `jury.panel_size.founder.severe` | int | 9 | [3, 11] odd | yes | no | OQ-026; founder × Severe = max-care |
+| Panel size — Probation Minor | `jury.panel_size.probation.minor` | int | 3 | [3, 11] odd | yes | no | OQ-026; probation = faster turnaround |
+| Panel size — Probation Moderate | `jury.panel_size.probation.moderate` | int | 5 | [3, 11] odd | yes | no | OQ-026 |
+| Panel size — Probation Severe | `jury.panel_size.probation.severe` | int | 5 | [3, 11] odd | yes | no | OQ-026 |
+| Quorum fraction — Minor | `jury.quorum_fraction.minor` | float | 0.6 | [0.5, 1.0] | yes | no | derived: 3-of-5 v0 baseline = 60% |
+| Quorum fraction — Moderate | `jury.quorum_fraction.moderate` | float | 0.6 | [0.5, 1.0] | yes | no | mirrors Minor for v1 |
+| Quorum fraction — Severe | `jury.quorum_fraction.severe` | float | 0.71 | [0.5, 1.0] | yes | no | derived: 5-of-7 = 71% |
+| Threshold fraction — Minor | `jury.threshold_fraction.minor` | float | 0.5001 | [0.5001, 1.0] | yes | no | [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) simple majority |
+| Threshold fraction — Moderate | `jury.threshold_fraction.moderate` | float | 0.6 | [0.5001, 1.0] | yes | no | [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) 60% |
+| Threshold fraction — Severe | `jury.threshold_fraction.severe` | float | 0.75 | [0.5001, 1.0] | yes | no | [01 §5.6](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) 75% supermajority |
+| Diversity — sponsor cluster | `jury.constraints.no_majority_from_same_sponsor_cluster` | bool | true | true / false | yes | no | [01 §4 principle 3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) kin-group |
+| Diversity — geographic | `jury.constraints.geographic_diversity_preferred` | bool | true | true / false | yes | no | OQ-V1-JM-02 lean |
+| Diversity — recent juror repeat | `jury.constraints.no_recent_juror_repeat` | bool | true | true / false | yes | no | OQ-V1-JM-02 anti-capture |
+| Juror cooldown days | `jury.constraints.juror_cooldown_days` | int | 7 | [0, 90] | yes | no | tunable per community size |
+| Diversity — endorsement chain | `jury.constraints.no_same_endorsement_chain` | bool | false | true / false | yes | no | v1.5 deferred (graph cost) |
+| Selection retries | `jury.constraints.max_retries_before_relax` | int | 5 | [1, 20] | yes | no | Operational tuning |
+| Per-juror cross-community cap | `jury.max_concurrent_assignments_per_juror_total` | int | 2 | [1, 10] | no (instance only) | no | §7.2 derived from cap=3 baseline |
+| Appeal panel multiplier | `appeal.panel_size_multiplier` | float | 1.5 | [1.0, 3.0] | yes | no | [01 §5.7](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) "larger jury" |
+| Appeal panel floor increment | `appeal.panel_size_floor_increment` | int | 2 | [0, 6] | yes | no | §6.1 minimum increment |
+| Appeal threshold tier bump | `appeal.threshold_tier_bump` | int | 1 | [0, 2] | yes | no | §6.3 "appeal raises bar" |
+| Appeal window days | `appeal.window_days` | int | 7 | [1, 90] | yes | no | matches v0 hardcoded `APPEAL_WINDOW_DAYS = 7` |
+| Auto re-jury on appeal | `appeal.auto_select_on_appeal_acceptance` | bool | true | true / false | yes | no | §6.6 default behaviour |
+
+**Knobs preserved from v0 (no change in v1, listed for completeness)**:
+
+| Knob | Namespace key | v0 default | v1 status |
+|---|---|---|---|
+| Concurrent cap | `jury.max_concurrent_assignments` | 3 | unchanged; per-community override now operationally relevant |
+| Fallback on small pool | `jury.fallback_on_small_pool` | true | unchanged; still the final fallback after constraint-relaxation cascade |
+| Reputation gate min | `thresholds.jury_reliability` | 50 | unchanged in this PRD; reputation-tuning-v1 PRD owns this |
+
+**Total new knobs introduced by this PRD: 25.**
+
+---
+
+## §11 — Backwards compatibility with v0 cases
+
+Per ADR-010 hard rule: config changes MUST NOT retroactively invalidate in-flight juries.
+
+**Mechanism**: the snapshot columns added in §8.1 (`panel_size_snapshot`, `quorum_snapshot`, `threshold_count_snapshot`, `severity_tier`, `status_tier`). The migration at §8.4 backfills these for every pre-v1 case.
+
+**Behaviour after v1 ships**:
+
+- A v0 case in `JurySelection` with 5 already-seated jurors continues with `quorum_snapshot=3`, `threshold_count_snapshot=3`, `severity_tier=Minor`. `submit_jury_vote` reads the snapshot, not the new config. The case completes under v0 rules.
+- A v0 case in `Decided` waiting for appeal gets `appeal_window_expires_at = decided_at + 7 days` from the backfill. If the appeal window had already expired by v1-ship date, the case is also flipped to `Closed` by the backfill (additional `WHERE decided_at + INTERVAL '7 days' < now()` clause).
+- New cases opened post-v1-ship use the new config and the new snapshot machinery from `admin_assign_jury` onward.
+
+**Test invariant**: A separate integration test in `tests/e2e.rs` named `v0_case_completes_under_v0_rules_after_v1_config_flip` opens a case under v0 defaults, mid-flight flips the v1 config to wildly different values (e.g. `panel_size=11, threshold=0.95`), and asserts the case still concludes with the v0 3-of-5 simple-majority rule per the snapshot.
+
+---
+
+## §12 — Security
+
+### §12.1 Severity tier assignment requires capability + audit
+
+- Severity tier set at case-open time can be:
+  - **Reporter-suggested** (default behaviour) — derived from `reason_code` + community policy mapping; no capability check.
+  - **Capability-tagged moderator override** — the `trusted_reporter` reputation flag (existing `reputation_snapshot.trusted_reporter`) is repurposed as the severity-override capability. A trusted reporter can override the suggested severity; their override is logged.
+  - **Admin override** — instance admin can override at any time before `JurySelection`. Logged.
+- Every severity change emits a `governance_log` entry tagged `severity_tier_assigned` (initial) or `severity_tier_overridden` (subsequent), with the reason_code, prior tier, new tier, actor pseudonym.
+- Severity tier is **frozen** on transition to `JurySelection`. The `severity_tier_frozen` log entry is the canonical "after this point, no change is procedurally legitimate" marker.
+
+### §12.2 Constraint relaxation requires audit-log entry visible to community admin
+
+Each relaxation in §5.3 emits both:
+
+- A tamper-evident `governance_log` entry of kind `jury_constraint_relaxed`.
+- A queryable `jury_constraint_violation_log` row.
+
+The community admin's dashboard (cross-referenced) surfaces these in a "Why was a constraint relaxed?" section. **Operators cannot silently relax constraints**; transparency replaces strict enforcement.
+
+### §12.3 Step-up auth for severity-tier changes mid-case
+
+ADR-010 disallows mid-case severity changes (would re-jury). v1 enforces:
+
+- After `JurySelection`, severity-tier updates are **rejected at the API level** with `ErrorMethodNotAllowed`. The only path to "change severity mid-case" is to close the case and open a new one (which is a separate audit event).
+- The `severity_tier_frozen` log entry serves as the immutability marker; any later attempt to update `moderation_case.severity_tier` triggers a database-level CHECK constraint failure (recommended) or handler-level rejection.
+
+### §12.4 Appeal-rights spoofing protection
+
+`request_appeal`'s reporter-eligibility check (§9.3) trusts `case.creator_id`. If `creator_id` is NULL (orphaned case via deleted reporter), reporter-appeal is impossible by construction. No spoofing surface.
+
+---
+
+## §13 — Open questions for v1 design phase
+
+(Already enumerated in §Open Questions Carried Forward; restated here for the standard PRD shape.)
+
+- **OQ-V1-JM-01**: Severity-tier inference — reporter-tags (lean) vs reported-content-classifier vs moderator-set. v1 commits to reporter-suggested + admin-override at case-open time.
+- **OQ-V1-JM-02**: Geographic diversity heuristic — declared community (lean), timezone (deferred v1.5), IP-region (rejected as PII).
+- **OQ-V1-JM-03**: Founder-status threshold — defendant status (lean) vs case-class. v1 commits to defendant status; case-class is v1.5.
+- **OQ-V1-JM-04**: Cross-instance juror eligibility — parked, v2 territory.
+- **OQ-V1-JM-05**: Re-jury auto vs admin trigger — default `auto_select_on_appeal_acceptance = true`.
+- **OQ-V1-JM-06**: Original-reporter appeal scope — only `NoAction` / `AdvisoryLabel` decisions; same window as defendant.
+
+---
+
+## §14 — Cross-references
+
+- **admin-dashboard-v1 PRD** (§3 config surface) — every config knob in §10 is exposed via the admin dashboard. The dashboard enforces bounds (panel_size odd, fractions in [0.5, 1.0]). Dashboard PRD must reserve the dotted namespace prefix `jury.*` and `appeal.*` for this PRD.
+- **reputation-tuning-v1 PRD** — owns the eligibility weighting (`thresholds.jury_reliability`, decay tuning). Jury-mechanics-v1 reads `reputation_snapshot.jury_eligible` but does not change how it's computed. Issue #19 (`count_active_sanctions` community-scope) belongs in reputation-tuning-v1.
+- **sponsor-liability-v1 PRD** — OQ-025 grace window. The `appeal.window_days` from this PRD and the `sponsor_grace_*_hours` from sponsor-liability-v1 must compose: a successful appeal voids sponsor-liability if it concludes before `min(appeal.window_days, sponsor_grace_days)` elapses.
+- **v2 messaging PRD** (`.claude/PRPs/prds/v2-messaging-rtc.prd.md`) — V2b auto-provisions a Matrix room on `CaseStatus::JurySelection`. Larger v1 panels mean bigger jury rooms; V2b's pseudonym rendering scales with `panel_size_snapshot`. No conflict.
+- **v0 implementation files** — every handler change in §9 lists its source file. None require new crates; all are extensions to existing v0 governance handlers in `crates/api/api{,_crud}/src/governance/`.
+- **GitHub issues carried forward**:
+  - #11 — original-reporter appeals → §6.4
+  - #14 — re-jury path for Appealed cases → §6.6, §9.4
+  - #15 — formalise appeal window with bounded duration → §6.5, §8.1, §9.3
+  - #19 — community-scope `count_active_sanctions` → reputation-tuning-v1 PRD (cross-ref only)
+  - #29 — config-flip determinism → §5.4 (audit-log shape supports stable assertions; v1 does not make selection deterministic)
+
+---
+
+### Critical Files for Implementation
+
+- `crates/api/api/src/governance/admin_assign_jury.rs` — sizing, snapshot, diversity selection (the largest single change surface)
+- `crates/api/api/src/governance/submit_jury_vote.rs` — read snapshots not config, threshold-based winner picking
+- `crates/api/api_crud/src/governance/request_appeal.rs` — bounded window, reporter rights, auto re-jury seeding
+- `crates/api/api/src/governance/config.rs` — new const defaults + new keys in `SEEDED_KEYS_WITH_CONSTS` + new `get_int_cascade` / `get_float_cascade` helpers per §3.5
+- `crates/db_schema_file/src/enums.rs` + a new migration `migrations/<ts>_jury_mechanics_v1/up.sql` — `SeverityTier`, `CaseStatusTier`, `JuryAssignmentRole` enums + the snapshot/audit columns and table
+
+---
+
+## §15 — Resolutions applied (2026-04-19)
+
+v1-planning-session cross-PRD coherence audit applied the following resolutions to this PRD. Traceable via `.claude/PRPs/v1-planning-queue.json`.
+
+| ID | Resolution | Effect in this PRD |
+|---|---|---|
+| **B1** | jury-mechanics owns `appeal.*` namespace fully | No change — already the owner. admin-dashboard §5.2 delegates and §10.2 #15 cross-references here. `appeal.original_jurors_excluded` remains a hard code rule (§6.2), not a config key. |
+| **B2** | Dotted `jury.panel_size.<status>.<severity>` matrix WITH single-key fallback per OQ-026 cascade | §3.5 Cascade fallback subsection added; §9.2 directive to use new `get_int_cascade` helper. Bare `jury.panel_size` retained as v1 root default (value=7) in admin-dashboard §5.1 — not duplicated here. |
+| **B6** | jury-mechanics owns combined post-v1 `submit_jury_vote` handler shape | **Done.** §9.1 expanded to 9-step combined-handler pseudocode (load-case/validate/insert-vote/tally → threshold-check with deadlock-to-AdminReview → winning-decision → sponsor-liability branch with `SponsorLiabilityPending` + grace-window compute + deferred public_log/juror-rep → no-sponsor Decided branch preserved from v0 → appeal-window bound step 9 firing on both paths). Cross-references to sponsor-liability-v1 §9.1/§9.3/§9.4 added. Golden-path test impact documented (step 8 no-sponsor assertions preserved; new sponsored-target test is v1-impl follow-up). sponsor-liability-v1 §9.3 reduces to pointer (see its §18 Resolutions). |
+| **N3** | jury-mechanics §5.3 constraint-relaxation algorithm clarified | **Done.** §5.3 rewritten into a three-phase flowchart (Phase 1 pool-build filter for cooldown, Phase 2 panel-sample re-roll for sponsor-cluster, Phase 3 panel-score soft bias for geographic). Relaxation cascade renamed to R1/R2/R3 with explicit triggers and audit-log entries; `warn!` added on R3 (sponsor-cluster drop) because it's the last resort. Makes the phase structure (filter vs check vs score) explicit for the §9.3 impl agent and clarifies why cooldown relaxes first (expands the pool), sponsor-cluster relaxes last (Brehon-essential structural-capture guard). |
+| **NOT1** | OQ prefixed-namespace convention (collision resolution) | **Done.** jury-mechanics' six `OQ-027..032` renumbered to `OQ-V1-JM-01..06` via mechanical replace-all. Affects §4 Open Questions table, §3.2 severity inference reference, §5 sponsor-cluster and geographic-diversity lean references, §6 appeal rerun config reference, §9 original-reporter eligibility reference, §14 OQs Opened Here summary. No substantive text changed; only the prefix shifts to match the convention already used by reputation-tuning / sponsor-liability / federation-inbound. Resolves the admin-dashboard/jury-mechanics OQ-027 collision identified during the audit. admin-dashboard OQ-027..031 renamed separately to OQ-V1-AD-01..05. |

--- a/.claude/PRPs/prds/v1-reputation-tuning.prd.md
+++ b/.claude/PRPs/prds/v1-reputation-tuning.prd.md
@@ -243,7 +243,7 @@ All five fixes ship in the same v1 release window so the v1 reputation API stabi
 
 ## 7. Cross-Cutting Impact
 
-- [x] **Hash-chain governance log touched?** YES — five new `ENTRY_KIND_*` constants added to `crates/api/api/src/governance/governance_log.rs`: `ENTRY_KIND_PARTICIPATION_CRON_TICK`, `ENTRY_KIND_VOTE_OUTCOME_RECORDED`, `ENTRY_KIND_EVIDENCE_QUALITY_RECORDED`, `ENTRY_KIND_ROLLUP_RECOMPUTED`, `ENTRY_KIND_DECAY_KNOB_CHANGED`. Zero migration per `governance_log.entry_kind` being TEXT.
+- [x] **Hash-chain governance log touched?** YES — **seven** new `ENTRY_KIND_*` constants added to `crates/api/api/src/governance/governance_log.rs` (defined in `crates/db_schema/src/source/governance/governance_log.rs` post-Phase-6 per DQ-6.6, re-exported via the api shim): `ENTRY_KIND_PARTICIPATION_CRON_TICK`, `ENTRY_KIND_VOTE_OUTCOME_RECORDED`, `ENTRY_KIND_EVIDENCE_QUALITY_RECORDED`, `ENTRY_KIND_ROLLUP_RECOMPUTED`, `ENTRY_KIND_DECAY_KNOB_CHANGED`, `ENTRY_KIND_SPONSOR_ALLOWLIST_ADDED` (§10 allowlist add), `ENTRY_KIND_SPONSOR_ALLOWLIST_REMOVED` (§10 allowlist remove). Zero migration per `governance_log.entry_kind` being TEXT. The allowlist pair covers the admin-owned `sponsor_allowlist` table introduced in §7 schema additions (this PRD owns them because the table is declared here; v1-AD-b consumes them via the admin-config write path).
 - [x] **`actor_pseudonym` table or redaction service touched?** YES (additive) — every cron emit logs via `actor_pseudonym`. Cron-batch entries use a synthetic `system` pseudonym (new addition; reserved value, never collides with a real person's pseudonym). Rollup writes log under the rolled-up person's pseudonym.
 - [x] **`CaseStatus::EmergencyRemove` affected?** YES — evidence-quality bad-faith path requires admin to flag an `EmergencyRemove` original report. New endpoint `POST /api/v4/governance/admin/emergency-remove/flag-bad-faith` (instance-admin only) writes a single `reputation_event` row + governance_log entry. ADR-013 admin-driven posture preserved.
 - [x] **AGPLv3 notice / source disclosure affected?** None. No new external dependencies.
@@ -396,7 +396,7 @@ Design-doc anchors:
 
 ---
 
-## 14. Resolutions applied (2026-04-19)
+## 15. Resolutions applied (2026-04-19)
 
 Cross-PRD coherence-audit edits applied during v1-PRD edit pass (see `.claude/PRPs/v1-planning-queue.json`):
 

--- a/.claude/PRPs/prds/v1-reputation-tuning.prd.md
+++ b/.claude/PRPs/prds/v1-reputation-tuning.prd.md
@@ -1,0 +1,433 @@
+# Sub-PRD: v1 Reputation Tuning
+
+**Scope**: v1 governance-mechanics track — promotes the v0 hardcoded reputation-decay stub and single-source endorsement model into a configurable, multi-source, per-dimension decay system tuned per community via admin dashboard.
+**Created**: 2026-04-19
+**Status**: DRAFT
+**Scheduled**: v1 (per [ADR-010](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — "Is it production-grade governance?"). Strictly post-v0; depends on Phase 5/6 completion.
+**Predecessor**: v0 reputation calculator at `crates/api/api/src/governance/reputation_snapshot.rs` (Phase 5a/5c) — the per-dimension halving stub that this PRD replaces.
+**Naming note**: "v1" in this document refers to the v1 milestone in [ADR-010](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md); not to be confused with v2-security or v3-verifiability tracks.
+
+---
+
+## 1. Problem Statement
+
+The v0 reputation system shipped as an intentional stub. The decay calculator in `crates/api/api/src/governance/reputation_snapshot.rs:320-349` halves positive organic events past a single instance-wide half-life (default 90d), never decays negative events (penalties persist), and applies one decay event per organic event regardless of how old it is — there is no chained halving, no per-dimension tuning, and no negative-decay path for restorative reintegration. The v0 `participation_consistency` dimension has exactly **one** event source (`create_endorsement` emits `+5` for the sponsee per [99 OQ-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)) — a user who never participates in the sponsorship graph stays pinned at zero forever, breaking the [01 §5.3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) principle that participation reputation should reflect "regular, constructive participation in community." The v0 sponsor-gate has three strategies (`age` / `open` / `closed`) but cannot express the nuanced gates real pilot communities will need (vouch-or-age, reputation-based, allowlist). Reputation snapshots are per-(person, community) only; instance admins cannot see a user's instance-wide standing for cross-community jury eligibility filters per [99 OQ-001](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md). Five carry-forward issues from CodeRabbit's PR #10 review (#19, #20, #21, #22, #31) are open against the v0 reputation surface.
+
+v1 lands the **production-grade reputation mechanic**: per-dimension decay rates tuned via admin dashboard, multi-source `participation_consistency` events fed by a weekly cron + vote/evidence outcomes, three additional sponsor-gate strategies, an instance-wide reputation roll-up endpoint, and the five carry-forward issue fixes.
+
+**Critical framing (user, 2026-04-19):** "The admin dashboard will allow community groups to experiment with how they configure a lot of these settings, although defaults might have to be decided on." Reputation parameters are **dashboard knobs with sensible defaults**; communities tune to taste. The PRD reflects this — every decay rate, multi-source increment, and gate strategy is config-driven.
+
+**Primary actor** ([02 §2](../../docs/brehon-law-inspired-network/02-domain-model.md)): **Community Admin** (operator persona). Tunes per-community reputation knobs from the dashboard and observes the downstream effects on jury eligibility, sponsor capability, and capability-flip cadence. Validation surface (whether the v1 mechanic actually feels right) lands here, not on individual jurors.
+
+**Secondary actors**: Instance admin (rolls up reputation across communities for cross-community eligibility queries; enables/disables v1 decay via feature flag), trusted member (sees their participation_consistency rise from non-endorsement event sources), juror (vote-outcome event source produces realised reputation deltas after case close).
+
+---
+
+## 2. Evidence
+
+**v0 reputation calculator** — `crates/api/api/src/governance/reputation_snapshot.rs:203-349` ships the single-half-life decay stub. Module-level docs at lines 1-46 are explicit that `compute_applied_delta` is a v0 simplification and that "v1 — switch to chained halving per half-life elapsed" is a documented TODO at line 341.
+
+**v0 config surface** — 33 keys seeded by Phase 5a task 50 in `crates/api/api/src/governance/config.rs:319-352, 423-458`. The reputation-relevant keys (`thresholds.*`, `decay.*`, `deltas.*`, `liability.*`, `onboarding.*`, `founder.*`, `job.*`) all live in `governance_config_current` and are reachable via the typed `get_int` / `get_float` / `get_bool` / `get_text` helpers at lines 290-302. **Only `decay.positive_half_life_days` exists as a decay knob today** — there is no per-dimension or per-direction (positive/negative) decay surface.
+
+**v0 reputation event sources** — Phase 5a/5b only emit reputation events from four code paths: `create_endorsement` (Phase 5a task 55, +5 to `endorsement_strength` for sponsor + +5 to `participation_consistency` for sponsee per [99 OQ-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)), `submit_jury_vote` (Phase 5b — juror align/outlier + reporter upheld/dismissed deltas per [05 §6](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md)), `apply_sponsor_liability` (Phase 5b task 56, sponsor-side penalties per [01 §5.2](../../docs/brehon-law-inspired-network/01-vision-and-principles.md)), and `seed_founders` CLI (Phase 5a task 59, founder-cliff seeds per [99 OQ-017](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)). **No periodic activity scan exists**. **No vote-outcome reputation feedback exists** beyond the alignment delta.
+
+**v0 snapshot scope** — `reputation_snapshot.community_id` is `Option<CommunityId>`, so the schema already supports both per-community (`Some`) and instance-wide (`None`) rows. v0 only writes per-community rows from the calculator; instance-wide rows would only ever be written by Phase 5c's `load_or_compute_snapshot(... community_id = None ...)` path — which exists but is not invoked from any v0 handler. This is the seam v1 uses for the rollup.
+
+**Issue carry-forward** — five PR #10 review findings deferred to v1: #19 (community-scope `count_active_sanctions` mismatch), #20 (`check_snapshot_staleness` overflow + spurious empty-table error), #21 (drop `Copy` on `ReputationBuckets` / `AdminReputationStatsResponse`), #22 (bound `limit` on `list_capability_changed_entries_since`), #31 (explicit `active_sanctions` constructor on `ReputationSummaryView::From<&ReputationSnapshot>`). All five have intact code paths today and intact test coverage; v1 is the ratification window.
+
+**OQ readiness** — [99 OQ-001](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md), [OQ-019](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md), [OQ-020](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) all opened with v1-leans documented. [OQ-018](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) (admin config write endpoint) is the upstream dependency; this PRD assumes it lands with `POST /api/v4/governance/admin/config { key, value }` per its current lean.
+
+---
+
+## 3. ADRs That Govern This
+
+| ADR | Summary | How it constrains us |
+|---|---|---|
+| [ADR-005](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Reputation is multi-dimensional + event-sourced; never a single score | **Load-bearing.** v1 must extend the dimension-wise decay surface, **not collapse** dimensions into a composite. Per-dimension decay is exactly what ADR-005 §Consequences anticipated when it said "Decay, tuning, and policy changes happen at the snapshot level without touching the event log." Event log stays append-only. |
+| [ADR-010](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Staged releases v0 → v1 → v2 → v3 | This PRD targets v1 ("Is it production-grade governance?"). Per [05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md), v1 explicitly ships **"Reputation decay tuning per dimension"** and **"Instance-wide reputation roll-up"** — so this PRD is fulfilling a chartered-in v1 deliverable, not adding scope. |
+| [ADR-008](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Append-only signed governance log | Every cron emit, every dashboard knob change, every rollup recomputation MUST emit a `governance_log` entry. v1 introduces `ENTRY_KIND_PARTICIPATION_CRON_TICK`, `ENTRY_KIND_VOTE_OUTCOME_RECORDED`, `ENTRY_KIND_EVIDENCE_QUALITY_RECORDED`, `ENTRY_KIND_ROLLUP_RECOMPUTED`, `ENTRY_KIND_DECAY_KNOB_CHANGED` (admin attribution per Watch 11). |
+| [ADR-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Illegal-content `EmergencyRemove` | Evidence-quality event source (§5.4) emits `−1` to reporter's `reporting_accuracy` only when admin flags an `EmergencyRemove` original report as bad-faith. The flag is admin-driven, not auto. Bad-faith reports of CSAM should NOT be auto-penalised — preserves the legal-compliance-first posture. |
+| [ADR-015](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Pseudonymised actor IDs | All v1 cron emits and rollup writes log via `actor_pseudonym`, never raw `person_id`. Existing pattern in `governance_log::append` is preserved. |
+| [99 OQ-001](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Instance-wide vs per-community reputation | Resolved-by-this-PRD: instance-wide rollup as a derived snapshot in `reputation_snapshot WHERE community_id IS NULL` rows. Lean confirmed. |
+| [99 OQ-019](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | `participation_consistency` event sources | Resolved-by-this-PRD: weekly cron emits `+1` per active user per community; `−2` per dormant user; vote-outcome and evidence-quality event sources additive. Aligned with the OQ's "v1 ships option (a)" lean. Option (b) event-driven per-comment is **rejected** in this PRD per OQ rationale (spam incentive). |
+| [99 OQ-020](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Sponsor gate-strategy expansion | Resolved-by-this-PRD: three additional strategies (`age_or_surety`, `reputation`, `allowlist`) ship in v1 with per-community config. Composition strategies (e.g. `age_or_surety_or_allowlist`) explicitly **rejected** per OQ — exponential test cost. |
+| [99 OQ-021](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | Negative-reputation floor + reintegration | **Out of scope here.** v1 introduces negative-decay rates but does NOT change the v0 zero-floor clamp on sponsor-liability ([99 OQ-024](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)). Negative-band-with-reintegration is v1-or-v2 successor PRD work. |
+
+**Contradiction check**: None found. ADR-005's "decay, tuning, and policy changes happen at the snapshot level without touching the event log" is the exact license this PRD operates under — events stay append-only, snapshots are the v1 evolution surface.
+
+---
+
+## 4. Open Questions Carried Forward
+
+| OQ | Status | Impact on this sub-PRD |
+|---|---|---|
+| [OQ-005](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) (UX flows) | 99-register; v1 scope | Soft gate. Admin dashboard surface for tuning decay knobs needs a basic config UI — the OQ-018 endpoint shape (per-key write) is sufficient backend. PRD does NOT ship the dashboard UI; it ships the API. UI is operator-side or v3 admin-dashboard-UX. |
+| [OQ-018](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) (admin config write endpoint) | 99-register; v1 scope | **Hard gate** (Blocking-Dependencies §). Dashboard knob writes go through `POST /api/v4/governance/admin/config`. This PRD assumes that endpoint lands with the per-key shape currently leaned in OQ-018. If endpoint shape changes to batch writes, §6 dashboard surface is unaffected (per-key calls compose into a UI batch); only audit-log granularity changes. |
+| [OQ-021](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) (negative-reputation floor + reintegration) | 99-register; deferred | **Out of scope.** v1 negative-decay rate (§4.3) is a slow-decay-towards-zero, not a negative-band-with-reintegration. The OQ-024 v0 zero-floor clamp on sponsor-liability is preserved unchanged. |
+| OQ-V1-01 (cron mechanism) | Opened here; resolved | In-app scheduler via clokwerk (existing Lemmy pattern in `crates/routes/src/utils/scheduled_tasks.rs:177`). NOT pg_cron. Preserves the no-postgres-extension posture. |
+| OQ-V1-02 (banned-from-community rollup behaviour) | Opened here; lean documented | Lean: exclude that community from the rollup denominator entirely. Banned users contribute zero rep + zero weight. Alternative (include with zero weight) under-counts the rollup. Resolution required before §7 implementation. |
+| OQ-V1-03 (negative-decay rate semantics) | Opened here; lean documented | Lean: slow time-decay (default `−5%/180d` half-life, vs positive `−10%/90d`) plus optional per-event corrective-action multiplier. Restorative principle preserved without making penalties evaporate quickly. |
+
+### Open Questions Opened Here
+
+- **OQ-V1-01 — Cron mechanism: in-app vs pg_cron.** Resolved 2026-04-19: in-app via clokwerk, mirroring the existing snapshot tick at `crates/routes/src/utils/scheduled_tasks.rs:177`. Rationale: pg_cron is a Postgres extension we have not adopted (cf. ADR-style "no extra extensions in v0 stack"), and Lemmy's existing scheduling pattern is well-tested. Trade-off: scheduler dies if the server process dies, but so does everything else.
+- **OQ-V1-02 — Banned-from-community rollup behaviour.** Open. Lean: when computing the instance-wide rollup for a person who is banned from community C, exclude C from the rollup entirely (denominator drops by 1, not by `(1, weight=0)`). Rationale: a ban means "this community has rejected your participation" and should not pull the user's instance-wide score down via a zero-vote inclusion. Counterargument: excluding could let a user game the rollup by attracting bans. PRD assumes exclude-from-denominator; revisit at v1-implementation review.
+- **OQ-V1-03 — Negative-decay rate semantics.** Open. Lean: negative reputation decays slower than positive (default `−5%/180d` half-life vs positive `−10%/90d`), AND a per-corrective-action accelerator can apply an extra positive event that offsets the penalty faster. This avoids the v0 simplification (negatives never decay → permanent outcasts on a long-enough timeline) without inventing a separate "reintegration ceremony" mechanic (which is OQ-021's territory). PRD assumes this lean; revisit at v1-implementation review.
+- **OQ-V1-04 — Rollup recomputation cadence vs synchronous.** Resolved 2026-04-19: weekly cron, materialised. Rationale: rollup recomputation across all communities is expensive (N × M dimension sums); a live-aggregation endpoint would either be slow or require a denormalised cache. Weekly cadence aligns with the participation cron, and instance-admins use the rollup for cross-community eligibility queries that do not need real-time freshness.
+- **OQ-V1-05 — Dashboard write granularity for decay rates.** Open. Single-knob writes (`POST /admin/config { key, value }`) per OQ-018's lean produce N audit-log entries for an N-knob change. A batch-write shape (`POST /admin/config { changes: [...] }`) would be one audit entry per batch but is also vetoed by OQ-018's lean ("batch writes are v1+ if pilot feedback says they're needed"). PRD aligns with OQ-018's lean: per-knob single writes; the audit-log granularity is the cost.
+
+---
+
+## 5. Proposed Solution
+
+Promote v0's hardcoded reputation-decay stub into a **per-dimension, per-direction, configurable decay system** with multi-source `participation_consistency` events fed by two weekly crons (activity-positive + dormancy-negative) plus vote-outcome + evidence-quality reputation feedback paths. Add three additional sponsor-gate strategies. Materialise instance-wide reputation rollup snapshots via a third weekly cron that runs after the participation cron. All knobs surface through `governance_config` and the admin dashboard via OQ-018's `POST /api/v4/governance/admin/config`. Address five carry-forward CodeRabbit issues in the same v1 release window so the v1 reputation API stabilises in one cut.
+
+v1 ships behind a feature flag (`feature.reputation_v1_decay_enabled`, default `false` at v1 release) so v0-style decay is preserved by default; instance operators opt in via dashboard once they trust the new defaults.
+
+### 5.1 Reputation Dimension Catalog (verified against v0 enums)
+
+The four dimensions per `crates/db_schema_file/src/enums.rs:589-594`:
+
+| Dimension | Purpose ([01 §5.3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md)) | v0 positive sources | v0 negative sources | v1 positive sources (new) | v1 negative sources (new) |
+|---|---|---|---|---|---|
+| `ReportingAccuracy` | Trust in flagging | `submit_jury_vote` upheld (default `+10`) | `submit_jury_vote` dismissed (default `−5`) | Evidence-quality event: `+1` if reporter's evidence cited in jury rationale | Evidence-quality event: `−1` if `EmergencyRemove` flagged bad-faith by admin |
+| `JuryReliability` | Trust in decisions | `submit_jury_vote` aligned with majority (default `+10`) | `submit_jury_vote` outlier (default `−5`) | (none) | (none) |
+| `ParticipationConsistency` | Engagement quality | `create_endorsement` (default `+5` to sponsee per [99 OQ-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)) | (none in v0) | Weekly activity cron `+1` per user per community with ≥1 comment that week. Vote-outcome cron `+1` per juror voted with majority post-decision (already exists for jury_reliability; v1 mirrors to participation). | Weekly dormancy cron `−2` for users dormant >30d in a community where they previously participated |
+| `EndorsementStrength` | Trust in vouching | `create_endorsement` (default `+5` to sponsor per [99 OQ-013](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)) | `apply_sponsor_liability` (defaults `−10` minor / `−50` moderate / `−200` severe per Phase 5b task 56), zero-floor clamped per [99 OQ-024](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) | (none) | (none) |
+
+Source citations for every entry in the v0 columns trace to verifiable code paths (`create_endorsement.rs`, `submit_jury_vote.rs`, `sponsor_liability.rs`); the v1 columns are introduced by this PRD.
+
+### 5.2 Decay configuration (per-dimension, per-direction)
+
+v0 ships a single `decay.positive_half_life_days` (default `90`). v1 expands this to a `(dimension, direction)` matrix — eight knobs total:
+
+| Knob | Default | Range | Per-community? | Notes |
+|---|---|---|---|---|
+| `decay.reporting_accuracy.positive_half_life_days` | 90 | 1–3650 | Yes | Mirrors v0 default |
+| `decay.reporting_accuracy.negative_half_life_days` | 180 | 1–3650 OR `unbounded` | Yes | OQ-V1-03 lean |
+| `decay.jury_reliability.positive_half_life_days` | 90 | 1–3650 | Yes | |
+| `decay.jury_reliability.negative_half_life_days` | 180 | 1–3650 OR `unbounded` | Yes | |
+| `decay.participation_consistency.positive_half_life_days` | 60 | 1–3650 | Yes | Faster than other dimensions: participation reputation reflects current behaviour, not lifetime |
+| `decay.participation_consistency.negative_half_life_days` | 60 | 1–3650 OR `unbounded` | Yes | Symmetric with positive |
+| `decay.endorsement_strength.positive_half_life_days` | 90 | 1–3650 | Yes | |
+| `decay.endorsement_strength.negative_half_life_days` | 180 | 1–3650 OR `unbounded` | Yes | Slower: sponsorship penalties should not evaporate; OQ-024 honour-price principle |
+
+**Calculation method: chained-halving exponential decay.** v0's single-halving stub becomes `delta * (0.5 ^ floor(age_days / half_life_days))` for organic events (`expires_at IS NULL`). Founder-cliff events (`expires_at IS NOT Null`) keep their full delta until the cliff, unchanged from v0 (Watch 8 from `reputation_snapshot.rs:30`).
+
+Justification for exponential over linear: the governance-research literature on slowly-decaying reputation (Friedman & Resnick 2001, Sabater & Sierra 2005) favours exponential decay because it asymptotes towards zero without ever reaching it — a high-reputation user who goes inactive for years drifts towards baseline rather than crashing through it, and the gradient of consequence is smooth enough that a user can recover from a lapse without a cliff. Linear decay produces a hard zero at `age = (delta / decay_rate)` which, combined with the OQ-024 zero-floor clamp, would give a user a single-event removal point — operationally jarring.
+
+**Floor and ceiling per dimension.** v0 has no per-dimension cap; raw deltas can sum to arbitrary values. v1 adds soft bounds to prevent grossly-out-of-range integer arithmetic and preserve the [01 §1 principle 5](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) "no permanent elites or outcasts" intent:
+
+| Knob | Default | Range | Per-community? |
+|---|---|---|---|
+| `bounds.reporting_accuracy.floor` | -100 | -10000 to 0 | Yes |
+| `bounds.reporting_accuracy.ceiling` | 100 | 0 to 10000 | Yes |
+| `bounds.jury_reliability.floor` | -100 | -10000 to 0 | Yes |
+| `bounds.jury_reliability.ceiling` | 100 | 0 to 10000 | Yes |
+| `bounds.participation_consistency.floor` | -100 | -10000 to 0 | Yes |
+| `bounds.participation_consistency.ceiling` | 100 | 0 to 10000 | Yes |
+| `bounds.endorsement_strength.floor` | 0 | -10000 to 0 | Yes (locked at 0 unless OQ-021 ships) |
+| `bounds.endorsement_strength.ceiling` | 200 | 0 to 10000 | Yes (higher because sponsor-event accumulator can reach `+5 * 5 = +25` quickly) |
+
+Bounds apply at snapshot-write time in `recompute_snapshot` after the dimension sums are tallied. They do **not** mutate `reputation_event` rows — the event log stays append-only per ADR-008.
+
+**Cron cadence.** Reputation snapshot recompute stays at 15-minute ticks (existing v0 behaviour at `crates/routes/src/utils/scheduled_tasks.rs:177`). Participation activity-positive + dormancy-negative crons run **weekly** (default; configurable via `job.participation_interval_days`, default `7`, range `1`–`30`). Rollup cron runs **weekly, after** the participation cron in the same scheduler tick to ensure rollup sees the freshest activity events.
+
+### 5.3 Multi-source `participation_consistency` events (resolves [99 OQ-019](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md))
+
+**Source 1 — Weekly activity cron.** Once per week (default), for each community, emit `+1 participation_consistency` per user with ≥1 non-deleted comment authored in that community in the lookback window. Knobs:
+
+- `deltas.participation_weekly_active` — default `1`, range `0`–`10` (policy knob: the reputation delta for an active user)
+- `participation.activity_threshold_comments` — default `1`, range `0`–`100` (context knob: what "active" means for this cron)
+- `participation.lookback_days` — default `7`, range `1`–`90` (context knob: the activity window)
+
+Idempotency: each emission writes a `reputation_event` row with `dedupe_key = format!("participation_cron:{community_id}:{iso_week}")` (new column on `reputation_event`, partial unique index where `dedupe_key IS NOT NULL`). Re-running the cron in the same ISO week is a no-op via `ON CONFLICT (dedupe_key) DO NOTHING`.
+
+Atomicity: each community's batch writes inside a single transaction. A mid-community crash rolls back that community only; earlier committed communities stay. Per-community batching matches the v0 snapshot-batch-chunk pattern at `reputation_snapshot.rs:465-495`.
+
+**Source 2 — Weekly dormancy cron.** Same scheduler tick, after the activity cron. For each community, for each `(person_id, community_id)` pair where the person previously had at least one `participation_consistency` event in that community AND has had zero non-deleted comments in the dormancy window, emit `−2 participation_consistency`. Knobs:
+
+- `deltas.participation_dormant` — default `-2`, range `-100`–`0` (policy knob: the reputation delta for a dormant user)
+- `participation.dormancy_window_days` — default `30`, range `1`–`365` (context knob: how long the user must be silent to qualify as dormant)
+
+Same dedupe-key pattern: `format!("dormancy_cron:{community_id}:{person_id}:{iso_week}")`. Same per-community-tx atomicity.
+
+**Source 3 — Vote-outcome event (post-decision, embedded in `submit_jury_vote`).** Already exists for `jury_reliability`. v1 mirrors: when the case is decided and a juror voted with the majority, emit `+1 participation_consistency` (same case_id, same juror, separate `reputation_event` row from the existing `jury_reliability` delta). When a juror voted in the minority, **emit nothing** — Brehon principle of no-penalty-for-dissent ([99 OQ-009 lean](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)). Knobs:
+
+- `deltas.participation_juror_aligned` — default `+1`, range `0`–`100`
+
+**Source 4 — Evidence-quality event (post-decision).** When a case is decided and the jury's rationale (free-text) cites the reporter's evidence (heuristic detection: case has `case_evidence` rows uploaded by the reporter AND the rationale length ≥ minimum threshold), emit `+1 reporting_accuracy` for the reporter. When the case is `EmergencyRemove`-status AND an admin flags the original report as bad-faith via a new admin action, emit `−1 reporting_accuracy` for the reporter. Knobs:
+
+- `deltas.evidence_cited` — default `+1`, range `0`–`100`
+- `deltas.evidence_bad_faith` — default `-1`, range `-100`–`0`
+- `participation.evidence_cited_rationale_threshold_chars` — default `256`, range `32`–`4096` (context knob: the minimum rationale length that qualifies a case as "evidence cited")
+
+The evidence-cited heuristic is a v1 simplification; v2 may add explicit "cite this evidence" UI. The bad-faith flag is admin-only (no auto-detection per ADR-013 legal-compliance posture).
+
+**v1-impl verification task (per N2 2026-04-19):** before implementing this source, verify that `jury_vote.rationale` (or equivalent column) exists as a free-text `TEXT` field in v0 schema and is populated by `submit_jury_vote`. If rationale is currently empty-by-default or nullable-unused, the heuristic has no signal and Source 4 cannot ship until v2 (explicit evidence-cite UI). The `256 chars` default is a placeholder — tune during v1-impl based on observed rationale lengths from pilot data.
+
+### 5.4 Sponsor gate strategies (resolves [99 OQ-020](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md))
+
+v0 ships three strategies in `config.onboarding.sponsor_gate_strategy` per `crates/api/api/src/governance/config.rs:346`:
+
+- `'age'` (default) — account age ≥ `onboarding.sponsor_min_account_age_days` (default `30d`)
+- `'open'` — bypass all checks (recruitment-drive mode)
+- `'closed'` — reject all endorsement attempts (emergency lockdown)
+
+v1 adds three:
+
+- `'age_or_surety'` — passes if age gate OR caller has ≥1 active surety (as sponsored party). Lets newly-vouched members sponsor before the age threshold. Implementation: `OR EXISTS (surety WHERE sponsored_id = caller AND revoked_at IS NULL)`.
+- `'reputation'` — passes if `reputation_snapshot.can_sponsor` is true for the caller (community-scoped if `community_id` provided, else instance-scoped). The `can_sponsor` boolean already populates per Phase 5a task 53 and is gated against `thresholds.endorsement_strength` (default `25`). v1 simply flips this from a computed-but-unread boolean ([99 OQ-014](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)) to a strategy-readable one.
+- `'allowlist'` — passes only if caller is in `sponsor_allowlist` table (new). Fields: `id`, `community_id` (nullable for instance-wide allowlist), `person_id`, `added_by_admin_id`, `added_at`, `note`. Admin-managed via new endpoints `POST /api/v4/governance/admin/sponsor-allowlist/add` + `POST /api/v4/governance/admin/sponsor-allowlist/remove`.
+
+Strategy is configured **per-community** (existing `sponsor_gate_strategy` key already supports per-community scope via `governance_config_current.scope`). The strategy is a single string — composition strategies (e.g. `'age_or_surety_or_allowlist'`) **explicitly rejected** per [99 OQ-020](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) "every new combination is exponential test cost."
+
+**Migration path for community switching strategies mid-flight.** When a community changes its `sponsor_gate_strategy` config, **existing endorsements are grandfathered** — no retroactive validation. Only new `create_endorsement` calls are evaluated against the new strategy. The dashboard surfaces a "this affects future endorsements only" tooltip on the strategy-change form. Existing `surety` and `endorsement` rows stay in their current state regardless.
+
+### 5.5 Instance-wide reputation rollup (resolves [99 OQ-001](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md))
+
+**Schema.** Reuse `reputation_snapshot` with `community_id IS NULL` for instance-wide rollup rows. v0 schema already supports this via `community_id: Option<CommunityId>`; v0 just never writes `None` rows. No migration needed.
+
+**Computation.** Materialised via a third weekly cron (`reputation_rollup_cron`) that runs after the participation cron. For each person with at least one per-community snapshot:
+
+```
+rollup.dimension = sum(per_community_snapshot.dimension * weight) / sum(weight)
+```
+
+Default weight is `1` per community (equal weights; weighted average). Per [99 OQ-001 lean](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md), per-community weights are tunable via a new config row but default to equal weights for v1 simplicity.
+
+Per OQ-V1-02 lean, communities the person is banned from (active sanction with `target_community_id` set, scope `Community`) are **excluded from the denominator entirely** — they do not contribute zero rep at zero weight, they do not contribute at all. A person banned from C1 and active in C2 has rollup = C2's snapshot.
+
+Rollup rows are upserted via the same `upsert_snapshot` machinery as per-community snapshots; capability-flip detection fires on rollup-row changes too (per Watch 11). Instance-wide capability-flips emit `governance_log::ENTRY_KIND_CAPABILITY_CHANGED` entries with `snapshot_community_id: null`.
+
+**Use case 1 — Instance-admin views user's standing.** New endpoint `GET /api/v4/governance/admin/reputation/rollup?person_id=N` (instance-admin only) returns the rollup row plus per-community contributing snapshots.
+
+**Use case 2 — Cross-community jury eligibility filters.** A v1 jury-mechanics feature (separate PRD, jury-mechanics-v1) reads the rollup to expand the eligible pool when a single community lacks enough qualified jurors. This PRD ships only the data; jury-pool expansion is jury-mechanics-v1 PRD scope.
+
+### 5.6 Issue carry-forward (CodeRabbit findings #19, #20, #21, #22, #31)
+
+| Issue | File | Fix |
+|---|---|---|
+| **#19** community-scope `count_active_sanctions` | `crates/db_views/reputation/src/impls.rs:42-53` and `crates/api/api/src/governance/get_my_reputation.rs:41` | Change `count_active_sanctions(conn, person_id)` signature to `count_active_sanctions(conn, person_id, community_id: Option<CommunityId>)`. Filter sanctions by community when `Some`; instance-wide when `None`. Thread `data.community_id` from the handler. |
+| **#20** `check_snapshot_staleness` overflow + spurious empty-table | `crates/api/api/src/governance/reputation_snapshot.rs:435` | Replace `2 * interval_s` with `interval_s.saturating_mul(2)`. In the `None` arm, query `reputation_event::table.count()` first; if zero, emit `tracing::info!` (not error) — fresh-deploy posture. Reserve `error!` for `Some` arm where the table has data but is stale. |
+| **#21** drop `Copy` on `ReputationBuckets` + `AdminReputationStatsResponse` | `crates/api/api_common/src/governance.rs:292, 336` | Drop `Copy` from both derives. No call sites require `Copy` semantics today (bucket arrays are small but not idiomatically copy-passed). Keeps forward-compat for future non-`Copy` fields. |
+| **#22** bound `limit` on `list_capability_changed_entries_since` | `crates/db_views/governance_modlog/src/impls.rs:196` | Add `let limit = limit.min(MAX_LIMIT);` at function top; use clamped value in `.limit(limit)`. Match the pattern at `list_cases_filtered`. |
+| **#31** explicit `active_sanctions` constructor | `crates/db_views/reputation/src/lib.rs` (the `From<&ReputationSnapshot>` impl) | Drop the `From` impl in favour of an explicit named constructor `ReputationSummaryView::from_snapshot_needing_sanction_count(&snapshot, active_sanctions: i64)`. The verbose name signals "not a complete view yet"; signature requires `active_sanctions` so callers cannot forget. Update the two known call sites (`get_my_reputation.rs:43`, plus any reputation view tests) to pass the count explicitly. |
+
+All five fixes ship in the same v1 release window so the v1 reputation API stabilises in one cut. Each fix has its own GitHub issue and deserves a dedicated v1 PR (or a single bundled "v1 reputation API hardening" PR — author's call).
+
+---
+
+## 6. Acceptance Criteria
+
+- All eight per-dimension/per-direction decay knobs surface in `governance_config` and are read by `recompute_snapshot` instead of the v0 single-knob path.
+- A snapshot-recompute integration test demonstrates chained halving: an organic positive event of `delta = +100` aged `2 × half_life` produces `applied_delta = 25` (vs v0's `50`).
+- A snapshot-recompute integration test demonstrates negative-direction half-life: an organic negative event of `delta = -20` aged `1 × negative_half_life` produces `applied_delta = -10` (vs v0's `-20`, never decays).
+- Weekly participation activity cron emits `+1 participation_consistency` per active user per community, idempotent across re-runs in the same ISO week (verified via `dedupe_key` constraint).
+- Weekly dormancy cron emits `−2 participation_consistency` per dormant user, idempotent across re-runs.
+- Vote-outcome event source emits `+1 participation_consistency` per aligned juror at case-decided time (in the same `submit_jury_vote` transaction).
+- Evidence-quality event source emits `+1 reporting_accuracy` when the heuristic detects rationale-cited evidence; admin-flagged bad-faith `EmergencyRemove` original report emits `−1 reporting_accuracy`.
+- Three new sponsor-gate strategies (`age_or_surety`, `reputation`, `allowlist`) each have integration-test coverage demonstrating the gate fires correctly under matching conditions.
+- Per-community strategy switch demonstrates grandfathering (existing endorsements pre-switch remain valid; only new `create_endorsement` calls are evaluated against the new strategy).
+- Instance-wide rollup snapshot exists in `reputation_snapshot WHERE community_id IS NULL` for every person with ≥1 per-community snapshot, populated by the weekly rollup cron.
+- `GET /api/v4/governance/admin/reputation/rollup` returns the rollup plus per-community contributing snapshots; rejects non-admin callers.
+- Issue #19: `get_my_reputation` returns sanction count scoped to the requested `community_id` (community-scoped when `Some`, instance-wide when `None`).
+- Issue #20: staleness check no longer emits spurious `error!` on a fresh-deploy empty table; no overflow on near-`i64::MAX` `interval_s`.
+- Issue #21: `ReputationBuckets` and `AdminReputationStatsResponse` no longer derive `Copy`; build still passes; no regressions.
+- Issue #22: `list_capability_changed_entries_since` rejects (or clamps) limits exceeding `MAX_LIMIT`.
+- Issue #31: `From<&ReputationSnapshot>` impl removed; named constructor required at every call site; cargo fails compile if a future caller forgets `active_sanctions`.
+- Feature flag `feature.reputation_v1_decay_enabled` defaults `false` at v1 release; flipping `true` activates per-dimension decay; flipping `false` reverts to v0 single-half-life behaviour without restart.
+- Every decay-knob dashboard write produces one `governance_log` entry with `entry_kind = decay_knob_changed`, `actor_pseudonym` of the calling admin, payload `{key, old_value, new_value, scope, community_id?}`.
+
+---
+
+## 7. Cross-Cutting Impact
+
+- [x] **Hash-chain governance log touched?** YES — five new `ENTRY_KIND_*` constants added to `crates/api/api/src/governance/governance_log.rs`: `ENTRY_KIND_PARTICIPATION_CRON_TICK`, `ENTRY_KIND_VOTE_OUTCOME_RECORDED`, `ENTRY_KIND_EVIDENCE_QUALITY_RECORDED`, `ENTRY_KIND_ROLLUP_RECOMPUTED`, `ENTRY_KIND_DECAY_KNOB_CHANGED`. Zero migration per `governance_log.entry_kind` being TEXT.
+- [x] **`actor_pseudonym` table or redaction service touched?** YES (additive) — every cron emit logs via `actor_pseudonym`. Cron-batch entries use a synthetic `system` pseudonym (new addition; reserved value, never collides with a real person's pseudonym). Rollup writes log under the rolled-up person's pseudonym.
+- [x] **`CaseStatus::EmergencyRemove` affected?** YES — evidence-quality bad-faith path requires admin to flag an `EmergencyRemove` original report. New endpoint `POST /api/v4/governance/admin/emergency-remove/flag-bad-faith` (instance-admin only) writes a single `reputation_event` row + governance_log entry. ADR-013 admin-driven posture preserved.
+- [x] **AGPLv3 notice / source disclosure affected?** None. No new external dependencies.
+- [x] **Schema changes** — three additions: (1) new `dedupe_key TEXT` nullable column on `reputation_event` with partial unique index; (2) new `source_event_type` enum column on `reputation_event` (`Endorsement | JuryVote | SponsorLiability | FounderSeed | ParticipationCron | DormancyCron | VoteOutcome | EvidenceQuality | ManualSeed`) — defaults to `Endorsement` for backfill, populated by emitters going forward; (3) new `sponsor_allowlist` table (id, community_id NULL, person_id, added_by_admin_id, added_at, note).
+- [x] **Backfill** — existing `reputation_event` rows get `dedupe_key = NULL` (only new cron events use it) and `source_event_type` default-mapped from existing `reason`/source columns via a one-off migration at v1 release.
+- [x] **Threat-model table extension** — [06 §7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) does not currently cover cron-emitted reputation events. v1-implementation phase adds rows for: (a) cron-based reputation farming (e.g. user gaming dormancy cron by writing one trivial comment per week to dodge the −2), (b) admin abuse of `flag-bad-faith` endpoint, (c) allowlist-table tampering.
+- [x] **Federation impact** — none in v1. Cross-instance reputation portability is v2/v3.
+
+---
+
+## 8. Defaults Matrix (every new knob)
+
+| Knob | Namespace | Type | Default | Range | Per-community? | Citation |
+|---|---|---|---|---|---|---|
+| `decay.reporting_accuracy.positive_half_life_days` | `decay.*` | int | 90 | 1–3650 | Yes | §5.2; mirrors v0 default |
+| `decay.reporting_accuracy.negative_half_life_days` | `decay.*` | int OR text(`unbounded`) | 180 | 1–3650 | Yes | §5.2; OQ-V1-03 lean |
+| `decay.jury_reliability.positive_half_life_days` | `decay.*` | int | 90 | 1–3650 | Yes | §5.2 |
+| `decay.jury_reliability.negative_half_life_days` | `decay.*` | int OR text(`unbounded`) | 180 | 1–3650 | Yes | §5.2 |
+| `decay.participation_consistency.positive_half_life_days` | `decay.*` | int | 60 | 1–3650 | Yes | §5.2; faster — current behaviour focus |
+| `decay.participation_consistency.negative_half_life_days` | `decay.*` | int OR text(`unbounded`) | 60 | 1–3650 | Yes | §5.2; symmetric |
+| `decay.endorsement_strength.positive_half_life_days` | `decay.*` | int | 90 | 1–3650 | Yes | §5.2 |
+| `decay.endorsement_strength.negative_half_life_days` | `decay.*` | int OR text(`unbounded`) | 180 | 1–3650 | Yes | §5.2; honour-price principle |
+| `bounds.reporting_accuracy.floor` | `bounds.*` | int | -100 | -10000–0 | Yes | §5.2 |
+| `bounds.reporting_accuracy.ceiling` | `bounds.*` | int | 100 | 0–10000 | Yes | §5.2 |
+| `bounds.jury_reliability.floor` | `bounds.*` | int | -100 | -10000–0 | Yes | §5.2 |
+| `bounds.jury_reliability.ceiling` | `bounds.*` | int | 100 | 0–10000 | Yes | §5.2 |
+| `bounds.participation_consistency.floor` | `bounds.*` | int | -100 | -10000–0 | Yes | §5.2 |
+| `bounds.participation_consistency.ceiling` | `bounds.*` | int | 100 | 0–10000 | Yes | §5.2 |
+| `bounds.endorsement_strength.floor` | `bounds.*` | int | 0 | -10000–0 | Yes | §5.2; OQ-024 floor preserved |
+| `bounds.endorsement_strength.ceiling` | `bounds.*` | int | 200 | 0–10000 | Yes | §5.2 |
+| `deltas.participation_weekly_active` | `deltas.*` | int | 1 | 0–10 | Yes | §5.3 source 1; policy knob |
+| `participation.activity_threshold_comments` | `participation.*` | int | 1 | 0–100 | Yes | §5.3 source 1; context knob |
+| `participation.lookback_days` | `participation.*` | int | 7 | 1–90 | Yes | §5.3 source 1; context knob |
+| `deltas.participation_dormant` | `deltas.*` | int | -2 | -100–0 | Yes | §5.3 source 2; policy knob |
+| `participation.dormancy_window_days` | `participation.*` | int | 30 | 1–365 | Yes | §5.3 source 2; context knob |
+| `job.participation_interval_days` | `job.*` | int | 7 | 1–30 | No (instance) | §5.2 cadence |
+| `job.rollup_interval_days` | `job.*` | int | 7 | 1–30 | No (instance) | §5.5 cadence |
+| `deltas.participation_juror_aligned` | `deltas.*` | int | 1 | 0–100 | Yes | §5.3 source 3 |
+| `deltas.evidence_cited` | `deltas.*` | int | 1 | 0–100 | Yes | §5.3 source 4 |
+| `deltas.evidence_bad_faith` | `deltas.*` | int | -1 | -100–0 | Yes | §5.3 source 4 |
+| `participation.evidence_cited_rationale_threshold_chars` | `participation.*` | int | 256 | 32–4096 | Yes | §5.3 source 4; N2 placeholder — tune per pilot data |
+| `feature.reputation_v1_decay_enabled` | `feature.*` | bool | false | true/false | No (instance) | §10 feature flag |
+| `job.rollup_equal_weights` | `job.*` | bool | true | true/false | No (instance) | §5.5 weighted-avg default |
+
+**Total new knobs: 28** (plus extension of existing `onboarding.sponsor_gate_strategy` enum range to add three new string values).
+
+---
+
+## 9. Backwards Compatibility
+
+- v0 reputation events remain valid. New `dedupe_key` and `source_event_type` columns are nullable / default-able; backfill populates `source_event_type` from `reason` heuristics + source FK presence.
+- v0 single-half-life decay (`decay.positive_half_life_days`) **stays in `governance_config` as the legacy knob**. v1 calculator reads `feature.reputation_v1_decay_enabled`: if `false`, falls through to v0 path; if `true`, reads the new per-dimension/per-direction knobs.
+- Migration plan: ship v1 with `feature.reputation_v1_decay_enabled = false`. Operators flip via dashboard after evaluating defaults against their pilot data. Reverting is a single boolean flip; no data loss because both code paths read the same `reputation_event` rows.
+- Cutover checkpoint: at the end of v1 (call it v1.x), the legacy `decay.positive_half_life_days` knob and the v0 code path are deleted. Operators who have not flipped by then get a one-version-ahead deprecation warning.
+
+### 9.1 ADR-010 compliance posture — feature flag vs snapshot columns (NOT3)
+
+Three of the five v1 sub-PRDs use **snapshot columns** to satisfy ADR-010's no-retroactive-invalidation-of-in-flight-juries invariant: `v1-jury-mechanics.prd.md` snapshots `quorum_snapshot` / `threshold_count_snapshot` / `panel_size_snapshot` / `severity_tier_snapshot` onto `moderation_case`; `v1-sponsor-liability.prd.md` snapshots `grace_expires_at` and severity onto the case at the Pending transition; `v1-admin-dashboard.prd.md` reads `applied_config_snapshot` for in-flight cases under `requires_re_jury` keys. Each snapshot column captures an **in-flight procedural invariant** — a rule under which a specific jury started voting or a specific sponsor was first notified — and is immutable for the life of the procedure. This is the strongest possible compliance: not just "don't retroactively change the rules," but "the old rules are physically preserved on the row in question."
+
+This PRD uses a **feature flag** (`feature.reputation_v1_decay_enabled`) instead of snapshot columns. That is a **weaker** compliance posture, and the weakening is deliberate. The reasons:
+
+- **Reputation snapshots are a rolling derived view, not an in-flight procedure.** A `reputation_snapshot` row for a given (person, community) is recomputed from the append-only `reputation_event` log on a 15-minute tick. There is no single "a decision is in flight" moment that must be pinned; the snapshot is always a recomputed summary of what the events say.
+- **ADR-010's textual invariant is about juries, not reputation.** The invariant reads "a config edit must not retroactively invalidate in-flight juries" (paraphrased). Reputation-decay parameter changes do change historical event contributions retroactively — but "historical events" is the wrong frame; what changes is the *computed delta* for each event the next time the snapshot is recomputed. The events themselves, append-only per ADR-008, do not move.
+- **Per-event-source snapshotting is v2-scope.** To give reputation the same compliance strength as jury-mechanics, every `reputation_event` row would need to store the `applied_delta` as-of-write-time (not just the raw `delta`), and every recompute would need to honour that frozen value. That requires either schema churn (add `applied_delta_snapshot`) or versioned calculator logic (add `calculator_version` column and dispatch). Both are v2-scope per ADR-010's staged release cadence — v1 is the "production-grade governance" milestone, not the "retroactively-complete reputation audit trail" milestone.
+- **Consequence users should understand.** With the feature flag, if an operator flips `feature.reputation_v1_decay_enabled = true` after some v0-era events have been emitted under v0 decay semantics, the next recompute applies v1 semantics to all events including those v0-era ones. This changes the snapshot. It does NOT change the underlying events. A user who wants to see "what my reputation was under v0 decay" can still compute it by re-reading the events through v0 logic — the events did not move, the lens moved.
+- **Escape hatch for pilot operators.** The feature flag is a single boolean; flipping it back is free. Operators who see pilot data under v1 decay they don't like can revert. Snapshot columns cannot be reverted (the snapshot is what it is).
+
+If pilot feedback during v1 surfaces that the weaker compliance is a problem, v2 can upgrade to the snapshot strategy via a migration that adds `applied_delta_snapshot` and populates it from existing event-source-type-conditioned re-computation. That is a forward-compatible path and nothing about v1's feature-flag posture forecloses it.
+
+---
+
+## 10. Security
+
+- Every cron emit signs into `governance_log` via the existing instance key. `system` pseudonym used for cron-batch entries; reserved value, never assigned to a real person.
+- Admin override of reputation events (e.g. revert a cron emit) is **not in v1 scope**. Reserved for v2 with step-up auth per [99 ADR-010 v2 milestone](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md). v1 admins may delete `governance_config` rows (reverting a knob change) but cannot directly mutate `reputation_event` rows.
+- Audit-log every dashboard knob change: one `governance_log` entry per write per OQ-018's per-key shape (one knob = one entry). The OQ-V1-05 trade-off ("N audit entries for N knob changes") is accepted as the v1 cost; batch writes are v1+.
+- `flag-bad-faith` endpoint: instance-admin only; emits `governance_log::ENTRY_KIND_EVIDENCE_QUALITY_RECORDED` with the admin's pseudonym, the original report's case_id, and the `−1 reporting_accuracy` event.
+- `sponsor_allowlist` table: writes via admin endpoints only; both add and remove emit `governance_log` entries (`ENTRY_KIND_SPONSOR_ALLOWLIST_ADDED`, `ENTRY_KIND_SPONSOR_ALLOWLIST_REMOVED`).
+
+---
+
+## 11. Implementation Phases (for follow-up `/prp-plan` runs)
+
+| # | Phase | Description | Status | Depends | PRP Plan |
+|---|---|---|---|---|---|
+| 1 | v1.r1 — schema & feature flag | Add `dedupe_key`, `source_event_type` columns; add `sponsor_allowlist` table; seed 28 new config rows + feature flag; backfill existing `reputation_event` rows | pending | OQ-018 endpoint | - |
+| 2 | v1.r2 — per-dimension chained-halving decay | Replace `compute_applied_delta` with per-dimension/per-direction calculator behind feature flag; add bounds clamping to `recompute_snapshot` | pending | v1.r1 | - |
+| 3 | v1.r3 — multi-source participation events | Add weekly activity cron + dormancy cron in `scheduled_tasks.rs`; add vote-outcome + evidence-quality emitters in `submit_jury_vote.rs`; add `flag-bad-faith` admin endpoint | pending | v1.r2 | - |
+| 4 | v1.r4 — sponsor-gate strategies | Add three new strategies to `create_endorsement` gate; add `sponsor_allowlist` admin endpoints | pending | v1.r1 (allowlist table) | - |
+| 5 | v1.r5 — instance-wide rollup | Add weekly rollup cron; add `GET /admin/reputation/rollup` endpoint | pending | v1.r2 (decay must be live for rollup) | - |
+| 6 | v1.r6 — issue carry-forward bundle | Fix issues #19, #20, #21, #22, #31 in a single PR; ship v1 reputation API stabilised | pending | independent of r2–r5; can land in parallel | - |
+
+---
+
+## 12. Blocking Dependencies
+
+**Hard gates (must be true at v1 schedule time):**
+
+- **OQ-018 admin config write endpoint exists.** All knob changes go through `POST /api/v4/governance/admin/config { key, value }` per its current lean. If endpoint shape changes to batch writes, the dashboard surface composes per-key calls into UI batches; only audit-log granularity is affected.
+- **Phase 5/6 reputation events are stable.** v1 builds on the v0 `reputation_event` table shape; no v0/v1 split in the event log.
+- **`scheduled_tasks::setup` accepts new clokwerk registrations.** Existing pattern at `crates/routes/src/utils/scheduled_tasks.rs:177-233` is the template; v1 adds three more `scheduler.every(...).run(...)` blocks following the same `RunningGuard` + concurrency-flag pattern.
+- **`governance_log::ENTRY_KIND_*` is TEXT-keyed.** Verified at `governance_log.rs:50-68`; no migration for new entry kinds.
+
+**Soft gates (nice to have):**
+
+- **Pilot-week retro data** for tuning the 28 default values. The defaults in §8 are best-guesses; one pilot week of v0 data would let v1 tune them empirically before shipping. Not blocking; defaults can be revisited at v1.x.
+- **OQ-005 UX flows** for the dashboard. v1 ships the API; the dashboard UI can be a v1 stretch goal or v3 admin-dashboard-UX milestone work.
+
+---
+
+## 13. Cross-references
+
+- admin-dashboard-v1 PRD (sibling) — config surface for all 28 knobs; consumes OQ-018's `POST /admin/config` endpoint.
+- jury-mechanics-v1 PRD (sibling) — juror eligibility filter consumes `reputation_snapshot WHERE community_id IS NULL` (rollup rows) when a community lacks enough qualified jurors.
+- sponsor-liability-v1 PRD (sibling) — `apply_sponsor_liability` interacts with negative-decay rate; OQ-025 grace window is sponsor-liability scope, not this PRD's.
+- v1 carry-forward issues: [#19](https://github.com/barrie-cork/lemmy/issues/19), [#20](https://github.com/barrie-cork/lemmy/issues/20), [#21](https://github.com/barrie-cork/lemmy/issues/21), [#22](https://github.com/barrie-cork/lemmy/issues/22), [#31](https://github.com/barrie-cork/lemmy/issues/31).
+- [99-decisions-and-open-questions.md](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — OQ-001, OQ-019, OQ-020 resolved by this PRD; OQ-021 deferred; new OQ-V1-01 through OQ-V1-05 opened.
+
+---
+
+## 14. Sources
+
+Codebase (fork-local):
+
+- `crates/db_schema/src/source/governance/reputation_event.rs:1-43` — v0 event row shape, includes `expires_at` for founder cliffs
+- `crates/db_schema/src/source/governance/reputation_snapshot.rs:1-48` — v0 snapshot row shape, `community_id: Option<CommunityId>` already supports rollup
+- `crates/db_views/reputation/src/impls.rs:1-280` — v0 view queries, `count_active_sanctions` mis-scoped per issue #19
+- `crates/api/api/src/governance/get_my_reputation.rs:27-49` — v0 handler, uses `community_id` for snapshot but instance-wide for sanction count
+- `crates/api/api/src/governance/admin_reputation_stats.rs:1-246` — v0 admin observability surface, `ReputationBuckets` derive `Copy` per issue #21
+- `crates/api/api/src/governance/reputation_snapshot.rs:1-899` — v0 calculator, `compute_applied_delta` line 320 is the decay stub; `check_snapshot_staleness` line 423 has issues #20
+- `crates/api/api/src/governance/config.rs:319-458` — 33 v0 config knobs, `decay.positive_half_life_days` is the only decay knob today
+- `crates/api/api/src/governance/governance_log.rs:50-68` — v0 entry-kind constants, TEXT-keyed
+- `crates/db_views/governance_modlog/src/impls.rs:196` — `list_capability_changed_entries_since` unclamped per issue #22
+- `crates/api/api_common/src/governance.rs:292, 336` — `ReputationBuckets` + `AdminReputationStatsResponse` `Copy` derives per issue #21
+- `crates/db_schema_file/src/enums.rs:589-594` — `ReputationDimension` enum, four variants
+- `crates/routes/src/utils/scheduled_tasks.rs:166-233` — v0 scheduler pattern; v1 adds three more cron blocks following the `RunningGuard` concurrency-guard template
+
+External:
+
+- Friedman & Resnick (2001), "The Social Cost of Cheap Pseudonyms" — exponential-decay reputation foundations
+- Sabater & Sierra (2005), "Review on Computational Trust and Reputation Models" — half-life and chained-halving justification
+
+Design-doc anchors:
+
+- [01-vision-and-principles.md §5.3](../../docs/brehon-law-inspired-network/01-vision-and-principles.md) — four reputation dimensions
+- [02-domain-model.md §4](../../docs/brehon-law-inspired-network/02-domain-model.md) — reputation as event-sourced
+- [04-data-model-and-api.md §3](../../docs/brehon-law-inspired-network/04-data-model-and-api.md) — `reputation_event`, `reputation_snapshot` tables
+- [05-mvp-and-delivery-plan.md §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md) — v1 reputation deliverables ("decay tuning per dimension" + "instance-wide reputation roll-up")
+- [99-decisions-and-open-questions.md OQ-001, OQ-019, OQ-020, OQ-024](../../docs/brehon-law-inspired-network/99-decisions-and-open-questions.md) — all resolved or referenced by this PRD
+
+---
+
+## 14. Resolutions applied (2026-04-19)
+
+Cross-PRD coherence-audit edits applied during v1-PRD edit pass (see `.claude/PRPs/v1-planning-queue.json`):
+
+| ID | Severity | Scope | Status |
+|---|---|---|---|
+| **B3** | blocking | Namespace collapse: `cron.*` / `rollup.*` / `reputation.*` collapsed into `job.*` / `deltas.*` / `participation.*` / `feature.*` to match v0 flat-namespace precedent and eliminate dual cron/job namespace for the same concept. 9 keys renamed per the table below. `bounds.*` preserved as first-class (floor/ceiling clamps are semantically distinct from `thresholds.*` capability cutoffs). | done |
+| **N2** | non-blocking | §5.3 source 4 evidence-cited heuristic now names an explicit threshold `participation.evidence_cited_rationale_threshold_chars = 256` (added to §8 defaults matrix). v1-impl verification task added: verify `jury_vote.rationale` free-text column exists and is populated before this source can ship. If rationale is empty-by-default in v0, Source 4 defers to v2 (explicit evidence-cite UI). | done |
+| **NOT3** | noted | §9.1 added: explicit framing of feature-flag posture as weaker-but-deliberate compared to the snapshot-column posture used by jury-mechanics / sponsor-liability / admin-dashboard. Documents (a) why reputation is a rolling derived view rather than an in-flight procedure, (b) ADR-010's textual scope is juries not reputation, (c) per-event-source snapshotting (`applied_delta_snapshot` / calculator versioning) is forward-compatible v2-scope, (d) the consequence user should understand when flipping the flag, (e) the v2 migration path remains open. | done |
+
+### B3 key-rename table (authoritative)
+
+| Old (draft) | New (final) | Rationale |
+|---|---|---|
+| `cron.participation.weekly_increment` | `deltas.participation_weekly_active` | Policy knob — reputation delta, not a cron knob |
+| `cron.participation.activity_threshold_comments` | `participation.activity_threshold_comments` | Context knob — what "active" means |
+| `cron.participation.lookback_days` | `participation.lookback_days` | Context knob — activity window |
+| `cron.participation.weekly_dormancy_decrement` | `deltas.participation_dormant` | Policy knob — reputation delta, not a cron knob |
+| `cron.participation.dormancy_window_days` | `participation.dormancy_window_days` | Context knob — how long before "dormant" |
+| `cron.participation_interval_days` | `job.participation_interval_days` | Cadence knob → job.* matches v0 `job.snapshot_interval_seconds` |
+| `cron.rollup_interval_days` | `job.rollup_interval_days` | Cadence knob → job.* |
+| `rollup.equal_weights` | `job.rollup_equal_weights` | Rollup job config → job.* (eliminates single-key namespace bloat) |
+| `reputation.v1.decay_enabled` | `feature.reputation_v1_decay_enabled` | Feature flag → feature.* (prophylactic for future deferred-enforcement toggles) |
+
+### Carry-forward impact
+
+- **reputation-tuning-v1 §5.2 cadence sentence** now reads `job.participation_interval_days` (was `cron.participation_interval_days`).
+- **reputation-tuning-v1 §5.3 source-1 and source-2 bullets** use the new policy/context split (4 knobs renamed in place).
+- **reputation-tuning-v1 §8 defaults matrix** reflects the final 15-namespace v1 inventory.
+- **reputation-tuning-v1 §6 feature-flag acceptance criterion** reads `feature.reputation_v1_decay_enabled`.
+- **reputation-tuning-v1 §9 backwards-compat** paragraph cites the same feature-flag key.
+- **admin-dashboard-v1 §3.1 namespace registry** updated separately to the 15-namespace / 138-key total (see admin-dashboard-v1 §11 Resolutions).
+
+Total v1 knobs in this PRD: **28** (unchanged; namespaces redistributed).
+

--- a/.claude/PRPs/prds/v1-sponsor-liability.prd.md
+++ b/.claude/PRPs/prds/v1-sponsor-liability.prd.md
@@ -267,12 +267,27 @@ Add to `crates/routes/src/utils/scheduled_tasks.rs::setup` (sibling of the 15-mi
 
 ```rust
 // Brehon governance v1: sponsor-liability grace-check tick.
-// Every 5 minutes, find SponsorLiabilityPending cases past their
+// Interval is read from `job.grace_check_interval_minutes` at scheduler
+// setup (default 5). Find SponsorLiabilityPending cases past their
 // grace_expires_at and transition them to Fired or Escaped.
 // Disabled in tests via BREHON_DISABLE_GRACE_CHECK_JOB=1 (mirrors the
 // snapshot-job override pattern from S4 design review).
+//
+// Interval-tunability semantics: clokwerk schedules are pinned at
+// `setup()` invocation time — they do NOT hot-reload when the config
+// key changes. Flipping `job.grace_check_interval_minutes` via the
+// admin-config write path (v1-AD-b) takes effect at the next server
+// restart. This matches v0 reputation-snapshot precedent (15-minute
+// interval hardcoded at scheduler setup; config-driven tunability
+// was deliberately deferred). Documented here and in §6.4 so
+// operators know flipping the key requires a restart.
 let context_grace = context.reset_request_count();
-scheduler.every(CTimeUnits::minutes(5)).run(move || {
+let grace_interval_minutes = lemmy_api::governance::config::get_int(
+    &mut context.pool(),
+    "job.grace_check_interval_minutes",
+    ConfigScope::Instance,
+).await.unwrap_or(5) as u32;
+scheduler.every(CTimeUnits::minutes(grace_interval_minutes)).run(move || {
   let context = context_grace.reset_request_count();
   async move {
     if std::env::var("BREHON_DISABLE_GRACE_CHECK_JOB").as_deref() == Ok("1") {
@@ -330,11 +345,11 @@ For each row, inside its **own** `run_transaction` (per-case isolation; one bad 
 
 ### 6.4 Configuration
 
-| Key | Type | Default | Scope |
-|---|---|---|---|
-| `job.grace_check_interval_minutes` | int | 5 | instance |
-| `job.grace_check_batch_size` | int | 100 | instance |
-| `job.grace_check_staleness_alert_multiplier` | float | 2.0 | instance |
+| Key | Type | Default | Scope | Hot-reload? |
+|---|---|---|---|---|
+| `job.grace_check_interval_minutes` | int | 5 | instance | **No — restart required.** Read once at scheduler `setup()`; changes via `POST /admin/config` are persisted but the running scheduler keeps its pinned interval until next restart. Matches v0 reputation-snapshot precedent. |
+| `job.grace_check_batch_size` | int | 100 | instance | Yes — read per-tick by `run_grace_check_batch` |
+| `job.grace_check_staleness_alert_multiplier` | float | 2.0 | instance | Yes — read per-staleness-check |
 
 ---
 

--- a/.claude/PRPs/prds/v1-sponsor-liability.prd.md
+++ b/.claude/PRPs/prds/v1-sponsor-liability.prd.md
@@ -1,0 +1,779 @@
+# Sub-PRD: v1 Sponsor Liability — Athgabál Grace Window + `endorsement/revoke`
+
+**Scope:** v1 of the Brehon governance fork (per ADR-010). Resolves OQ-025; ships the v0-deferred `endorsement/revoke` endpoint per [05 §7.1](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md). Additive to numbered design docs; does NOT supersede any ADR.
+**Created:** 2026-04-19
+**Status:** DRAFT
+**Scheduled:** v1 cycle, gated on **admin-dashboard-v1 PRD** (provides the config-write surface) and **jury-mechanics-v1 PRD** (severity tiers feeding grace-window duration mapping). Issue #24 (partial index on `surety`) folded into this PRD's migration plan.
+**Naming note:** "v1" here is the ADR-010 v1 milestone ("Is it production-grade governance?") — distinct from the V2 messaging capability track.
+
+---
+
+## §1. Vision and Goals
+
+### 1.1 Brehon mapping — `athgabál` as carrot for early intervention
+
+Brehon distraint (`athgabál`, Higgins 2010 p.7) required the wronged party to issue **formal notice** to the wrongdoer's surety, then wait through a **grace period "depending on the nature of the wrong committed"** before seizure could take place. The grace window served two purposes simultaneously:
+
+1. **Procedural fairness** — no surprise seizure; the surety knew enforcement was coming and could weigh response options.
+2. **Carrot for de-escalation** — if the surety revoked their guarantee OR the wrongdoer made restitution within the window, seizure was averted entirely. The grace window is **how Brehon law turned enforcement into invitation**.
+
+v0 of the fork ships sponsor-liability immediately on case-decision (Phase 5b task 56's `apply_sponsor_liability` runs in the same `run_transaction` as the sanction insert). This is the procedurally simplest implementation but **diverges from the Brehon notice requirement**: the sponsor receives no formal notice, has no opportunity to escape liability, and learns of the reputation hit only after the modlog publishes. v1 closes this gap.
+
+### 1.2 v1 goals
+
+1. **Procedural fairness** — every sponsor-liability event is preceded by a formal notice to all active sponsors, with a severity-proportional grace window (Minor 24h / Moderate 72h / Severe 168h defaults; per-community configurable).
+2. **Carrot for early intervention** — sponsor revocation OR defendant restoration during the grace window severs the liability chain. The reputation event is never written; the case transitions to a terminal `SponsorLiabilityEscaped` state.
+3. **Audit transparency** — every grace-window state change emits a `governance_log` entry. Auditors can reconstruct the full timeline (notice issued → revocation OR restoration OR expiry → fired-or-escaped) from the log alone.
+4. **Operator tunability** — grace-window durations and severity-tier mappings are dashboard knobs with sensible Brehon-derived defaults. Per-community overrides allowed; instance-wide defaults seeded.
+5. **Backwards compatibility** — v0 cases that have already fired liability are unaffected; cases mid-flight at v1 deploy time get the most lenient retroactive grace per ADR-010's won't-disadvantage rule.
+
+### 1.3 Non-goals
+
+- Cross-instance sponsor-liability (deferred to v2 federation work — see ADR-014).
+- Automatic restoration mediation (research territory; v2+ at earliest).
+- Negative-band reputation reintegration ceremonies (OQ-021 — v1+ separate PRD).
+- Variant refinement of `Restoration` into `Apology | ContentCorrection | CommunityService` (OQ-003 amendment) — flagged here in §7 but is its own decision.
+
+---
+
+## §2. Scope
+
+### IN scope (v1)
+
+- **`CaseStatus::SponsorLiabilityPending`** — new variant inserted between `Decided` and the eventual liability fire.
+- **`CaseStatus::SponsorLiabilityFired`** — terminal variant; reputation event was written.
+- **`CaseStatus::SponsorLiabilityEscaped`** — terminal variant; sponsor revoked or defendant restored within window.
+- **Severity-proportional grace windows** — Minor 24h / Moderate 72h / Severe 168h defaults; per-community configurable via `governance_config` keys with `community:<id>` scope.
+- **`POST /api/v4/governance/endorsement/revoke`** HTTP endpoint — the v0-deferred sprint-2 endpoint per [05 §2](../../docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md) line 44, now landing.
+- **Scheduled task `sponsor_liability_grace_check`** — runs every 5 min via clokwerk; transitions `SponsorLiabilityPending` cases past `grace_expires_at` to `SponsorLiabilityFired` or `SponsorLiabilityEscaped`.
+- **Audit-log of every grace-window state change** — five new `ENTRY_KIND_*` constants; payloads pseudonymised per ADR-015.
+- **Issue #24 partial index** on `surety(sponsored_id, sponsor_id) WHERE revoked_at IS NULL` — folded into this PRD's migration to avoid a second migration churn.
+- **Migration backfill** for v0 cases mid-flight at upgrade time (most-lenient default per ADR-010).
+
+### OUT of scope (deferred)
+
+- **Cross-instance sponsor-liability** — v2 federation work. Inbound `sponsor_liability_pending` notices are stored as advisory evidence per ADR-006; no auto-application across federation boundary.
+- **Automatic restoration mediation** — research territory; the v1 design treats restoration as defendant-initiated + admin-attested.
+- **Step-up auth for admin revocation** — slot reserved (v2 per ADR-010, alongside Keycloak/MFA).
+- **Notification UX surface** — Lemmy notification + dashboard listing only in v1; richer email / push deferred per OQ-005.
+- **`Restoration` variant refinement** — flagged in §7 as cross-PRD decision; PRD does not commit.
+
+---
+
+## §3. CaseStatus Extensions
+
+### 3.1 New variants
+
+The `CaseStatus` enum at `crates/db_schema_file/src/enums.rs:393-408` currently has 9 variants (Open, ThresholdMet, JurySelection, InReview, Decided, Appealed, Closed, EmergencyRemove, AdminReview). v1 adds **three** new variants:
+
+```rust
+pub enum CaseStatus {
+  // ... existing 9 variants ...
+
+  /// Per OQ-025 / v1 sponsor-liability athgabál window.
+  /// Case has been Decided AND a sanction with sponsor-liability implications
+  /// was created; the case is in its grace window. `moderation_case.grace_expires_at`
+  /// holds the computed deadline. Sponsor revocation OR defendant restoration
+  /// during this window transitions to `SponsorLiabilityEscaped`. Window expiry
+  /// triggers `SponsorLiabilityFired`.
+  SponsorLiabilityPending,
+
+  /// Terminal — the grace window expired without escape. The
+  /// `apply_sponsor_liability` helper (v0 Phase 5b code, now gated) ran and the
+  /// `reputation_event` rows for sponsors were written.
+  SponsorLiabilityFired,
+
+  /// Terminal — sponsor revoked or defendant restored within the grace window.
+  /// `moderation_case.liability_escape_reason` records the escape mechanism.
+  /// No `reputation_event` rows for sponsors were written.
+  SponsorLiabilityEscaped,
+}
+```
+
+### 3.2 New lifecycle
+
+```
+... existing Phase 4 lifecycle through Decided ...
+    │
+    ▼
+[Decided + sanction with liability implications]
+    │
+    ▼  (immediately)
+[Set grace_expires_at = decided_at + grace_window_for_severity]
+    │
+    ▼
+SponsorLiabilityPending
+    │
+    ├── Sponsor revokes endorsement during window ───┐
+    │                                                 │
+    ├── Defendant marks restoration complete +       │
+    │   admin attests during window ─────────────────┤
+    │                                                 │
+    │                                                 ▼
+    │                                          SponsorLiabilityEscaped (terminal)
+    │
+    └── Window expires
+          │
+          ▼
+     [Scheduled grace-check task evaluates escape conditions]
+          │
+          ├── Escape conditions met ──► SponsorLiabilityEscaped (terminal)
+          │
+          └── No escape ──► [apply_sponsor_liability fires]
+                            │
+                            ▼
+                     SponsorLiabilityFired (terminal)
+```
+
+The existing `Decided → Appealed | Closed` paths still apply for cases without sponsor-liability implications (e.g. `JuryDecision::NoAction` cases, or Person-target cases where the target has no active sureties). For those, the v0 lifecycle is preserved unchanged.
+
+### 3.3 ADR-013 compliance
+
+Every existing `match CaseStatus { ... }` site MUST be updated to handle the three new variants explicitly — no `_ =>` arms (per workspace clippy `feedback_clippy_test_style.md` denial). Sites enumerated by grep at PRD-write time:
+
+| Site | Current handling | v1 required handling |
+|---|---|---|
+| `crates/api/api_crud/src/governance/request_appeal.rs:90-102` | `Decided => {}` allows; all others reject | Add `SponsorLiabilityPending => {}` (allow appeal — v1 design choice: appeals during grace window are valid; appeals reset the case to `Appealed` and cancel the grace timer); `SponsorLiabilityFired \| SponsorLiabilityEscaped => Err(NotFound)` (case is terminal — appeal window already expired by the time we reached either) |
+| `crates/api/api/src/governance/admin_close_case.rs:65-75` | All except `Closed` allowed | Add three new variants to allowed-set (admins may force-close terminal liability states for ops purposes, e.g. if scheduler is broken) |
+| `crates/api/api/src/governance/get_case.rs` (any matches) | TBD per implementation audit | Add three variants where matched |
+| `crates/db_views/governance_case/src/impls.rs` | TBD per implementation audit | Add three variants where matched (display label rendering in views) |
+| `crates/db_views/governance_modlog/src/impls.rs` | TBD per implementation audit | Add three variants where matched |
+| `crates/server/tests/e2e.rs` test-side matches | TBD per implementation audit | Add three variants |
+
+The migration adding the three Postgres enum values uses the **`-- no-transaction`** Diesel directive (per Phase 5b task 56's `Restoration` variant precedent and the carry-forward documented in `phase-5a-config-and-reputation-infrastructure.plan.md §17.2`).
+
+### 3.4 Migration enum additions
+
+```sql
+-- migrations/{ts}_add_sponsor_liability_grace_window/up.sql
+-- no-transaction
+ALTER TYPE case_status ADD VALUE IF NOT EXISTS 'SponsorLiabilityPending';
+ALTER TYPE case_status ADD VALUE IF NOT EXISTS 'SponsorLiabilityFired';
+ALTER TYPE case_status ADD VALUE IF NOT EXISTS 'SponsorLiabilityEscaped';
+```
+
+Down migration is a no-op doc-comment per OQ-003 / Phase 5b precedent (Postgres enum-value drop unsupported without full type rebuild).
+
+---
+
+## §4. Grace Window Durations
+
+### 4.1 Severity-proportional defaults (Brehon-derived)
+
+| Severity | Default grace window | Brehon-derived rationale |
+|---|---|---|
+| Minor (Label, VisibilityReduction, Restoration) | **24 hours (1d)** | Restorative-band sanctions imply softest correction; one day suffices for sponsor self-awareness via dashboard or notification |
+| Moderate (TemporaryRestriction, ContentRemoval) | **72 hours (3d)** | Mid-band sanctions deserve the working-week window; matches typical activist-coordination response cadence |
+| Severe (CommunityExclusion, InstanceSuspension, FederationQuarantineRecommendation) | **168 hours (7d)** | Highest stakes — give sponsors the full week to deliberate, consult sponsee, and choose revocation vs. defending |
+
+Severity is determined by the same `severity_for_action` function in `crates/api/api/src/governance/sponsor_liability.rs:112-124` that v0 ships. Snapshot semantics per ADR-010 won't-disadvantage rule: severity is recorded **at jury-decision time** (Phase 4b Decided transition), not re-evaluated against config at fire time.
+
+### 4.2 Configuration knobs (per-community + instance default)
+
+New `governance_config` rows seeded by the v1 migration:
+
+| Key | Type | Instance default | Range | Per-community? |
+|---|---|---|---|---|
+| `liability.grace_window_minor_hours` | int | 24 | 1 – 720 (30d) | Yes |
+| `liability.grace_window_moderate_hours` | int | 72 | 1 – 720 | Yes |
+| `liability.grace_window_severe_hours` | int | 168 | 1 – 720 | Yes |
+| `liability.grace_window_minimum_hours` | int | 1 | hard floor; community cannot go below | No (instance only) |
+| `liability.grace_window_maximum_hours` | int | 720 | hard ceiling; community cannot exceed | No (instance only) |
+| `liability.grace_window_alert_threshold_hours` | int | 24 | audit alert if community sets any per-tier grace below this value | No (instance only) |
+
+Read cascade follows v0 `config.rs` pattern: `community:<id>` row → `instance` row → Rust `const DEFAULT_*` fallback. The dashboard-write path enforces the min/max range; direct `psql` writes also bounded by a Postgres `CHECK` added in the v1 migration (defence-in-depth).
+
+### 4.3 Severity-source semantics (snapshot, not config-derived)
+
+Per ADR-010 the severity that determines grace-window duration is **the severity recorded on the `moderation_case` row at Decided-transition time** (a snapshot of the case's `severity` field), NOT re-evaluated from config at fire-time. This prevents an admin who lowers `Severe → Minor` mid-grace from accelerating fire on cases that were severe at decision-time.
+
+The grace-window duration itself, however, IS read from current config at the `Decided → SponsorLiabilityPending` transition (so admin retuning of grace windows DOES affect cases not yet in pending). After the transition, `grace_expires_at` is locked on the row.
+
+---
+
+## §5. `POST /api/v4/governance/endorsement/revoke` Endpoint
+
+### 5.1 Request DTO
+
+```rust
+// crates/api/api_common/src/governance.rs
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct RevokeEndorsement {
+  pub endorsement_id: EndorsementId,
+  pub reason: String,  // required; passed through redaction layer per ADR-015
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(optional_fields, export))]
+pub struct RevokeEndorsementResponse {
+  pub endorsement_id: EndorsementId,
+  pub revoked_at: DateTime<Utc>,
+  /// Set true when the revocation severed an active grace-window chain
+  /// (transitioned a `SponsorLiabilityPending` case to `SponsorLiabilityEscaped`).
+  pub liability_chain_severed_for_cases: Vec<ModerationCaseId>,
+}
+```
+
+### 5.2 Capability check
+
+- **Self-revocation:** any user MAY revoke their own outbound endorsements (where `endorsement.from_person_id == caller_id`). No reputation gate, no admin role required.
+- **Admin revocation:** instance admins MAY revoke any endorsement; requires `is_admin(&local_user_view)` check. Step-up auth is reserved for v2 per ADR-010 (slot in `RevokeEndorsement` DTO would be a `step_up_token: Option<String>` field added in v2 without breaking v1 callers).
+
+### 5.3 Effect
+
+Inside a single `run_transaction` closure (per `feedback_multi_write_handlers_need_transactions.md`):
+
+1. Load endorsement; verify caller is sponsor OR admin; verify not already revoked.
+2. Set `endorsement.revoked_at = now()`.
+3. Find the matching `surety` row (`from_person_id == sponsor_id, to_person_id == sponsored_id, community_id`); set `surety.revoked_at = now()` if it exists. (Endorsement and Surety are sibling rows created together in `create_endorsement`; revocation severs both.)
+4. **Grace-window evaluation:** query for any `moderation_case` rows with `status = 'SponsorLiabilityPending'` AND `target_person_id = sponsored_id` AND `grace_expires_at > now()`. For each such case:
+   - Re-query active sponsors (those with `revoked_at IS NULL` after step 3's update).
+   - Apply community-configured escape rule (§13's "multiple sponsors" config — default: any-sponsor revocation escapes).
+   - If escape condition met: transition case to `SponsorLiabilityEscaped`, set `liability_escape_reason = json!({"reason": "sponsor_revoked", "endorsement_id": ..., "revoked_by_pseudonym": ...})`, emit `sponsor_liability_escaped` log entry.
+   - Append revoked case ID to response's `liability_chain_severed_for_cases`.
+5. Emit `endorsement_revoked` governance-log entry (always — even if no grace-window severance).
+6. Recompute snapshots for sponsor + sponsee (sibling-write pattern from `create_endorsement.rs:307-309`).
+
+### 5.4 Idempotency
+
+Re-revocation is a no-op: if `endorsement.revoked_at IS NOT NULL` on read, the handler returns the existing `revoked_at` in the response with `liability_chain_severed_for_cases: vec![]` and emits no log entry. Per `feedback_multi_write_handlers_need_transactions.md` — read inside the same transaction to avoid TOCTOU.
+
+### 5.5 Backfill
+
+Prior endorsements (v0 rows) with `revoked_at = NULL` continue working unchanged. The endorsement ID space is preserved; no schema column rename. v0 callers of `POST /api/v4/governance/endorsement` are unaffected.
+
+### 5.6 Route registration
+
+Add to `crates/api/routes/src/lib.rs:518` (after `route("/endorsement", post().to(create_endorsement))`):
+
+```rust
+.route("/endorsement/revoke", post().to(revoke_endorsement))
+```
+
+Handler lives at `crates/api/api_crud/src/governance/revoke_endorsement.rs` (CRUD-shaped per `crates/api/api_crud/src/governance/mod.rs` siblings: `create_endorsement.rs`, `request_appeal.rs`, `create_report.rs`).
+
+---
+
+## §6. Grace-Window Scheduler
+
+### 6.1 New scheduled task
+
+Add to `crates/routes/src/utils/scheduled_tasks.rs::setup` (sibling of the 15-minute `reputation_snapshot` job at lines 166-233):
+
+```rust
+// Brehon governance v1: sponsor-liability grace-check tick.
+// Every 5 minutes, find SponsorLiabilityPending cases past their
+// grace_expires_at and transition them to Fired or Escaped.
+// Disabled in tests via BREHON_DISABLE_GRACE_CHECK_JOB=1 (mirrors the
+// snapshot-job override pattern from S4 design review).
+let context_grace = context.reset_request_count();
+scheduler.every(CTimeUnits::minutes(5)).run(move || {
+  let context = context_grace.reset_request_count();
+  async move {
+    if std::env::var("BREHON_DISABLE_GRACE_CHECK_JOB").as_deref() == Ok("1") {
+      return;
+    }
+    if SPONSOR_LIABILITY_GRACE_RUNNING
+      .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+      .is_err()
+    {
+      warn!("sponsor_liability_grace_check: previous batch still running, skipping this tick");
+      return;
+    }
+    let _guard = GraceCheckRunningGuard;
+    lemmy_api::governance::sponsor_liability_grace::run_grace_check_batch(&context)
+      .await
+      .inspect_err(|e| warn!("Failed to run grace-check batch: {e}"))
+      .ok();
+  }
+});
+```
+
+`SPONSOR_LIABILITY_GRACE_RUNNING: AtomicBool` + `GraceCheckRunningGuard: Drop` follow the `REPUTATION_SNAPSHOT_RUNNING` / `RunningGuard` pattern from `scheduled_tasks.rs:65-79`.
+
+### 6.2 `run_grace_check_batch` semantics
+
+In `crates/api/api/src/governance/sponsor_liability_grace.rs` (new module):
+
+```sql
+-- Conceptual query (Diesel-built in Rust)
+SELECT id, target_person_id, community_id, severity, decided_at, grace_expires_at
+FROM moderation_case
+WHERE status = 'SponsorLiabilityPending'
+  AND grace_expires_at <= now()
+ORDER BY grace_expires_at ASC
+LIMIT $batch_size;  -- config.job.grace_check_batch_size, default 100
+```
+
+For each row, inside its **own** `run_transaction` (per-case isolation; one bad case doesn't block the rest):
+
+1. Re-load case row with `FOR UPDATE` (per `feedback_multi_write_handlers_need_transactions.md` and Phase 5a Watch 9 pattern).
+2. Re-check status (defence against scheduler-vs-handler race): if status is no longer `SponsorLiabilityPending`, skip silently.
+3. Evaluate escape conditions:
+   - Any active sponsor revoked since `decided_at`? → Escape.
+   - Any restoration completed for `target_person_id` between `decided_at` and now (community config dependent — see §7)? → Escape.
+4. If escape: transition to `SponsorLiabilityEscaped`, emit `sponsor_liability_escaped` log, set `liability_escape_reason` with the cause.
+5. If fire: invoke the existing `apply_sponsor_liability` helper (Phase 5b code) — now refactored per §9.1 into a "fire" function gated on this scheduler. After fire, transition to `SponsorLiabilityFired`, emit `sponsor_liability_fired` log entry.
+
+### 6.3 Failure mode + observability
+
+- Cron failure logged via `warn!` (mirrors `reputation_snapshot` pattern at line 198).
+- Cases stuck in `SponsorLiabilityPending` past `2× max grace window` (i.e. >60 days) emit a `tracing::error!` from a sibling staleness check (mirrors `check_snapshot_staleness` at lines 209-228) — observable from admin dashboard.
+- Per-case failure inside the per-case transaction is logged but doesn't block the batch — next tick retries.
+
+### 6.4 Configuration
+
+| Key | Type | Default | Scope |
+|---|---|---|---|
+| `job.grace_check_interval_minutes` | int | 5 | instance |
+| `job.grace_check_batch_size` | int | 100 | instance |
+| `job.grace_check_staleness_alert_multiplier` | float | 2.0 | instance |
+
+---
+
+## §7. Restoration Interaction (OQ-003)
+
+### 7.1 v0 reservation
+
+Phase 5b task 56 reserved `SanctionAction::Restoration` as a **unit variant** (per GOTCHA-56b fallback — see `crates/db_schema_file/src/enums.rs:540-557`). The variant is enum-exhaustiveness only in v0; no v0 handler emits it.
+
+### 7.2 v1 refinement (separate decision; flagged here)
+
+OQ-003 contemplates refining `Restoration` into `Apology | ContentCorrection | CommunityService`. **This PRD does NOT commit to that refinement** — it lives in its own jury-mechanics-v1 PRD (which also handles severity-tier widening). This PRD's responsibility is to define how restoration interacts with the grace window IF it lands.
+
+### 7.3 Restoration completion as escape mechanism
+
+When the defendant marks their own restoration as complete AND an admin attests, the case transitions to `SponsorLiabilityEscaped` (sponsor never absorbs reputation hit). Two sub-questions:
+
+1. **Who initiates?** Defendant via a v1 endpoint `POST /api/v4/governance/restoration/complete` (out of scope for this PRD; lives in restorative-mechanics-v1 PRD). Admin attests via a sibling endpoint OR by approving the defendant's claim from the dashboard.
+2. **Does restoration ALWAYS escape liability, or just reduce severity?** Configurable per-community:
+
+| Key | Type | Default | Scope |
+|---|---|---|---|
+| `liability.restoration_escapes_liability` | bool | `true` | community + instance |
+| `liability.restoration_severity_reduction_steps` | int | 0 (means "full escape"; non-zero shifts severity down N tiers) | community + instance |
+
+Default `true` keeps the carrot; communities preferring "restoration mitigates but doesn't fully escape" set `restoration_escapes_liability = false` and `restoration_severity_reduction_steps = 1` (Severe→Moderate→Minor cascade).
+
+### 7.4 Cross-PRD coordination
+
+This PRD defines the **escape semantics** at the grace-window level. The jury-mechanics-v1 PRD (which lives in OQ-003 and the wider v1 sanction-variant work) defines the **restoration completion mechanism** itself. Both PRDs reference this section as the contract.
+
+---
+
+## §8. Database & Migration Changes
+
+### 8.1 New columns on `moderation_case`
+
+```sql
+ALTER TABLE moderation_case ADD COLUMN grace_expires_at TIMESTAMPTZ;
+COMMENT ON COLUMN moderation_case.grace_expires_at IS
+    'Per OQ-025 v1 sponsor-liability grace window. Set when transitioning Decided → SponsorLiabilityPending; locked thereafter. NULL for cases not in the grace lifecycle (NoAction outcomes, no-sponsor target, v0 backfill).';
+
+ALTER TABLE moderation_case ADD COLUMN liability_escape_reason JSONB;
+COMMENT ON COLUMN moderation_case.liability_escape_reason IS
+    'Per OQ-025: structured reason recording the mechanism that caused SponsorLiabilityEscaped. Schema: {"reason": "sponsor_revoked"|"restoration_completed"|"admin_override", "actor_pseudonym": "...", "endorsement_id"|"restoration_id": ...}. NULL for non-escaped cases.';
+
+CREATE INDEX moderation_case_grace_expires_idx
+    ON moderation_case (grace_expires_at)
+    WHERE status = 'SponsorLiabilityPending';
+```
+
+The partial index above is the scheduler's primary access path — only ~handful of pending cases at any time across an instance, so the partial-index covers the scheduler query in O(rows-pending).
+
+### 8.2 Issue #24 partial index
+
+Per GitHub issue [#24](https://github.com/barrie-cork/lemmy/issues/24) (CodeRabbit finding on PR #10) — fold into this PRD's migration to avoid a second migration churn:
+
+```sql
+CREATE INDEX surety_sponsored_id_active
+    ON surety (sponsored_id, sponsor_id)
+    WHERE revoked_at IS NULL;
+COMMENT ON INDEX surety_sponsored_id_active IS
+    'Per Issue #24 (CodeRabbit, PR #10). Speeds up jury_common::select_eligible_jurors EXISTS subquery and apply_sponsor_liability sponsor enumeration. Partial WHERE matches the existing "active sureties" filter pattern in both call sites.';
+```
+
+The matching `DROP INDEX IF EXISTS surety_sponsored_id_active;` lands in `down.sql`.
+
+### 8.3 New `governance_config` seed rows
+
+The v1 migration seeds the §4.2, §6.4, §7.3, §12.1, §13.1 keys via `INSERT INTO governance_config ... ON CONFLICT DO NOTHING` (matches the Phase 5a task 50 idempotent-seed pattern). Full enumeration in §10 defaults matrix.
+
+### 8.4 Migration backfill (ADR-010 won't-disadvantage rule)
+
+Per ADR-010: existing v0 cases with already-fired liability are unchanged (their `reputation_event` rows already exist; their `status = Decided`; no migration touches them). For cases mid-flight at v1 deploy time:
+
+```sql
+-- For cases that have decided_at recent enough that liability was supposed to fire
+-- under v0 semantics but the v1 deploy interrupts: retroactive grace window of
+-- 24h (Minor default — most lenient per ADR-010 won't-disadvantage rule).
+-- These cases acquire SponsorLiabilityPending status; the scheduler picks them up.
+-- IMPORTANT: must also exclude cases where v0 immediate-fire already wrote
+-- reputation_event rows for sponsors (otherwise we double-fire on next scheduler tick).
+UPDATE moderation_case
+SET status = 'SponsorLiabilityPending',
+    grace_expires_at = decided_at + INTERVAL '24 hours'
+WHERE status = 'Decided'
+  AND decided_at IS NOT NULL
+  AND decided_at > now() - INTERVAL '24 hours'
+  AND target_person_id IS NOT NULL
+  AND id IN (
+    SELECT mc.id
+    FROM moderation_case mc
+    WHERE EXISTS (
+      SELECT 1 FROM surety s
+      WHERE s.sponsored_id = mc.target_person_id
+        AND s.revoked_at IS NULL
+    )
+    AND EXISTS (
+      SELECT 1 FROM sanction sa
+      WHERE sa.case_id = mc.id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM reputation_event re
+      WHERE re.source_case_id = mc.id
+        AND re.reason = 'sponsor_liability_applied'
+    )
+  );
+```
+
+The 24-hour minor-default grace gives sponsors of mid-flight cases a chance to escape liability — most lenient possible interpretation of the v0→v1 transition.
+
+### 8.5 Migration ordering
+
+Single migration file: `migrations/{ts}_add_sponsor_liability_grace_window/`. Combines:
+
+1. `-- no-transaction` directive (required for `ALTER TYPE`).
+2. Three `ALTER TYPE case_status ADD VALUE IF NOT EXISTS ...` statements.
+3. Two `ALTER TABLE moderation_case ADD COLUMN ...` statements.
+4. Index creation: `moderation_case_grace_expires_idx` + `surety_sponsored_id_active` (Issue #24).
+5. Seed `INSERT INTO governance_config ... ON CONFLICT DO NOTHING` for all new keys.
+6. Backfill `UPDATE moderation_case ...` for mid-flight cases.
+
+The migration runs idempotently; reruns after manual admin edits preserve the edits via the unique-on-`(scope, key, valid_from)` constraint.
+
+---
+
+## §9. Handler Changes
+
+### 9.1 `apply_sponsor_liability` split
+
+Phase 5b's `crates/api/api/src/governance/sponsor_liability.rs` currently does both **compute** AND **fire** in one function call (called from `submit_jury_vote::process_vote` step 8.5). v1 splits it:
+
+- **`compute_sponsor_liability(...) -> Vec<SponsorDelta>`** — pure read; computes every per-sponsor delta, founder multiplier, clamped final delta. Does NOT write `reputation_event` or `governance_log`. Idempotent.
+- **`fire_sponsor_liability(deltas: Vec<SponsorDelta>, ...) -> LemmyResult<usize>`** — writes `reputation_event` rows + `sponsor_liability_applied` + `sponsor_liability_clamped` log entries. Called from the **scheduler** (§6) at grace-window expiry, not from `submit_jury_vote`.
+
+Existing `apply_sponsor_liability` becomes a thin wrapper retained for **internal call sites that DO want immediate fire** (none in v1, but preserved for v2 admin-override paths).
+
+### 9.2 New handler: `revoke_endorsement`
+
+File: `crates/api/api_crud/src/governance/revoke_endorsement.rs` (new).
+Module wiring: add `pub mod revoke_endorsement;` to `crates/api/api_crud/src/governance/mod.rs`.
+Route wiring: per §5.6.
+
+Implementation skeleton mirrors `create_endorsement.rs:118-145` (outer handler) + `process_endorsement(...)` (transaction body):
+
+```rust
+pub async fn revoke_endorsement(
+  Json(data): Json<RevokeEndorsement>,
+  context: Data<LemmyContext>,
+  local_user_view: LocalUserView,
+) -> LemmyResult<Json<RevokeEndorsementResponse>> {
+  check_local_user_valid(&local_user_view)?;
+
+  let caller_id = local_user_view.person.id;
+  let caller_pseudonym =
+    actor_pseudonym_helper::get_or_create(&mut context.pool(), caller_id).await?;
+  let is_admin_caller = is_admin(&local_user_view).is_ok();
+
+  let pool = &mut context.pool();
+  let conn = &mut get_conn(pool).await?;
+
+  let outcome = conn
+    .run_transaction(|conn| {
+      async move {
+        process_revocation(conn, caller_id, caller_pseudonym, is_admin_caller, data).await
+      }
+      .scope_boxed()
+    })
+    .await?;
+
+  Ok(Json(outcome))
+}
+```
+
+`process_revocation` body follows §5.3.
+
+### 9.3 `submit_jury_vote` mutation — pointer to jury-mechanics-v1 §9.1
+
+**Per B6 resolution 2026-04-19, the combined post-v1 `submit_jury_vote` handler shape is owned by `v1-jury-mechanics.prd.md` §9.1** (9-step integrated pseudocode: load/validate/insert-vote → tally → threshold-check with deadlock-to-`AdminReview` → winning-decision sanction-insert → **sponsor-liability branch (this PRD contributes the semantics)** → no-sponsor `Decided` branch preserved from v0 → appeal-window bound). See that section for the full flow; the rest of this paragraph documents what **this** PRD contributes into the integrated handler:
+
+1. **The `SponsorLiabilityPending` status transition.** When the sanction has liability implications AND the target has active sponsors, the handler transitions the case to `CaseStatus::SponsorLiabilityPending` (rather than v0's immediate `Decided`). The compute phase (not the fire phase) runs inline; the fire phase runs from the scheduler per §6.
+2. **Grace-window computation.** `grace_expires_at = now() + grace_window_for_severity(severity)`, snapshotted onto `moderation_case.grace_expires_at` at the Pending transition. The severity used is the snapshot severity (§4.3), not the live config-read severity.
+3. **Deferred write set.** On the `SponsorLiabilityPending` branch, `public_case_log` entries and juror `reputation_event` rows are **NOT written at vote-tally time**. They fire from the scheduler when the case transitions to `SponsorLiabilityFired` or `SponsorLiabilityEscaped` (see §6.2 `run_grace_check_batch`). This is deliberate — auditors see "case decided X AND liability outcome was Y" as one coherent timeline event per §11.4. The no-sponsor path (step 8 of the integrated handler) preserves v0 immediate-write semantics.
+
+The **compute/fire split** itself (`compute_sponsor_liability` vs `fire_sponsor_liability`) is specified in §9.1 of this PRD. The **grace-window helper module** (`grace_window_for_severity`, `evaluate_escape_conditions`, `fire_or_escape_case`) is specified in §9.4 of this PRD. The **`submit_jury_vote` call site** where the compute phase fires is specified in `v1-jury-mechanics.prd.md` §9.1 step 7.
+
+### 9.4 Grace-window helper module
+
+New file: `crates/api/api/src/governance/sponsor_liability_grace.rs`. Contains:
+
+- `pub async fn run_grace_check_batch(context: &LemmyContext) -> LemmyResult<()>` — scheduler entry.
+- `pub async fn evaluate_escape_conditions(conn, case_id, target_person_id, community_id) -> LemmyResult<EscapeStatus>` — pure read; returns `Escape{reason}` or `Fire`.
+- `pub async fn fire_or_escape_case(conn, case_row, ...) -> LemmyResult<()>` — per-case transaction body.
+
+Module wired via `crates/api/api/src/governance/mod.rs` `pub mod sponsor_liability_grace;`.
+
+### 9.5 Scheduler wiring
+
+Per §6.1 — additions to `crates/routes/src/utils/scheduled_tasks.rs`.
+
+---
+
+## §10. Defaults Matrix
+
+| Knob | Namespace | Default | Range | Per-community? | Citation |
+|---|---|---|---|---|---|
+| Minor grace window | `liability.grace_window_minor_hours` | 24 (1d) | 1–720 | Yes | §4.1 Brehon-derived; OQ-025 |
+| Moderate grace window | `liability.grace_window_moderate_hours` | 72 (3d) | 1–720 | Yes | §4.1 |
+| Severe grace window | `liability.grace_window_severe_hours` | 168 (7d) | 1–720 | Yes | §4.1; mirrors typical "deliberation week" |
+| Hard floor | `liability.grace_window_minimum_hours` | 1 | (instance) | No | §4.2 audit-floor |
+| Hard ceiling | `liability.grace_window_maximum_hours` | 720 (30d) | (instance) | No | §4.2; matches admin-config-write maximum-config-rolloff |
+| Audit alert below | `liability.grace_window_alert_threshold_hours` | 24 | (instance) | No | §4.2; trips dashboard warning if community sets <24h |
+| Restoration auto-escapes | `liability.restoration_escapes_liability` | true | bool | Yes | §7.3 |
+| Restoration severity-reduction steps | `liability.restoration_severity_reduction_steps` | 0 | 0–3 | Yes | §7.3 |
+| Multi-sponsor escape rule | `liability.multi_sponsor_escape_rule` | `"any_revocation"` | enum: `any_revocation` \| `all_revocation` \| `majority_revocation` | Yes | §13.1 |
+| Revocation rate-limit (per user per day) | `liability.revoke_rate_limit_per_day` | 5 | 1–100 | No (instance) | §12.1 |
+| Grace-check tick interval | `job.grace_check_interval_minutes` | 5 | 1–60 | No (instance) | §6.4 |
+| Grace-check batch size | `job.grace_check_batch_size` | 100 | 1–10000 | No (instance) | §6.4 |
+| Staleness alert multiplier | `job.grace_check_staleness_alert_multiplier` | 2.0 | 1.0–10.0 | No (instance) | §6.4 |
+
+**Total new config keys:** 12. All seeded in the v1 migration via the same `ON CONFLICT DO NOTHING` idempotent-seed pattern from Phase 5a.
+
+---
+
+## §11. Backwards Compatibility (incl. documented behavioural changes)
+
+### 11.1 Already-fired v0 cases
+
+Cases with `status = 'Decided'` AND already-existing `reputation_event` rows for sponsors (the v0 immediate-fire pattern) are **unchanged**. The migration backfill query (§8.4) excludes them via the `AND NOT EXISTS reputation_event` clause.
+
+### 11.2 Mid-flight cases at v1 deploy
+
+Cases `Decided` within the last 24 hours of v1 deploy time get retroactive grace per ADR-010 won't-disadvantage rule:
+
+- `status` flipped to `SponsorLiabilityPending`.
+- `grace_expires_at = decided_at + 24h` (Minor default — most lenient).
+- The scheduler picks them up at `grace_expires_at` and fires-or-escapes.
+
+### 11.3 v0 endpoint contracts preserved
+
+- `POST /api/v4/governance/endorsement` — unchanged (sets `revoked_at = NULL` on insert; v1 readers handle NULL identically to v0).
+- `POST /api/v4/governance/jury/vote` — DTO unchanged; response shape unchanged. Internal lifecycle differs (case may flip to `SponsorLiabilityPending` instead of `Decided`) but the response field `case_decided: true` still fires when quorum is reached.
+- `GET /api/v4/governance/case` — exposes `status: CaseStatus` directly; clients should handle the three new variants. Deprecation pattern: clients that match exhaustively on `CaseStatus` will fail-loud with v1 enum additions; clients that switch on a few variants and ignore the rest are unaffected.
+
+### 11.4 v0 modlog readers — documented behavioural change
+
+`GET /api/v4/governance/modlog` returns rows from `public_case_log` — which for sponsor-liability-bearing cases is ONLY written **at scheduler fire/escape time**, not at vote-tally time (see `v1-jury-mechanics.prd.md` §9.1 step 7's deferred-write set). v0 modlog readers polling the modlog for a case in `SponsorLiabilityPending` state see the case **absent** from the modlog until the grace window expires and the scheduler transitions it to `SponsorLiabilityFired` or `SponsorLiabilityEscaped`. Until then (minutes-to-days delay, bounded by the grace window — default Minor 24h / Moderate 72h / Severe 168h per §4.1), the `modlog` endpoint reports "no entry" for that case.
+
+**This is a documented behavioural change from v0**, not a bug. Framed as correct semantics — the case isn't "publicly decided" until liability is resolved. But v0 clients that poll `GET /modlog` and expect decided cases to appear immediately will observe a delay gap on sponsor-liability cases. No API versioning is introduced for this change (v4 modlog endpoint unchanged); the delay is a property of when `public_case_log` emits.
+
+**Recommended v1 client pattern:**
+- Poll `GET /case/<id>` for the authoritative current state. The `status` field reflects the truth immediately at vote-tally time: `InReview` → (`Decided` | `SponsorLiabilityPending` | `AdminReview`) is visible in the case endpoint within the same transaction as the jury vote.
+- Poll `GET /modlog` for the **public** event stream; accept that sponsor-liability-bearing cases will appear minutes-to-days after the jury decides, once liability is resolved.
+- For admin dashboards, prefer the admin case-list endpoint (`GET /admin/cases?status=SponsorLiabilityPending`) which surfaces mid-grace cases explicitly.
+
+ADR-010's won't-disadvantage rule is honoured: v0-decided cases (those already in `Decided` status at v1 deploy) have their existing `public_case_log` entries preserved, and the migration backfill (§8.4) only touches cases where both the `Decided` status AND the absence of `reputation_event` rows for sponsors indicate the case is genuinely mid-flight. Already-published modlog entries are not rewritten.
+
+### 11.5 Federation interop
+
+ADR-014: governance signals are fork-only AP types. v1 MUST NOT silently introduce a new `SponsorLiabilityPendingObject` AP type — federation handling of grace windows is **out of scope** per §2 OUT (cross-instance sponsor-liability deferred to v2). Federated content actions (sanction-mediated `removed = true` flips on posts) still fire from the scheduler at fire-time, identical to v0 fire-time semantics.
+
+---
+
+## §12. Security
+
+### 12.1 Endorsement revocation rate-limit
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `liability.revoke_rate_limit_per_day` | int | 5 | Per-user per-rolling-24h cap on revocation calls |
+
+Implemented as `count(*) FROM endorsement WHERE from_person_id = caller_id AND revoked_at > now() - INTERVAL '24 hours'` check at handler entry, before any writes. Rate-limit response is `LemmyErrorType::RateLimitError` (consistent with `crates/api/api_crud/src/governance/create_endorsement.rs:198-214` cooldown pattern).
+
+Admin revocation **bypasses the rate-limit** (explicit log entry records the bypass).
+
+### 12.2 Admin revocation requires audit-log + reason
+
+The `RevokeEndorsement.reason` field is **required** (length > 0 after trim — mirror of `admin_close_case.rs:30-32` pattern). Scrubbed via `governance_log`'s `scrub_json` on append (per ADR-015).
+
+### 12.3 Step-up auth — v2 reservation
+
+Per ADR-010 v2 brings step-up auth (Keycloak/MFA). v1 reserves a slot in the DTO (a future `step_up_token: Option<String>` field) but does not enforce. Documented in code-comments and the v2-security-hardening PRD.
+
+### 12.4 Threat-model rows for v1
+
+The threat-model in [06 §7](../../docs/brehon-law-inspired-network/06-security-and-threat-model.md) gains rows for:
+
+| Threat | Mitigation |
+|---|---|
+| Compromised sponsor account mass-revokes during grace windows to escape liability for malicious sponsees | Revocation rate-limit (§12.1) bounds blast radius; admin can re-fire post-hoc via `admin_force_liability_fire` (v2 reservation) |
+| Hostile community admin sets `grace_window.severe = 1h` to squeeze sponsors of dissident defendants | Hard floor `minimum_hours = 1` (instance, non-overridable); audit alert when community sets <`alert_threshold_hours` |
+| Scheduler crash/silent failure leaves cases stuck in `SponsorLiabilityPending` indefinitely | Staleness check (§6.3) emits `tracing::error!`; admin dashboard surfaces stuck cases |
+| Defendant + sponsor collude on fake restoration to escape liability | Admin-attestation requirement on restoration completion (§7.3); audit-log captures attestor pseudonym |
+| Race between scheduler fire and sponsor revocation | Per-case `FOR UPDATE` (§6.2 step 1); revocation handler re-queries case status inside its own tx (§5.3 step 4) |
+
+---
+
+## §13. Open Questions for v1 Design Phase
+
+### OQ-V1-SL-01 — Multi-sponsor escape rule
+
+**Question:** If a user has 3 sponsors and 1 revokes during the grace window, does liability escape for ALL sponsors (including the 2 who didn't revoke), or only for the revoking sponsor?
+
+**Proposal:** Configurable per-community via `liability.multi_sponsor_escape_rule`:
+
+| Value | Behaviour |
+|---|---|
+| `any_revocation` (default) | One sponsor revoking severs the chain entirely; ALL sponsors escape liability. Reflects Brehon "any surety can refuse" reading. |
+| `all_revocation` | Only escapes if EVERY active sponsor revokes during the window. Stricter; prevents one cooperative sponsor from absolving the others. |
+| `majority_revocation` | Escapes when >50% of active sponsors revoke. Mid-ground. |
+
+Default `any_revocation` favours the carrot-for-de-escalation reading. Communities preferring stricter accountability set `all_revocation`.
+
+### OQ-V1-SL-02 — Sponsor-of-sponsor liability chain depth
+
+**Question:** v0 sponsor-liability is 1-deep (sponsor → sponsee). Should v1 cascade liability through multi-hop chains (sponsor of a sponsor of a sanctioned user)?
+
+**Proposal:** **Keep 1-deep for v1.** Multi-hop is an OQ-021-adjacent design surface that needs pilot data before committing. Document as v2 candidate.
+
+### OQ-V1-SL-03 — Sponsor notification cadence
+
+**Question:** How does v1 notify sponsors that they're in a grace window?
+
+**Proposal:** Per OQ-005 (juror notification UX, v1 scope) the v1 notification surface already grows. Reuse it:
+
+- **Lemmy notification row** at `Decided → SponsorLiabilityPending` transition (per `crates/api/api_utils/src/notify.rs` plugin-hook surface).
+- **Admin dashboard listing** of sponsor's active grace-window cases (read-side view crate).
+- **Email** opt-in via `notification_settings` (already exists in upstream Lemmy).
+
+Reminder cadence: at 50% of grace-window elapsed, plus 24h before expiry. No SMS / push in v1 (v3 polish per ADR-010).
+
+### OQ-V1-SL-04 — Restoration mechanism interaction with grace window
+
+**Question:** Should the restoration completion endpoint be in this PRD, the jury-mechanics-v1 PRD, or a third "restorative-mechanics-v1" PRD?
+
+**Current lean:** Restorative-mechanics-v1 PRD owns the endpoint; this PRD owns only the **escape semantics** (§7). Cross-reference both ways.
+
+### OQ-V1-SL-05 — `liability_escape_reason` schema versioning
+
+**Question:** The `liability_escape_reason` JSONB column is unversioned in this PRD. Should we add `{"version": 1, "reason": ..., ...}` from day one for forward-compat?
+
+**Proposal:** **Yes** — add `version: 1` to the JSON shape at v1 land. Future schema changes (e.g. adding `restoration_id` for restoration escapes vs `endorsement_id` for revocation escapes) bump version. Costs nothing in v1; saves a migration in v2.
+
+---
+
+## §14. Cross-References
+
+- **admin-dashboard-v1 PRD** (sibling) — provides the config-write surface for §4.2 community-scoped grace-window keys, §10 defaults matrix, and §13 multi-sponsor escape-rule selection. Soft gate: admins can edit via direct `psql` until dashboard ships, mirroring the v0→v1 admin-config-write maturity curve (OQ-018).
+- **jury-mechanics-v1 PRD** (sibling) — provides the v1 severity tiers (Low/Medium/High/Critical → Minor/Moderate/Severe sponsor-liability buckets) that feed §4.1 grace-window duration mapping. The PRD also handles the OQ-003 `Restoration` variant refinement that this PRD's §7.3 references.
+- **reputation-tuning-v1 PRD** (sibling) — provides per-dimension decay tuning that interacts with how sponsors recover from sponsor-liability events. v1 scope per ADR-010.
+- **OQ-018 admin config write endpoint** (99-register) — provides the HTTP endpoint that the dashboard calls to mutate this PRD's config keys.
+- **OQ-021 (negative-band reintegration ceremony)** — separate v1+ design surface; this PRD's `SponsorLiabilityEscaped` status interacts with reintegration paths.
+
+### v1 carry-forward issues
+
+- **GitHub Issue [#24](https://github.com/barrie-cork/lemmy/issues/24)** — Partial index on `surety(sponsored_id)` — folded into this PRD's migration (§8.2).
+
+---
+
+## §15. Implementation Phases (for follow-up `/prp-plan` runs)
+
+| # | Phase | Description | Status | Depends |
+|---|---|---|---|---|
+| 1 | v1-SL-a — Schema + enum + migration | Three new `CaseStatus` variants; two new `moderation_case` columns; Issue #24 partial index; 12 new `governance_config` seed rows; backfill query | pending | v0 merge complete |
+| 2 | v1-SL-b — `revoke_endorsement` handler + DTO + route | New handler crate; route registration; integration tests for self-revoke + admin-revoke + idempotency + rate-limit | pending | Phase 1 |
+| 3 | v1-SL-c — Scheduler + grace-check helper | New `sponsor_liability_grace.rs` module; clokwerk wiring at 5-min tick; staleness check; per-case `FOR UPDATE` semantics | pending | Phase 1 |
+| 4 | v1-SL-d — `submit_jury_vote` mutation + `apply_sponsor_liability` split | Compute/fire split; `Decided → SponsorLiabilityPending` transition; sponsor notifications | pending | Phases 1, 3 |
+| 5 | v1-SL-e — e2e test suite | Three+ branches: revocation-during-window-escapes; restoration-during-window-escapes; window-expiry-fires; backfill-of-mid-flight | pending | Phases 1–4 |
+
+Each phase is independently shippable behind a feature flag if needed (e.g. `feature.sponsor_liability_grace_window_enabled` per the B3 `feature.*` namespace convention); v1-SL-a alone is harmless (the new variants exist but no handler writes them).
+
+---
+
+## §16. Decisions Log
+
+| Decision | Choice | Alternatives | Rationale |
+|---|---|---|---|
+| Three new `CaseStatus` variants vs reuse of `Decided` | Three variants (Pending, Fired, Escaped) | Single `Decided` with sub-status column | Three variants compose with ADR-013 exhaustive-match invariant; sub-status would split the truth across two columns and require custom checks at every match site |
+| Grace-window severity source | Snapshot at Decided-transition time | Re-evaluate from config at fire-time | Per ADR-010 won't-disadvantage rule; admin retuning of severity mid-grace would otherwise re-litigate the jury's decision |
+| Default grace windows | Minor 24h / Moderate 72h / Severe 168h | All-72h flat; admin sets all | Brehon athgabál required severity-proportional windows; "depending on the nature of the wrong" is the original principle |
+| Multi-sponsor escape rule | Configurable; default any-revocation | Always-all; always-any | OQ-V1-SL-01 — communities should choose; default favours carrot-for-de-escalation |
+| Restoration escape | Configurable per-community | Always-escape; severity-reduction-only | OQ-V1-SL-04; restorative-band community policy varies |
+| Issue #24 partial index | Fold into v1-SL migration | Separate migration | Avoids second migration churn; index needs land in same release as grace-window scheduler that exercises the same query path |
+| Step-up auth for admin revocation | Reserve slot for v2; no enforcement in v1 | Implement now | Per ADR-010 v2 brings step-up auth alongside Keycloak; v1 doesn't have the auth substrate |
+| Scheduler tick interval | 5 minutes | 1 min; 15 min | 5 min balances responsiveness (sponsors don't wait long after grace expires) with DB load (one query every 5 min is negligible) |
+| Mid-flight backfill window | 24h pre-deploy | 7 days; 0 (don't backfill) | Most lenient default per ADR-010; 24h covers same-day rollouts; longer windows risk re-firing already-fired cases without a careful EXISTS guard |
+| `liability_escape_reason` schema versioning | Version 1 from day one | Unversioned | OQ-V1-SL-05 — costs nothing now, saves migration later |
+| Public log + juror reputation timing | Move to scheduler fire-time | Keep at jury-vote-submission time | Auditors see coherent timeline (decision + outcome) in one logical "event"; matches Brehon "decision is incomplete until enforcement resolves" model |
+
+---
+
+## §17. Cross-Cutting Impact
+
+- [x] **Hash-chain governance log touched?** YES — five new `ENTRY_KIND_*` constants: `SPONSOR_LIABILITY_PENDING`, `SPONSOR_LIABILITY_FIRED`, `SPONSOR_LIABILITY_ESCAPED`, `ENDORSEMENT_REVOKED`, `RESTORATION_COMPLETED` (the last reserved here even though emitted by the restorative-mechanics-v1 PRD's endpoint, for `governance_log.rs` const-discipline). Zero migration — `entry_kind` is TEXT per PR #10 / V2 messaging research §Q4.
+- [x] **`actor_pseudonym` table or redaction service touched?** YES (passively) — every grace-window log entry uses `actor_pseudonym_helper::get_or_create` for sponsor / defendant / admin attribution. No change to the helper or redaction logic.
+- [x] **`CaseStatus::EmergencyRemove` affected?** No — emergency-remove cases bypass the grace window entirely (admin override is post-facto reviewed by jury but never produces sponsor-liability per Phase 5b GOTCHA-56h target-person inference).
+- [x] **AGPLv3 notice / source disclosure affected?** No — additive code only.
+- [x] **ADR-013 enum-exhaustiveness invariant?** YES — three new `CaseStatus` variants force every existing match site to update. v1-SL-a phase plan must enumerate via grep (mirror of Phase 5b `SanctionAction::Restoration` audit at plan §10).
+- [x] **ADR-010 won't-disadvantage rule?** YES — §11.2 backfill applies most-lenient default (Minor 24h) to mid-flight cases.
+- [x] **ADR-015 pseudonymisation?** YES — every new log payload routed through `governance_log::append`'s `scrub_json` layer; no raw `person_id` in any payload (Watch 10 grep applies).
+
+---
+
+## §18. Resolutions applied (2026-04-19)
+
+Cross-PRD coherence-audit edits applied during v1-PRD edit pass (see `.claude/PRPs/v1-planning-queue.json`):
+
+| ID | Severity | Scope | Status |
+|---|---|---|---|
+| **B4** | blocking | Flatten `sponsor.liability.*` → `liability.*` to match v0 flat-namespace precedent. 10 keys renamed (6 grace-window + 2 restoration + 1 multi-sponsor + 1 rate-limit). Eliminates a parallel `sponsor.*` top-level namespace for the same concept as `liability.*` (v0 flat). | done |
+| **B6** | blocking | §9.3 reduced from full Rust pseudocode to pointer to `v1-jury-mechanics.prd.md` §9.1 (combined 9-step `submit_jury_vote` handler). This PRD retains ownership of three semantic contributions: the `SponsorLiabilityPending` status transition, the grace-window compute formula, and the deferred `public_case_log` + juror `reputation_event` write set. §9.1 compute/fire split and §9.4 scheduler helper module remain this PRD's concern. | done |
+| **N4** | non-blocking | §11.4 rewritten as explicit documented behavioural change: sponsor-liability-bearing cases appear in modlog minutes-to-days after jury decides (bounded by grace window), not immediately. Client pattern recommended: poll `GET /case/<id>` for authoritative status and `GET /modlog` for the public event stream; admin dashboards should prefer the admin case-list endpoint. §11 heading renamed to "Backwards Compatibility (incl. documented behavioural changes)." | done |
+
+### B4 key-rename table (authoritative)
+
+| Old (draft) | New (final) |
+|---|---|
+| `sponsor.liability.grace_window.minor_hours` | `liability.grace_window_minor_hours` |
+| `sponsor.liability.grace_window.moderate_hours` | `liability.grace_window_moderate_hours` |
+| `sponsor.liability.grace_window.severe_hours` | `liability.grace_window_severe_hours` |
+| `sponsor.liability.grace_window.minimum_hours` | `liability.grace_window_minimum_hours` |
+| `sponsor.liability.grace_window.maximum_hours` | `liability.grace_window_maximum_hours` |
+| `sponsor.liability.grace_window.alert_threshold_hours` | `liability.grace_window_alert_threshold_hours` |
+| `sponsor.liability.restoration_escapes_liability` | `liability.restoration_escapes_liability` |
+| `sponsor.liability.restoration_severity_reduction_steps` | `liability.restoration_severity_reduction_steps` |
+| `sponsor.liability.multi_sponsor_escape_rule` | `liability.multi_sponsor_escape_rule` |
+| `sponsor.liability.revoke_rate_limit_per_day` | `liability.revoke_rate_limit_per_day` |
+
+### Carry-forward impact
+
+- **§4.2 configuration-knobs table** reflects new flat keys (6 rows).
+- **§7.3 restoration-escape knobs** reflect new flat keys (2 rows).
+- **§10 Defaults Matrix** — all 10 sponsor-liability-owned rows carry new key names; `job.grace_check_*` rows unchanged (already under `job.*`).
+- **§12.1 revocation rate-limit table** reflects new flat key name.
+- **§13 OQ-V1-SL-01 multi-sponsor escape-rule** references new flat key.
+- **§15 implementation-phase feature-flag illustration** updated to use `feature.*` namespace (from B3).
+- **admin-dashboard-v1 §3.1 + §5.2** updated separately to reflect these 10 owned keys (see admin-dashboard-v1 §11 Resolutions B4 row).
+
+Total new config keys in this PRD: **12** (10 sponsor-liability + 2 scheduler-job; unchanged; namespace flattened).
+
+---
+
+*Generated: 2026-04-19*
+*Status: DRAFT — v1 scope. Review before running `/prp-plan` (at v1 schedule time, after admin-dashboard-v1 PRD ships).*

--- a/.claude/PRPs/prds/v1-sponsor-liability.prd.md
+++ b/.claude/PRPs/prds/v1-sponsor-liability.prd.md
@@ -92,7 +92,7 @@ pub enum CaseStatus {
 
 ### 3.2 New lifecycle
 
-```
+```text
 ... existing Phase 4 lifecycle through Decided ...
     │
     ▼
@@ -296,6 +296,8 @@ scheduler.every(CTimeUnits::minutes(5)).run(move || {
 
 `SPONSOR_LIABILITY_GRACE_RUNNING: AtomicBool` + `GraceCheckRunningGuard: Drop` follow the `REPUTATION_SNAPSHOT_RUNNING` / `RunningGuard` pattern from `scheduled_tasks.rs:65-79`.
 
+**Scheduler latency bound.** The 5-minute tick interval means a case whose `grace_expires_at` falls at 00:00:01 may not transition to `SponsorLiabilityFired`/`SponsorLiabilityEscaped` until as late as 00:05:00 — worst-case **~4m 59s** delay. This is well inside the grace-window scale (24h minor / 72h moderate / 168h severe), so it does not affect procedural fairness, but user-facing surfaces that display `grace_expires_at` must document "expires at X" as "will be processed within ≤5 min after X" rather than "fires at exactly X". The `BREHON_DISABLE_GRACE_CHECK_JOB` env toggle (per §6.4) disables the scheduler entirely for test environments.
+
 ### 6.2 `run_grace_check_batch` semantics
 
 In `crates/api/api/src/governance/sponsor_liability_grace.rs` (new module):
@@ -444,6 +446,8 @@ WHERE status = 'Decided'
 
 The 24-hour minor-default grace gives sponsors of mid-flight cases a chance to escape liability — most lenient possible interpretation of the v0→v1 transition.
 
+**Performance note.** The backfill UPDATE uses three nested `EXISTS` subqueries (`surety`, `sanction`, `reputation_event`). The `decided_at > now() - INTERVAL '24 hours'` filter bounds the driving set tightly — in any realistic deployment this is at most a few hundred rows — but implementers should still run `EXPLAIN (ANALYZE, BUFFERS)` against a production-sized staging copy before deploy. If the staging EXPLAIN shows a sequential scan on `moderation_case` or >1s of runtime, rewrite as a `JOIN` form (`LEFT JOIN reputation_event re ON re.source_case_id = mc.id AND re.reason = 'sponsor_liability_applied'` + `WHERE re.id IS NULL`) and add a batch-size `LIMIT` with a repeat-until-empty wrapper. The logic is correct as-written — the three EXISTS guards are load-bearing (surety presence, sanction presence, no-prior-fire) — but the shape can be optimised without semantic drift.
+
 ### 8.5 Migration ordering
 
 Single migration file: `migrations/{ts}_add_sponsor_liability_grace_window/`. Combines:
@@ -553,7 +557,7 @@ Per §6.1 — additions to `crates/routes/src/utils/scheduled_tasks.rs`.
 | Grace-check batch size | `job.grace_check_batch_size` | 100 | 1–10000 | No (instance) | §6.4 |
 | Staleness alert multiplier | `job.grace_check_staleness_alert_multiplier` | 2.0 | 1.0–10.0 | No (instance) | §6.4 |
 
-**Total new config keys:** 12. All seeded in the v1 migration via the same `ON CONFLICT DO NOTHING` idempotent-seed pattern from Phase 5a.
+**Total new config keys:** 13 (10 `liability.*` + 3 `job.grace_check_*`). All seeded in the v1 migration via the same `ON CONFLICT DO NOTHING` idempotent-seed pattern from Phase 5a.
 
 ---
 
@@ -771,7 +775,7 @@ Cross-PRD coherence-audit edits applied during v1-PRD edit pass (see `.claude/PR
 - **§15 implementation-phase feature-flag illustration** updated to use `feature.*` namespace (from B3).
 - **admin-dashboard-v1 §3.1 + §5.2** updated separately to reflect these 10 owned keys (see admin-dashboard-v1 §11 Resolutions B4 row).
 
-Total new config keys in this PRD: **12** (10 sponsor-liability + 2 scheduler-job; unchanged; namespace flattened).
+Total new config keys in this PRD: **13** (10 `liability.*` + 3 `job.grace_check_*`; namespace flattened from the pre-B4 draft's `sponsor.liability.*` / `cron.*` / `job.*` split).
 
 ---
 

--- a/.claude/PRPs/v1-issue-triage.md
+++ b/.claude/PRPs/v1-issue-triage.md
@@ -1,0 +1,273 @@
+# v1 Issue Triage — Phase 6 Parallel Workability
+
+**Date:** 2026-04-19
+**Author:** triage-claude (Opus 4.7, 1M ctx)
+**Audience:** advisor + user, deciding what to plan/ship while Phase 6 federation runs in the advisor worktree
+**Inputs:** open `v1` issues #11–#31 (excluding plan-drift #6); Phase 6 plan at
+`C:\Users\barri\Developer\brehon-fork-advisor-phase6\.claude\PRPs\plans\phase-6-federation.plan.md`;
+`docs/brehon-law-inspired-network/IMPLEMENTATION-PLAN-v0.md` §3 Phase 6;
+`99-decisions-and-open-questions.md` OQ-018, OQ-019, OQ-025
+**Phase 6 modified-files cross-reference:** plan §"Files to Change" → MODIFIED FILES table (lines 430–447)
+
+---
+
+## §1 Executive Summary
+
+**Bucket counts (19 issues triaged):**
+
+| Bucket | Count | Issue numbers |
+|---|---:|---|
+| **A. Plan-and-ship now** (zero conflict, no design blocker) | **10** | #20, #21, #22, #23, #24, #25, #26, #27, #28, #31 |
+| **B. Plan now, ship after Phase 6 merges** (file-overlap rebase risk) | **4** | #19, #29, #30 + a half-credit on #16 (see §4) |
+| **C. Wait — needs design/PRD first** | **5** | #11, #14, #15, #16, #19 (see notes) |
+| **D. Wait — direct Phase 6 conflict** | **0** | (see §4 watch-list — #19 and #29 sit on the boundary) |
+
+Note: #19 appears in two rows because it is a single-file isolated CodeRabbit fix (Bucket B by file-conflict policy) but its semantics depend on the OQ-019 / admin-dashboard "what's the right scope?" question (Bucket C lens). The recommended posture: **plan now, ship the mechanical change post-Phase-6 with OQ-019 referenced as a follow-up** — see §4.
+
+**Recommended first batch the user can hand off this week (highest confidence Bucket A):**
+
+1. **Batch CR-MECH** — issues #20, #21, #22, #23, #25, #27, #28 (7 issues) — all single-file mechanical CodeRabbit follow-ups, zero Phase 6 file overlap, total expected effort ~half day. PR title: `chore(v1-cleanup): mechanical CR follow-ups from PR #10`.
+2. **Batch CR-PROBES** — issues #26, #28 (the two `actix_smoke_probe.sh` cross-platform/AWK-state-machine fixes plus the `notify_smoke_probe.sh` zero-notify guard). All under `scratch/phase-5c-probes/`, zero crate overlap. PR title: `chore(probes): cross-platform + AWK-robustness for phase-5c smoke probes`.
+3. **Batch CR-DB-INDEX** — issue #24 alone (new migration adding partial index on `surety(sponsored_id) WHERE revoked_at IS NULL`). Migration timestamp must be `> 2026-04-20-000100-0000` (latest existing) but **also strictly different from any timestamp Phase 6 task 70 will pick** — Phase 6 uses `> 2026-04-20-000000-0000` per its plan §11 task 70. Coordinate timestamp choice with advisor (use `2026-04-21-...` or later to give Phase 6 priority on `2026-04-20-...`).
+
+**Surprises uncovered:**
+
+- **Issue #16 (OQ-018 admin-config-write endpoint)** is the *only* issue with a hard design blocker. It needs the admin-dashboard PRD before code lands. Per the user's framing, the dashboard PRD reframes most "what's the default?" questions as "ship a sensible default + make it configurable." This **does not, however, upgrade any other v1 issue from C → A** — the 4 other Bucket-C items (#11, #14, #15, see also #19 dual-list) are not waiting on a config decision; they are waiting on jury-mechanics-v1, appeal-flow-v1, or community-membership-v1 design. See §4.
+- **Issue #29** (e2e.rs config-flip test flakiness at line 2715) sits on `crates/server/tests/e2e.rs` — the same file Phase 6 task 77 adds `sanction_notice_round_trip` to. Not a hard conflict (different test functions in the same file), but **rebase risk is real** if Phase 6 lands a sweeping reorg of test helpers. Recommended: hold #29 until Phase 6 merges, then ship in a 1-line fix PR.
+- **Issue #19** (community-scope `count_active_sanctions`) modifies `crates/db_views/reputation/src/impls.rs` (the `count_active_sanctions` function, line 42) and threads `Option<CommunityId>` into `crates/api/api/src/governance/get_my_reputation.rs:41`. **Phase 6 does not touch either file**, but the semantic change overlaps with the `active_sanctions` constructor question in #31, so batch them.
+- **Issue #30** (governance-ai-review 413) is infrastructure — workflow YAML only. Zero code conflict. Bucket B because the user may want to wait until after Phase 6 ships before deciding among options A–E (the Phase 6 PR will be the next 413 victim).
+
+---
+
+## §2 Per-Issue Triage Table
+
+Files verified by `Read` / `Glob` against current `governance-v0` HEAD (`ddb9fc4e9`).
+
+| # | Title (short) | Bucket | Files (verified) | Phase-6 conflict | Effort | Batch | One-line rationale |
+|---:|---|---|---|---|---|---|---|
+| 11 | original-reporter appeals on `request_appeal` | **C** | `crates/api/api_crud/src/governance/request_appeal.rs` (line 6 doc + handler logic) | none — Phase 6 doesn't touch this file | M | jury-v1 PRD batch | Needs appeal-flow-v1 PRD to define who-can-appeal-when matrix; not a single mechanical change |
+| 12 | add `assignee` filter to `list_cases` DTO | **A** | `crates/api/api_common/src/governance.rs` (DTO `ListGovernanceCases`), `crates/api/api/src/governance/list_cases.rs` (line 9 doc + handler), `crates/db_views/governance_case/src/impls.rs` (`CasesFilter`) | none | S | filter-batch | Mechanical: add `assignee: Option<PersonId>` to DTO, thread into `CasesFilter`, add Diesel filter clause. No Phase 6 overlap. (Re-bucketed from C → A: this is a pure additive DTO change, no new policy.) |
+| 13 | per-community permission filter on `list_cases` | **C** | same as #12 + new permission helper | none on files; design overlap with community-membership-v1 | M | community-perm-v1 batch | Needs community-membership policy — what counts as "belongs to community"? Subscriber, mod, follower, ever-posted? Ship after a community-perm PRD or alongside #12 in a richer DTO that gates on a clear answer. |
+| 14 | re-jury path for Appealed cases | **C** | `crates/api/api/src/governance/admin_close_case.rs`, `crates/api/api_crud/src/governance/request_appeal.rs`, possibly new handler `re_jury` | none | L | jury-v1 PRD batch | Needs sub-PRD: panel size for re-jury (5 vs 7?), threshold change, who picks the new panel, what happens to original jurors. Block on PRD before code. |
+| 15 | formalise appeal window with bounded duration | **C** | `crates/api/api_crud/src/governance/request_appeal.rs` (lines 11–12 doc), `crates/api/api/src/governance/config.rs` (new config key `governance.appeal.window_hours`), DTO surface | none | S–M | jury-v1 PRD batch | Needs OQ-style decision (window length, instance vs community scope). Once decision lands, the code change is small. **Admin-dashboard PRD likely upgrades to A** because "ship a default + make it configurable" pattern fits perfectly — flagged in §4. |
+| 16 | OQ-018 admin config-write HTTP endpoint | **C** | new files: `crates/api/api/src/governance/admin_set_config.rs`, route in `crates/api/api/src/governance/mod.rs`, DTO in `crates/api/api_common/src/governance.rs`, e2e test | none on existing files | L | dashboard-PRD batch | Hard design blocker per OQ-018 (still open). Per-key vs batch, dry-run shape, instance-only vs community-scoped admin gating, audit-trail granularity. **The admin-dashboard PRD this issue is gating on is the same PRD that unblocks #15 and shapes #19** — write the PRD first, then this issue and #15 land together. |
+| 19 | community-scope `count_active_sanctions` in `get_my_reputation` | **B** *(C-flavoured)* | `crates/db_views/reputation/src/impls.rs:42` (signature change), `crates/api/api/src/governance/get_my_reputation.rs:41` (call-site update) | none on files; **but** semantic overlap with #31 + #20 (all touch reputation read-path) | S | reputation-cleanup batch | Mechanical fix is small (add `community_id: Option<CommunityId>` param, add `.filter(...)` for community-scoped sanctions). The "what *should* community-scope mean for sanctions?" question is real but answerable from existing data model — `sanction.community_id` already exists. Plan now, ship after Phase 6 to avoid touching the reputation read-path concurrently with Phase 6's reputation-event-driven federation work. |
+| 20 | harden staleness_check against interval overflow + soften empty-table | **A** | `crates/api/api/src/governance/reputation_snapshot.rs:440–459` (`check_snapshot_staleness`) | none | XS | CR-MECH | Two-line fix: `interval_s.saturating_mul(2)` + downgrade `tracing::error!` to `tracing::warn!` (or empty-arm pre-check). Pure mechanical CR follow-up. |
+| 21 | drop `Copy` on `ReputationBuckets` + `AdminReputationStatsResponse` | **A** | `crates/api/api_common/src/governance.rs:336` and `:339` | none | XS | CR-MECH | Single-line derive change × 2. Forward-compat hygiene. |
+| 22 | bound limit on `list_capability_changed_entries_since` | **A** | `crates/db_views/governance_modlog/src/impls.rs:200–217` | none | XS | CR-MECH | Add `let limit = limit.min(MAX_LIMIT);` at top of function. One-line fix. |
+| 23 | serde serialization for `governance_log` signature as base64 | **A** | `crates/db_views/governance_modlog/src/lib.rs:85–94` (struct `CapabilityChangeLogEntry`); possibly add `serde_bytes` workspace dep | **near-miss** — Phase 6 adds 4 new entry-kind const strings to `crates/api/api/src/governance/governance_log.rs`, but does NOT change the `CapabilityChangeLogEntry` view-struct. Independent. | XS | CR-MECH | Add `#[serde(with = "serde_bytes")]` on `signature: Option<Vec<u8>>` (and a tiny ts-rs annotation tweak). One-line + dep-add. |
+| 24 | partial index on `surety(sponsored_id) WHERE revoked_at IS NULL` | **A** | new migration `migrations/<ts>_add_surety_active_index/{up,down}.sql` | **timestamp-coordination only** — Phase 6 task 70 picks `> 2026-04-20-000000-0000`. Use `2026-04-21-...` or later for #24's migration to give Phase 6 priority. | XS | CR-DB-INDEX | One CREATE INDEX (partial) + one DROP INDEX. Standard Postgres pattern, already named in CR. Migration filename must not collide with Phase 6's `add_federation_attestations`. |
+| 25 | RCA evidence examples should use batch-file reproductions | **A** | `.claude/PRPs/debug/rca-issue-8-cargo-test-exit-code-masking.md` (docs only) | none | XS | CR-MECH (docs subset) | Markdown-only edit. Add two `.bat` reproductions (broken + fixed) to existing RCA. |
+| 26 | actix_smoke_probe route threshold + cross-platform path | **A** | `scratch/phase-5c-probes/actix_smoke_probe.sh:13` | none | S | CR-PROBES | Update header comment + gate `cmd //c` behind `[[ "$OSTYPE" == "msys"* ]]`. Bash script only. |
+| 27 | actix_smoke_probe AWK brittleness on lib.rs reformat | **A** | `scratch/phase-5c-probes/actix_smoke_probe.sh:35` (AWK_BLOCK pattern) | none | S | CR-PROBES | Replace fixed end-marker AWK with paren-depth state machine. Bash/awk only. |
+| 28 | notify_smoke_probe should fail on zero-notify | **A** | `scratch/phase-5c-probes/notify_smoke_probe.sh:81` | none | S | CR-PROBES | Capture background `LISTEN psql` stdout/stderr to file; assert non-empty after wait; non-zero exit otherwise. |
+| 29 | config-flip assertion determinism in e2e.rs | **B** | `crates/server/tests/e2e.rs:2715` | **soft conflict** — Phase 6 task 77 adds new test `sanction_notice_round_trip` to the same file (different function, but rebase risk if helper layout reorganises). | XS | post-phase-6 | One-line assertion change (or 2-line seeding adjustment). Hold until Phase 6 merges to avoid double-touching e2e.rs. |
+| 30 | governance-ai-review workflow 413s on phase PRs | **B** | `.github/workflows/governance-ai-review.yml` (no code conflict) | none on workflow file; but Phase 6 PR will be the next 413 victim | M (decision) / S (impl) | post-phase-6 | Decide between options A–E from issue body. Workflow infra, no code overlap. Plan now (decision), ship after Phase 6 to gather one more data point (Phase 6 PR will fail too — strengthens case). |
+| 31 | make `active_sanctions` constructor explicit (`From` impl defaults to 0) | **A** | `crates/db_views/reputation/src/lib.rs:74–89` (the `From<&ReputationSnapshot> for ReputationSummaryView` impl — note: issue body says `ReputationSummary`; actual struct is `ReputationSummaryView`) | none — Phase 6 doesn't touch reputation views | S | reputation-cleanup batch (with #19) | Pick option B (named constructor `from_snapshot_needing_sanction_count`) or C (`Option<i64>`). Touches one impl + 1–2 call sites in `crates/api/api/src/governance/get_my_reputation.rs:43–46` and `crates/db_views/reputation/src/impls.rs::build_summary_view` (line 56). |
+
+---
+
+## §3 Recommended Batch Groups
+
+### Batch CR-MECH — `chore(v1-cleanup): mechanical CR follow-ups from PR #10`
+**Issues:** #20, #21, #22, #23, #25
+**Files:** `crates/api/api/src/governance/reputation_snapshot.rs`, `crates/api/api_common/src/governance.rs`, `crates/db_views/governance_modlog/src/{impls.rs,lib.rs}`, `.claude/PRPs/debug/rca-issue-8-cargo-test-exit-code-masking.md`
+**Scope (one paragraph):** Five single-file mechanical fixes from CodeRabbit on PR #10. Each is XS effort and produces a clear cargo-check + clippy + (where relevant) e2e signal. Bundle as one commit-per-issue, one PR. Adds `serde_bytes` workspace dep (#23). No new design surface, no Phase 6 conflict, no migration. Ships in a single review pass; CodeRabbit will likely re-affirm in <30 min.
+**Estimated PR size:** ~50 LOC across 4 files + 1 doc edit.
+**Validation:** `cargo check --workspace --features full` + `cargo clippy -p lemmy_api -p lemmy_api_common -p lemmy_db_views_governance_modlog --no-deps -- -D warnings`. No e2e required (no behaviour change).
+
+### Batch CR-PROBES — `chore(probes): cross-platform + AWK-robustness for phase-5c smoke probes`
+**Issues:** #26, #27, #28
+**Files:** `scratch/phase-5c-probes/{actix_smoke_probe.sh,notify_smoke_probe.sh}` (no Rust)
+**Scope:** Three bash/awk hardening fixes. (1) Cross-platform OS detection on `cmd //c`, (2) replace fixed-marker AWK with paren-depth state machine for governance-scope extraction, (3) capture LISTEN psql output and fail loud on zero-notify. All in `scratch/` — zero impact on crates, builds, or CI Rust gates. Pure shell-script polish that strengthens the smoke probes against future code reformats.
+**Estimated PR size:** ~80 LOC across 2 files.
+**Validation:** Run each probe locally (sh on Windows via Git Bash and on Linux via WSL or CI runner) and assert exit-code parity vs current behaviour on the unmodified governance scope.
+
+### Batch CR-DB-INDEX — `perf(governance): partial index on surety(sponsored_id) for active-record lookups`
+**Issues:** #24
+**Files:** new `migrations/2026-04-21-XXXXXX-0000_add_surety_sponsored_id_active_index/{up,down}.sql`, `crates/db_schema/src/schema.rs` (regenerated by `diesel print-schema`)
+**Scope:** One new migration adding `CREATE INDEX surety_sponsored_id_active ON surety (sponsored_id, sponsor_id) WHERE revoked_at IS NULL;` and the matching DROP. Mirrors the active-record-index pattern Postgres docs recommend for nullable-timestamp columns. **Coordinate timestamp with advisor**: Phase 6 task 70's migration is `> 2026-04-20-000000-0000`; pick `2026-04-21-...` or later for #24 to ensure deterministic ordering. Cargo will regenerate `schema.rs` on `diesel print-schema`; no manual schema edits.
+**Estimated PR size:** 2 SQL files + auto-generated `schema.rs` diff.
+**Validation:** `cargo check -p lemmy_db_schema --features full`; verify `EXPLAIN` on `select_eligible_jurors`'s EXISTS subquery shows index-scan instead of seq-scan via a smoke probe in `scratch/`.
+
+### Batch FILTER-DTO — `feat(governance): assignee filter on list_cases (v1)`
+**Issues:** #12 (alone — #13 deferred to community-perm PRD)
+**Files:** `crates/api/api_common/src/governance.rs` (DTO `ListGovernanceCases` + ts-rs export), `crates/api/api/src/governance/list_cases.rs` (handler doc + thread param), `crates/db_views/governance_case/src/impls.rs` (`CasesFilter` + Diesel filter clause)
+**Scope:** Pure additive DTO change. Add `assignee: Option<PersonId>` to `ListGovernanceCases`; thread to `CasesFilter`; add `.filter(jury_assignment::juror_id.eq(...))` join clause when `assignee = Some(_)`. No new policy — assignee-by-PersonId is well-defined, no community-scope ambiguity (that's #13's territory). Update handler doc-comment to remove "v1 scope per plan §11.7 GOTCHA" line for the assignee field (#13's per-community filter line stays).
+**Estimated PR size:** ~30 LOC + e2e test extension.
+**Validation:** Add a sub-test to existing `list_cases` e2e or write a new small test `list_cases_filters_by_assignee`.
+
+### Batch REP-CLEANUP — `refactor(reputation): explicit From + community-scoped sanction count`
+**Issues:** #19 + #31 (sequenced one commit each)
+**Files:** `crates/db_views/reputation/src/lib.rs` (drop or rename `From` impl), `crates/db_views/reputation/src/impls.rs:42` (`count_active_sanctions` signature `Option<CommunityId>`), `crates/api/api/src/governance/get_my_reputation.rs:41–46` (call-site update + remove `..ReputationSummaryView::from(&snapshot)` shorthand)
+**Scope:** Two related changes that touch the same reputation read-path. (1) #31 drops the silent-default `From<&ReputationSnapshot>` pattern in favour of either named-constructor or `Option<i64>` field shape — this forces every call site to think about `active_sanctions` explicitly. (2) #19 then threads `Option<CommunityId>` through `count_active_sanctions` so community-scoped reputation reads return community-scoped sanction counts (eliminating the misleading composite where snapshot is community-scoped but count is instance-wide). Recommended sequencing: ship #31 first (mechanical refactor), then #19 (semantic fix that benefits from the explicit constructor). **Hold until after Phase 6 merges** to avoid touching the reputation read-path concurrently with Phase 6 task 76's federation publish (which fires *from* `submit_jury_vote` — separate call path but adjacent in the codebase).
+**Estimated PR size:** ~60 LOC + e2e test for community-scoped count.
+
+### Batch INFRA-AI-413 — `infra(ci): pick mitigation for governance-ai-review 413 on phase PRs`
+**Issues:** #30 (alone)
+**Files:** `.github/workflows/governance-ai-review.yml` (option C: rewrite to sample N most-interesting files; option D: delete file + update `.coderabbit.yaml` and README)
+**Scope:** Decision-then-impl. The decision is "which of options A–E in the issue body do we pick?" — the user should choose. Once chosen, the workflow change is small (~50 LOC for option C, or 5 LOC + readme blurb for option D). **Hold until after Phase 6 merges** because the Phase 6 PR will be the next 413 victim and provides a fresh data point. CodeRabbit Pro is the authoritative review path either way.
+
+### Issues NOT batched — `Watch list / PRD-blocked`
+**Issues:** #11, #13, #14, #15, #16, #29
+- #11, #14: jury-mechanics-v1 PRD (re-jury path, who-can-appeal matrix)
+- #13: community-membership-v1 PRD
+- #15: admin-dashboard PRD upgrade candidate (see §4)
+- #16: admin-dashboard PRD blocking (the canonical OQ-018 issue)
+- #29: hold one PR cycle for Phase 6 to land first
+
+---
+
+## §4 Watch-List — Bucket Assignment Depends on a Phase-6 Choice or v1 PRD
+
+### W1 — Issue #29 (e2e.rs config-flip flakiness)
+**Status:** Bucket **B** today; could become A if Phase 6 task 77 lands cleanly without restructuring `e2e.rs` test helpers.
+**Phase-6 dependency:** task 77 adds `sanction_notice_round_trip` test function and may introduce 2-DB test scaffolding that other tests adopt. If the scaffolding refactor relocates `seed_case` / `eligibles[]` helpers around line 2715, #29's fix needs to be re-anchored.
+**Decision rule:** Wait for Phase 6 PR to open; check whether `crates/server/tests/e2e.rs` got reorganised. If yes, hold #29 until merge. If no (Phase 6 only appends a new test function), upgrade #29 to A and ship in the next mechanical batch.
+
+### W2 — Issue #15 (formalise appeal window) + admin-dashboard PRD
+**Status:** Bucket **C** today (waits on a "what's the default appeal window?" answer).
+**Upgrade path:** **The admin-dashboard PRD reframes "what's the default?" as "ship a sensible default (say, 7 days) + make it a configurable governance_config key + UI to tune."** If the user adopts that framing, #15 upgrades to **B** — the implementation becomes mechanical (add config key, read it in `request_appeal.rs` to reject post-window appeals, surface in DTO). The remaining decision shrinks to "what's the v0 default value?" which is one judgment call, not a multi-week design.
+**Decision rule:** When the admin-dashboard PRD is written, re-triage #15 immediately. Likely outcome: B → ships alongside #16 once #16's HTTP endpoint exists.
+
+### W3 — Issue #19 (community-scope count_active_sanctions)
+**Status:** Bucket **B** today. Single-file mechanical fix, no Phase 6 conflict, but bundled with #31 in REP-CLEANUP for cohesion.
+**Upgrade-to-A blocker:** none structural — purely a "ship after Phase 6 merges to avoid concurrent reputation-path edits" precaution. Could be A if the user is comfortable with two PRs touching reputation code in flight simultaneously (Phase 6 task 76 modifies `submit_jury_vote.rs` which writes reputation events; #19 modifies the read path — they don't overlap, so risk is small).
+
+### W4 — Issue #16 (OQ-018 admin config-write endpoint)
+**Status:** Bucket **C**, blocking on admin-dashboard PRD (the canonical instance of OQ-018 deferral).
+**Knock-on effects:** Once the admin-dashboard PRD lands, #16 upgrades to a single-PR implementation effort (~L). The PRD's per-key vs batch / dry-run / instance-vs-community decisions are all in OQ-018's "Current lean" — that lean could become the PRD verbatim, in which case #16 is implementable in 1–2 days post-PRD.
+
+### W5 — Issues #11, #14 (jury-mechanics-v1 PRD)
+**Status:** Bucket **C**, blocking on a sub-PRD covering: who can appeal (target-only vs original-reporter vs both with separate flows), re-jury panel size (5 vs 7), threshold change for re-jury, original-juror exclusion. Both issues are moderate effort (M) once the PRD lands.
+**Combined PR potential:** #11 + #14 + #15 (if #15 hasn't been upgraded by then) could ship as one "appeal-flow-v1" feature PR. Estimate: 1 week post-PRD.
+
+---
+
+## §5 Cross-Reference — Bucket A/B Issues + `gh` Commands and File Paths
+
+For a planning agent picking up any Bucket A or B issue:
+
+### Issue #20 — staleness_check hardening (Bucket A, XS)
+```
+gh issue view 20 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/api/api/src/governance/reputation_snapshot.rs:438-459`
+
+### Issue #21 — drop Copy on reputation aggregates (Bucket A, XS)
+```
+gh issue view 21 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/api/api_common/src/governance.rs:336` (ReputationBuckets derive)
+- `crates/api/api_common/src/governance.rs:339` (AdminReputationStatsResponse derive)
+
+### Issue #22 — bound limit on capability_changed listing (Bucket A, XS)
+```
+gh issue view 22 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/db_views/governance_modlog/src/impls.rs:198-217` (`list_capability_changed_entries_since`)
+
+### Issue #23 — base64 signature serialization (Bucket A, XS)
+```
+gh issue view 23 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/db_views/governance_modlog/src/lib.rs:85-94` (`CapabilityChangeLogEntry`)
+- `crates/db_views/governance_modlog/Cargo.toml` (add `serde_bytes` if not in workspace deps)
+
+### Issue #24 — partial index on surety active records (Bucket A, XS)
+```
+gh issue view 24 --repo barrie-cork/lemmy --json number,title,body
+```
+- new: `migrations/2026-04-21-NNNNNN-0000_add_surety_sponsored_id_active_index/{up,down}.sql`
+- regenerated: `crates/db_schema/src/schema.rs`
+- read-only refs: `crates/api/api/src/governance/jury_common.rs:42` (the EXISTS query that benefits)
+
+### Issue #25 — RCA batch-file reproductions (Bucket A, XS, docs only)
+```
+gh issue view 25 --repo barrie-cork/lemmy --json number,title,body
+```
+- `.claude/PRPs/debug/rca-issue-8-cargo-test-exit-code-masking.md` (append two `.bat` repros to evidence section near line 49)
+
+### Issue #26 — actix_smoke_probe cross-platform (Bucket A, S)
+```
+gh issue view 26 --repo barrie-cork/lemmy --json number,title,body
+```
+- `scratch/phase-5c-probes/actix_smoke_probe.sh:13` (header + cargo-check OS gate)
+
+### Issue #27 — actix_smoke_probe AWK state machine (Bucket A, S)
+```
+gh issue view 27 --repo barrie-cork/lemmy --json number,title,body
+```
+- `scratch/phase-5c-probes/actix_smoke_probe.sh:35` (AWK_BLOCK)
+
+### Issue #28 — notify_smoke_probe zero-notify guard (Bucket A, S)
+```
+gh issue view 28 --repo barrie-cork/lemmy --json number,title,body
+```
+- `scratch/phase-5c-probes/notify_smoke_probe.sh:81` (background LISTEN handling)
+
+### Issue #31 — explicit active_sanctions constructor (Bucket A, S)
+```
+gh issue view 31 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/db_views/reputation/src/lib.rs:74-89` (the `From` impl for `ReputationSummaryView`)
+- `crates/db_views/reputation/src/impls.rs:55-` (`build_summary_view` — alternate constructor pattern already in place)
+- `crates/api/api/src/governance/get_my_reputation.rs:43-46` (call site using `..ReputationSummaryView::from(&snapshot)`)
+
+### Issue #12 — assignee filter (Bucket A, S, batched alone or with #19 mass v1-cleanup if user prefers)
+```
+gh issue view 12 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/api/api_common/src/governance.rs` (`ListGovernanceCases` DTO)
+- `crates/api/api/src/governance/list_cases.rs:9` (doc + handler)
+- `crates/db_views/governance_case/src/impls.rs` (`CasesFilter` + `list_cases_filtered`)
+
+### Issue #19 — community-scope count_active_sanctions (Bucket B, S)
+```
+gh issue view 19 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/db_views/reputation/src/impls.rs:42-53` (`count_active_sanctions` — add `Option<CommunityId>` param)
+- `crates/api/api/src/governance/get_my_reputation.rs:41` (call site — pass `data.community_id`)
+- read-only ref for FK column existence: `migrations/2026-04-15-100100-0000_add_governance_core/up.sql` (sanction.community_id)
+
+### Issue #29 — config-flip determinism (Bucket B, XS, hold for Phase 6 merge)
+```
+gh issue view 29 --repo barrie-cork/lemmy --json number,title,body
+```
+- `crates/server/tests/e2e.rs:2705-2730` (BRANCH 3 of the `assignment_cap_branches` test)
+
+### Issue #30 — governance-ai-review 413 mitigation (Bucket B, M decision / S impl)
+```
+gh issue view 30 --repo barrie-cork/lemmy --json number,title,body
+```
+- `.github/workflows/governance-ai-review.yml`
+- referenced: `.coderabbit.yaml` (if option D — disable + update CR config)
+
+---
+
+## Appendix — Phase 6 modified-file inventory (cross-reference source)
+
+For verification, Phase 6's MODIFIED FILES list (plan §"Files to Change"):
+
+- `crates/db_schema/src/schema.rs`
+- `crates/db_schema/src/source/governance/mod.rs`
+- `crates/db_schema/src/newtypes.rs`
+- `crates/apub/objects/src/lib.rs`
+- `crates/apub/activities/src/lib.rs`
+- `crates/apub/activities/src/activity_lists.rs`
+- `crates/apub/apub/src/lib.rs`
+- `crates/api/api/src/governance/governance_log.rs` (adds 4 new entry-kind const strings)
+- `crates/api/api/src/governance/submit_jury_vote.rs` (insert federation publish call between lines 395 and 397)
+- `crates/server/tests/e2e.rs` (new `sanction_notice_round_trip` test)
+- `docs/brehon-law-inspired-network/SUBSCRIPTIONS.md`
+- `Cargo.lock`
+
+**Cross-check vs v1 issues:**
+- `governance_log.rs` — issues #22, #23 touch the *modlog view* (`governance_modlog/src/{impls,lib}.rs`), not this file. No conflict.
+- `submit_jury_vote.rs` — no v1 issue touches it. No conflict.
+- `e2e.rs` — issue #29 touches it (line 2715); soft-conflict / rebase risk. Hold #29.
+- `schema.rs` / `newtypes.rs` / `governance/mod.rs` — issue #24 regenerates `schema.rs` via `diesel print-schema` (new index). Trivial merge if Phase 6 lands first; pick a later timestamp than Phase 6 to be safe.
+- `activity_lists.rs`, `lib.rs` (apub) — no v1 issue touches AP code.
+- `SUBSCRIPTIONS.md`, `Cargo.lock` — no v1 issue touches them.
+
+**Net result:** zero hard Phase 6 conflicts in any of the 19 v1 issues. All conflicts are either (a) soft `e2e.rs` co-occupancy (#29) or (b) timestamp coordination on a new migration (#24). The Bucket A set is genuinely shippable in parallel with Phase 6.

--- a/.claude/PRPs/v1-issue-triage.md
+++ b/.claude/PRPs/v1-issue-triage.md
@@ -26,7 +26,7 @@ Note: #19 appears in two rows because it is a single-file isolated CodeRabbit fi
 
 **Recommended first batch the user can hand off this week (highest confidence Bucket A):**
 
-1. **Batch CR-MECH** — issues #20, #21, #22, #23, #25, #27, #28 (7 issues) — all single-file mechanical CodeRabbit follow-ups, zero Phase 6 file overlap, total expected effort ~half day. PR title: `chore(v1-cleanup): mechanical CR follow-ups from PR #10`.
+1. **Batch CR-MECH** — issues #20, #21, #22, #23, #25, #27 (6 issues) — all single-file mechanical CodeRabbit follow-ups, zero Phase 6 file overlap, total expected effort ~half day. PR title: `chore(v1-cleanup): mechanical CR follow-ups from PR #10`. (Note: #28 is a smoke-probe shell-script fix and lives in Batch CR-PROBES below, not here — earlier drafts double-assigned it; sole owner is CR-PROBES.)
 2. **Batch CR-PROBES** — issues #26, #28 (the two `actix_smoke_probe.sh` cross-platform/AWK-state-machine fixes plus the `notify_smoke_probe.sh` zero-notify guard). All under `scratch/phase-5c-probes/`, zero crate overlap. PR title: `chore(probes): cross-platform + AWK-robustness for phase-5c smoke probes`.
 3. **Batch CR-DB-INDEX** — issue #24 alone (new migration adding partial index on `surety(sponsored_id) WHERE revoked_at IS NULL`). Migration timestamp must be `> 2026-04-20-000100-0000` (latest existing) but **also strictly different from any timestamp Phase 6 task 70 will pick** — Phase 6 uses `> 2026-04-20-000000-0000` per its plan §11 task 70. Coordinate timestamp choice with advisor (use `2026-04-21-...` or later to give Phase 6 priority on `2026-04-20-...`).
 

--- a/.claude/PRPs/v1-planning-queue.json
+++ b/.claude/PRPs/v1-planning-queue.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": 1,
+  "purpose": "V1-planning design queue. Scope: cross-PRD coherence findings + deferred OQs from the five v1 sub-PRDs. NOT the Phase 6 advisor/impl decision channel (that lives at .claude/decision-queue.json and is off-limits to this session per 2026-04-19 guardrails).",
+  "attribution_rule": "Only the advisor session may use resolved_by='advisor'. This planning session uses resolved_by='v1-planning-session' for its own resolutions; resolved_by='user' for user-authorised decisions; resolved_by=null when pending.",
+  "affected_prds_legend": "admin-dashboard | jury-mechanics | reputation-tuning | sponsor-liability | federation-inbound",
+  "severity_legend": "blocking = must-resolve-before-prp-plan | non-blocking = should-fix-before-prp-plan | noted = deferred-to-impl-phase",
+
+  "resolved": [
+    {
+      "id": "B1",
+      "severity": "blocking",
+      "affected_prds": ["admin-dashboard", "jury-mechanics", "sponsor-liability"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:30:00Z",
+      "subject": "appeal.* namespace ownership across admin-dashboard / jury-mechanics / sponsor-liability",
+      "context": "Three PRDs touched appeal.* with different subsets and defaults: admin-dashboard §5.2 had appeal.window_days + appeal.panel_size_increase + appeal.original_jurors_excluded; jury-mechanics §10 had appeal.window_days + appeal.panel_size_multiplier (1.5) + appeal.panel_size_floor_increment + appeal.threshold_tier_bump + appeal.auto_select_on_appeal_acceptance; sponsor-liability referenced appeal.window_days in §6.5 for grace-window composition. Two real contradictions: (i) admin-dashboard's panel_size_increase=2 vs jury-mechanics' multiplier=1.5+floor=2 compute different panel sizes (5→7 vs 5→8); (ii) admin-dashboard declared appeal.original_jurors_excluded as configurable bool while jury-mechanics §6.2 cited [01 §5.7] as a hard code-level rule, not a config key.",
+      "proposed_resolutions": [
+        "A. jury-mechanics owns appeal.* fully; admin-dashboard cross-references. original_jurors_excluded stays as hard code rule, not config.",
+        "B. admin-dashboard owns appeal.*; drop jury-mechanics' multiplier shape. Simpler math but loses [01 §5.7] 1.5x scaling.",
+        "C. Split: admin-dashboard owns appeal.window_days only; jury-mechanics owns panel/threshold knobs."
+      ],
+      "resolution": "A",
+      "resolution_rationale": "appeal.* is procedural-legitimacy territory (ADR-007 -> ADR-010 upgrade path) which is jury-mechanics' charter. Multiplier preserves [01 §5.7] 'larger jury' principle. admin-dashboard keeps its write-surface role via cross-reference pattern (same idiom as jury.* via OQ-026). original_jurors_excluded as hard code rule is correct - Brehon invariant, not community taste knob.",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T14:35:00Z",
+      "edit_scope": {
+        "admin-dashboard": "§5.2: delete rows for appeal.window_days, appeal.panel_size_increase, appeal.original_jurors_excluded. Add one cross-ref line to jury-mechanics-v1 §10. §10.2 note issue #15 resolution lands in jury-mechanics.",
+        "jury-mechanics": "No changes needed - already owns the shape.",
+        "sponsor-liability": "No changes needed - §6.5 reference to appeal.window_days remains valid."
+      }
+    },
+    {
+      "id": "B2",
+      "severity": "blocking",
+      "affected_prds": ["admin-dashboard", "jury-mechanics"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:35:00Z",
+      "subject": "jury.panel_size shape: single key vs 9-cell matrix",
+      "context": "admin-dashboard §5.1 had single jury.panel_size=5 v0 -> 7 v1; jury-mechanics §3.4 replaced with 9-key matrix jury.panel_size.<status>.<severity> across (Regular|Founder|Probation) x (Minor|Moderate|Severe) with no bare jury.panel_size key. v0 code at admin_assign_jury.rs:120 reads bare jury.panel_size via config::get_int.",
+      "proposed_resolutions": [
+        "A. 9-key matrix replaces single key entirely. Breaks v0 read site; forces explicit status+severity selection.",
+        "B. Dotted matrix WITH single-key fallback per OQ-026 cascade (jury.panel_size.<status>.<severity> -> jury.panel_size.<severity> -> jury.panel_size -> const). v0-compatible.",
+        "C. Keep single key; defer matrix to v1.5. Loses status-aware sizing from [01 §5.2 honour-price]."
+      ],
+      "resolution": "B",
+      "resolution_rationale": "OQ-026 option (a) IS the cascade pattern. admin-dashboard §3.5 already commits to option (a); Option B operationalises it end-to-end. v0 compatibility preserved (admin_assign_jury.rs:120 read site unchanged during v1 rollout). Communities get both ergonomics: single-int tuning OR per-cell tuning.",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T14:40:00Z",
+      "edit_scope": {
+        "admin-dashboard": "§5.1: jury.panel_size row kept, value bumped to 7 as v1 root default, tag (a). §3.5 adds cascade sentence. §3.1 jury.* count stays at 5 v0 + 4 v1 = 9 (matrix keys documented in jury-mechanics, not re-enumerated).",
+        "jury-mechanics": "§3.4 adds 'Cascade fallback' subsection noting bare jury.panel_size key exists as final fallback before const. §9.2 admin_assign_jury read site must use new cascade helper, not get_int(dotted_key) directly."
+      }
+    },
+    {
+      "id": "B3",
+      "severity": "blocking",
+      "affected_prds": ["admin-dashboard", "reputation-tuning"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:40:00Z",
+      "subject": "Reputation-tuning's new namespaces vs admin-dashboard's 13-namespace inventory",
+      "context": "admin-dashboard §3.1 enumerates 13 namespaces. reputation-tuning adds 28 keys across 4 namespaces not in admin-dashboard's list: cron.* (7 keys, same concept as existing job.*), bounds.* (8 keys, genuinely new - per-dimension floor/ceiling), rollup.* (1 key, single-key namespace bloat), reputation.* (1 key, feature flag). admin-dashboard's prose claim '62 keys across 7 namespaces' is incorrect once reputation-tuning lands - real v1 total is ~138 keys across 15 namespaces.",
+      "proposed_resolutions": [
+        "A. Collapse into admin-dashboard namespaces: cron.* -> job.*; bounds.* stays new; rollup.* -> job.*; reputation.* -> feature.*. Consistent with v0 job.snapshot_interval_seconds idiom.",
+        "A-modified (user adjustment). Same as A but: cron.participation.* split into (i) deltas.* for reputation-policy knobs (weekly_increment, dormancy_decrement) and (ii) participation.* for context knobs (activity_threshold_comments, lookback_days, dormancy_window_days); cron.{participation,rollup}_interval_days -> job.*; rollup.equal_weights -> job.rollup_equal_weights; reputation.v1.decay_enabled -> feature.reputation_v1_decay_enabled; bounds.* and feature.* kept as first-class new namespaces.",
+        "B. Accept all 4 reputation-tuning namespaces; admin-dashboard expands to 17 namespaces. Two names for same concept (job/cron) = permanent operator confusion.",
+        "C. Narrow cron.* to interval-only (participation_interval_days, rollup_interval_days), move event-tuning to deltas.*. Cron/job split subtle enough ops may still confuse."
+      ],
+      "resolution": "A-modified",
+      "resolution_rationale": "Load-bearing: v0 establishes liability.* + job.* as flat namespaces. Dual cron.*+job.* namespaces for same concept is a permanent tax. participation-event tuning keys aren't cron knobs semantically - they're reputation deltas conditioned on cron-batch context, so they belong with deltas.* (policy) or participation.* (context). bounds.* genuinely new (post-clamp snapshot ceilings - different from thresholds.* capability cutoffs). feature.* prophylactic for growth (every deferred-enforcement toggle will need one).",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T14:45:00Z",
+      "edit_scope": {
+        "admin-dashboard": "§3.1 namespace table: correct '62 keys across 7 namespaces' -> '138 keys across 15 namespaces (v1 inventory crossing all 5 sub-PRDs)' with per-PRD contribution sub-table. Add rows for bounds.* (8 keys, reputation-tuning domain) and feature.* (1 key, reputation-tuning domain, future-expandable). Add rows noting participation.* (+2), deltas.* (+3), job.* (+3) extensions. Add B3 entry to Resolutions log.",
+        "reputation-tuning": "§8 defaults matrix: rename 10 keys per table. §5.2 + §5.3: adjust namespace references. §13 cross-references: update consumers. Add §14 'Resolutions applied (2026-04-19)' noting B3 namespace collapse."
+      },
+      "key_renames": {
+        "cron.participation.weekly_increment": "deltas.participation_weekly_active",
+        "cron.participation.activity_threshold_comments": "participation.activity_threshold_comments",
+        "cron.participation.lookback_days": "participation.lookback_days",
+        "cron.participation.weekly_dormancy_decrement": "deltas.participation_dormant",
+        "cron.participation.dormancy_window_days": "participation.dormancy_window_days",
+        "cron.participation_interval_days": "job.participation_interval_days",
+        "cron.rollup_interval_days": "job.rollup_interval_days",
+        "rollup.equal_weights": "job.rollup_equal_weights",
+        "reputation.v1.decay_enabled": "feature.reputation_v1_decay_enabled"
+      }
+    },
+    {
+      "id": "B4",
+      "severity": "blocking",
+      "affected_prds": ["admin-dashboard", "sponsor-liability"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:45:00Z",
+      "subject": "sponsor-liability's sponsor.liability.* prefix vs v0/admin-dashboard's flat liability.*",
+      "context": "v0 code establishes flat liability.* (liability.founder_multiplier, liability.regular_multiplier, liability.sponsor_liability_floor). admin-dashboard §5.2 extends flat (liability.grace_window_minor_hours). sponsor-liability §4.2/§10 invented three-level sponsor.liability.grace_window.minor_hours despite v0 precedent. Resulting namespace would be LESS structured: liability.founder_multiplier (v0 flat) and sponsor.liability.grace_window.minor_hours (v1 three-deep) in different trees for no semantic reason.",
+      "proposed_resolutions": [
+        "A. Flat liability.* matches v0 + admin-dashboard. Rename 10 sponsor-liability keys.",
+        "B. Dotted liability.* (liability.grace_window.minor_hours). Forces v0 key renaming too; partial v0 rename blast radius.",
+        "C. Accept sponsor.* top-level namespace. Splits conceptually-related knobs across trees; namespace sprawl (16)."
+      ],
+      "resolution": "A",
+      "resolution_rationale": "v0 precedent is authoritative. Extending liability.* is free; introducing sponsor.* creates parallel namespace for same concern. Consistency with existing flat v0 keys > structural elegance. Partial N1 collateral: admin-dashboard §5.2 only listed 2 of 3 grace-window keys (missing minor_hours) - B4 resolution fixes by enumerating all 10 sponsor-liability-owned liability.* keys.",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T14:50:00Z",
+      "edit_scope": {
+        "admin-dashboard": "§3.1 liability.* row: update 'v1 additions' count 2 -> 10. §5.2: add 7 new rows for sponsor-liability non-grace keys (restoration x2, multi-sponsor x1, revoke-rate-limit x1, grace_window minimum/maximum/alert_threshold x3). §11 Resolutions: note B4 + partial N1 collateral.",
+        "sponsor-liability": "§4.2 table: rename 6 rows. §5.1 body: remove sponsor.liability.* prefix references throughout. §7.3 table: rename 2 rows. §10 defaults matrix: rename 10 entries. §12.1: rename rate-limit key. §13 OQ-V1-SL-01: rename multi_sponsor_escape_rule key. Add §18 Resolutions applied entry."
+      },
+      "key_renames": {
+        "sponsor.liability.grace_window.minor_hours": "liability.grace_window_minor_hours",
+        "sponsor.liability.grace_window.moderate_hours": "liability.grace_window_moderate_hours",
+        "sponsor.liability.grace_window.severe_hours": "liability.grace_window_severe_hours",
+        "sponsor.liability.grace_window.minimum_hours": "liability.grace_window_minimum_hours",
+        "sponsor.liability.grace_window.maximum_hours": "liability.grace_window_maximum_hours",
+        "sponsor.liability.grace_window.alert_threshold_hours": "liability.grace_window_alert_threshold_hours",
+        "sponsor.liability.restoration_escapes_liability": "liability.restoration_escapes_liability",
+        "sponsor.liability.restoration_severity_reduction_steps": "liability.restoration_severity_reduction_steps",
+        "sponsor.liability.multi_sponsor_escape_rule": "liability.multi_sponsor_escape_rule",
+        "sponsor.liability.revoke_rate_limit_per_day": "liability.revoke_rate_limit_per_day"
+      }
+    },
+    {
+      "id": "B5",
+      "severity": "blocking",
+      "affected_prds": ["federation-inbound", "admin-dashboard"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:50:00Z",
+      "subject": "federation-inbound's schema additions attach to Phase 6 tables still in-flight",
+      "context": "federation-inbound §8.2 ALTER TABLE federation_attestation ADD COLUMN source_instance TEXT, received_at TIMESTAMPTZ, peer_trust_level_at_receipt, ... + ALTER TABLE remote_sanction_notice. Both tables created by Phase 6 tasks 70/71 in worktree advisor-phase6 (off-limits this session). Phase 6 hasn't opened PR yet. PRD framed Phase 6 dependency as descriptive §15.1 alignment notes rather than prescriptive hard gate. Additional ordering constraint: migration timestamp must sort after Phase 6's add_federation_attestations (2026-04-20).",
+      "proposed_resolutions": [
+        "A. Formalise Phase 6 as hard gate + add verify-before-migrate preamble SQL DO block. User-modified: drop specific 2026-04-22 reservation, use 'must sort after Phase 6' invariant only.",
+        "B. Split federation-inbound into schema-addendum + handler/UX PRDs. Splits one coherent design; PRD bureaucracy.",
+        "C. Defer federation-inbound entirely until Phase 6 merges. Discards Phase-6-independent design work (AP types, trust states, wrapper, rate limits)."
+      ],
+      "resolution": "A-modified",
+      "resolution_rationale": "federation-inbound's non-schema design work is Phase-6-independent and coherent. Deferring whole PRD discards audit value. Option A's verification preamble + explicit gate makes ordering fail-loud. Timestamp invariant: 'must sort after add_federation_attestations' - exact slot assigned at impl time (2026-04-22 reservation would be premature). Partial N5 collateral: §8.0 enumeration of Phase 6 schema assumptions graduates N5 (FK vs domain-string mismatch) from 'noted' to 'resolved at v1-impl time via explicit precondition'.",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T14:55:00Z",
+      "edit_scope": {
+        "federation-inbound": "Insert new §8.0 'Dependencies' subsection before §8.1: Phase 6 merge as hard gate, explicit preconditions list (tables exist, enum types exist, specific columns assumed per §15.2 carry-forwards, Phase 6 entry_kind consts present, source_instance is TEXT not FK). §8.2 SQL: prepend DO block checking federation_attestation table exists and remote_sanction_notice.received_at column exists; RAISE EXCEPTION otherwise. §15.2 DQ-6.1/DQ-6.2 paragraphs: rewrite to reference §8.0 as canonical preconditions list; prescriptive tone. Rename §8 heading to 'Dependencies, database & migration changes'. §1 frontmatter scheduling line: 'Hard-gated on Phase 6 PR merge; no implementation before gate satisfied. Plan-level review can proceed in parallel.' Add §16 Resolutions applied entry.",
+        "admin-dashboard": "§10.1 cross-references: add one-line note under federation-inbound consumer row: 'depends on Phase 6 merge - see v1-federation-inbound-v1.prd.md §8.0 for hard-gate conditions.'"
+      }
+    },
+    {
+      "id": "B6",
+      "severity": "blocking",
+      "affected_prds": ["jury-mechanics", "sponsor-liability"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:55:00Z",
+      "subject": "sponsor-liability §9.3 + jury-mechanics §9.1 both rewrite submit_jury_vote with no unified shape",
+      "context": "Both PRDs rewrite crates/api/api/src/governance/submit_jury_vote.rs. jury-mechanics §9.1 pre-decision threshold/quorum snapshot reads + deadlock -> AdminReview. sponsor-liability §9.3 post-decision lifecycle branch: compute_sponsor_liability (split from apply_sponsor_liability), grace_expires_at, flip to SponsorLiabilityPending, defer public_log + juror rep events to scheduler fire/escape. Five questions unanswered: (1) threshold-failure short-circuits sponsor-liability? (2) AdminReview bypasses? (3) SponsorLiabilityPending replaces Decided or rewrites? (4) public_case_log timing? (5) juror reputation_events timing?",
+      "proposed_resolutions": [
+        "A. jury-mechanics §9.1 owns combined post-v1 handler shape via new §9.1a subsection with 9-step pseudocode; sponsor-liability §9.3 reduces to pointer.",
+        "B. sponsor-liability §9.3 owns combined shape. Backwards - jury-mechanics is the bigger change.",
+        "C. Extract appendix PRD v1-handler-integration.prd.md. PRD bureaucracy for one handler.",
+        "D. Keep separate with cross-ref sub-bullets. Fragments pseudocode across PRDs."
+      ],
+      "resolution": "A",
+      "resolution_rationale": "submit_jury_vote is primarily jury-mechanics' handler - v1 changes it owns (quorum/threshold/deadlock) define the decision point. sponsor-liability's post-decision lifecycle branch is coherent continuation. Option C appendix = scaffolding PRD nobody owns. Option D fragmentation is exactly what caused this audit finding. User-provided 9-step pseudocode resolves all 5 questions: threshold-failure short-circuits before sanction insert; AdminReview bypasses entirely; SponsorLiabilityPending replaces Decided (single write); public_log + juror rep events fire at scheduler fire/escape time on liability path, at vote-tally on no-sponsor path. Appeal-window-bound step 9 fires on both paths per sponsor-liability §6.5 min(...) composition. Golden-path test impact minimal (existing test likely uses unsponsored target -> step 8 no-sponsor path).",
+      "resolved_by": "user",
+      "resolved_at": "2026-04-19T15:00:00Z",
+      "edit_scope": {
+        "jury-mechanics": "§9.1 expand from ~5 bullets to full 9-step combined-handler pseudocode (threshold check, winning_decision, sponsor-liability branch, no-sponsor/NoAction path, appeal window bound). Add sub-note on golden-path test impact (unsponsored target -> step 8, assertions preserved; new sponsored-target test is v1-impl follow-up). Add cross-reference: 'SponsorLiabilityPending branch specified by sponsor-liability-v1 §9.3; this section owns the integrated lifecycle shape.' §15 Resolutions applied entry.",
+        "sponsor-liability": "§9.3 reduce from ~50 lines Rust pseudocode to ~10-line pointer to jury-mechanics-v1 §9.1. Keep §9.1 compute/fire split and §9.4 scheduler module sections. §18 Resolutions applied entry."
+      },
+      "handler_pseudocode_reference": "See conversation 2026-04-19 for 9-step pseudocode; to be inlined into jury-mechanics §9.1 during edit pass."
+    }
+  ],
+
+  "non_blocking": [
+    {
+      "id": "N1",
+      "severity": "non-blocking",
+      "affected_prds": ["admin-dashboard"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:00:00Z",
+      "subject": "admin-dashboard §5.2 decide-later count mismatch: claims 5 (c) tags, table has 1",
+      "context": "§5.2 prose claims '5 are decide-later (c)': participation.attestation_enabled (tagged explicitly) + '4 reserved-for-v1.5 keys for federation peer-trust-state knobs that this PRD does not enumerate'. The 4 phantom entries inflate the count without being rows in the table.",
+      "proposed_resolutions": [
+        "A. Drop the '4 reserved' phrasing; count reflects only tagged rows (1). Move federation-peer-trust-state reservation to federation-inbound PRD §10 where peer-trust knobs live.",
+        "B. Enumerate the 4 reserved keys explicitly. Probably belong in federation-inbound, not admin-dashboard.",
+        "C. Keep prose, delete the count discrepancy noise via a note."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "Partially collateraled by B4 resolution (§5.2 grows to enumerate all 10 sponsor-liability keys; count inflation pressure diminishes). Cleanest is to drop the phantom 4 from the count in the B4 edit pass and note federation-peer-trust-state knobs live in federation-inbound §10.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "N2",
+      "severity": "non-blocking",
+      "affected_prds": ["reputation-tuning"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:05:00Z",
+      "subject": "reputation-tuning §5.3 evidence-cited heuristic under-specified",
+      "context": "§5.3 source 4 says 'heuristic detection: case has case_evidence rows uploaded by the reporter AND the rationale length >= minimum threshold'. No threshold value. No verification that jury rationale is stored as free-text in v0 schema. Needs code verification before implementation.",
+      "proposed_resolutions": [
+        "A. Add placeholder default (e.g. 256 chars) + flag as v1-impl verification task: verify jury.rationale column exists and is free-text in submit_jury_vote DTO.",
+        "B. Remove evidence-cited source entirely from v1; keep only admin-flagged bad-faith. Simpler; 1 fewer source.",
+        "C. Promote to blocking; resolve now by reading submit_jury_vote.rs."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "Adding a placeholder threshold + v1-impl verification task is cheap. Removing entirely loses positive reputation feedback for high-quality reporters. Promoting to blocking over-scopes this session.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "N3",
+      "severity": "non-blocking",
+      "affected_prds": ["jury-mechanics"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:10:00Z",
+      "subject": "jury-mechanics §5.3 constraint-relaxation ordering has a subtle algorithm bug",
+      "context": "§5.3 says relax priority: (1) cooldown, (2) geographic, (3) sponsor-cluster. §9.3 says constraint application happens after eligible pool built. But cooldown BUILDS the pool (excludes recent jurors). Removing cooldown EXPANDS pool, which may resolve pool-too-small without dropping sponsor-cluster. 're-roll up to N_RETRIES before relaxing' is ambiguous about which constraint is being re-rolled against.",
+      "proposed_resolutions": [
+        "A. Rewrite §5.3 algorithm flowchart: cooldown applied at pool-build (filter), sponsor-cluster checked at panel-sample (re-roll up to N), geographic checked at panel-sample (soft scoring). Relaxation cascade: if pool < panel_size post-cooldown, drop cooldown FIRST and retry pool-build; if post-expansion sample still violates sponsor-cluster after N re-rolls, drop geographic scoring; last-resort drop sponsor-cluster (log warning).",
+        "B. Simpler: always try cooldown=ON first, if pool too small try cooldown=OFF, then try sponsor-cluster relaxation. Geographic scoring soft, never relaxed formally. Less nuanced but clearer.",
+        "C. Keep existing §5.3 text; add explicit algorithm sketch as Appendix."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "The algorithm confusion is load-bearing for §9.3 impl agent. Rewrite in place during edit pass. Option A matches the intent implied by 'Brehon-essential' prioritisation while making the phase structure (build-time filter vs sample-time check vs soft score) explicit.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "N4",
+      "severity": "non-blocking",
+      "affected_prds": ["sponsor-liability"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:15:00Z",
+      "subject": "sponsor-liability §11.4 v0-modlog-reader regression not explicitly handled",
+      "context": "§11.4 says 'v0 modlog readers see case absent from modlog until grace expires'. Framed as 'correct semantic' but v0 clients relying on GET /modlog returning decided cases immediately will observe a behavioural regression on sponsor-liability cases. No API versioning, no migration note, no client warning mechanism described.",
+      "proposed_resolutions": [
+        "A. Add §11.4 paragraph: explicit note that public_case_log emits at scheduler fire/escape time (not vote-tally time) for sponsor-liability cases; v0 clients that poll modlog will see delayed appearance (minutes-to-days delay, bounded by grace window). Recommend v1 client-side: poll both case endpoint (status SponsorLiabilityPending visible immediately) AND modlog (appears after liability resolves). Add as documented behavioural change in §11 heading.",
+        "B. Add API versioning: v4/modlog returns eager entries (v0 behaviour); v5/modlog returns fire/escape-gated entries (v1 behaviour). Heavy; requires two code paths.",
+        "C. Defer to v1-impl; add as carry-forward issue on GH post-v1."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "Option B overkill for a boundary that pre-v0 operators tolerate already (Lemmy's own modlog has similar eventual-consistency). Option A documents the change-in-behaviour honestly without requiring client churn.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "N5",
+      "severity": "non-blocking",
+      "affected_prds": ["federation-inbound"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:20:00Z",
+      "subject": "federation-inbound §4.1 FK-shape vs §8.1 TEXT domain mismatch surfaced but not elevated",
+      "context": "§4.1 declares federation_peer.instance_id INT PRIMARY KEY REFERENCES instance(id). §8.1 notes Phase 6's remote_sanction_notice.source_instance is TEXT (peer domain), not FK to instance(id). Join path: JOIN instance ON instance.domain = remote_sanction_notice.source_instance. §15.3 point 1 mentions case-sensitivity concern as a parenthetical. Should be a first-order implementation warning.",
+      "proposed_resolutions": [
+        "A. Already collateraled by B5 resolution. §8.0 preconditions list includes 'assumes remote_sanction_notice.source_instance is TEXT (peer domain), not FK' - reviewer who disagrees must push back before v1 migration. Graduates N5 from 'noted' to 'resolved-at-v1-impl-time'.",
+        "B. Rewrite §4.1 schema to match Phase 6's TEXT convention: federation_peer.peer_domain TEXT PRIMARY KEY (no FK). Simpler join path but loses ON DELETE CASCADE from instance.id.",
+        "C. Promote to blocking; resolve schema choice now."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "B5 resolution absorbs this already via explicit §8.0 precondition enumeration. Impl-time verification is correct scope; schema choice depends on what Phase 6 actually ships.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    }
+  ],
+
+  "noted": [
+    {
+      "id": "NOT1",
+      "severity": "noted",
+      "affected_prds": ["admin-dashboard", "jury-mechanics", "reputation-tuning", "sponsor-liability", "federation-inbound"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:25:00Z",
+      "subject": "OQ numbering collision: admin-dashboard and jury-mechanics both claim OQ-027",
+      "context": "Handover claimed '~15 new OQs' - actual ~26. More importantly: admin-dashboard opens OQ-027 (bulk config import/export format). jury-mechanics ALSO opens OQ-027 (severity tier inference). These can't coexist in a unified 99-decisions-and-open-questions.md register. Other prefixed PRDs (reputation-tuning OQ-V1-01..05, sponsor-liability OQ-V1-SL-01..05, federation-inbound OQ-FED-IN-1..5) are collision-free.",
+      "proposed_resolutions": [
+        "A. Adopt prefixed namespace convention consistently. admin-dashboard OQ-027..031 becomes OQ-V1-AD-01..05; jury-mechanics OQ-027..032 becomes OQ-V1-JM-01..06. Collision resolved; pattern matches other 3 PRDs.",
+        "B. Renumber sequentially: admin-dashboard keeps 27-31, jury-mechanics bumps to 32-37. Breaks cross-references in jury-mechanics §Open Questions table and adds ordering fragility.",
+        "C. Defer OQ-renumbering to post-impl; stale cross-refs accepted."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "Prefixed convention already established by 3 of 5 PRDs. Applying consistently removes the only real collision and sets forward-compat pattern. Breaks admin-dashboard §5.3 (c)-key escalation table OQ-027/028 references and jury-mechanics §Open Questions OQ-027 through OQ-032 references - mechanical find-replace.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done",
+      "renames": {
+        "admin-dashboard": {
+          "OQ-027": "OQ-V1-AD-01 (bulk config import/export format)",
+          "OQ-028": "OQ-V1-AD-02 (multi-tenant on one instance)",
+          "OQ-029": "OQ-V1-AD-03 (federation peer trust dashboard scope)",
+          "OQ-030": "OQ-V1-AD-04 (participation attestation UX)",
+          "OQ-031": "OQ-V1-AD-05 (dry-run preview logging)"
+        },
+        "jury-mechanics": {
+          "OQ-027": "OQ-V1-JM-01 (severity tier inference)",
+          "OQ-028": "OQ-V1-JM-02 (geographic diversity heuristic)",
+          "OQ-029": "OQ-V1-JM-03 (founder-status threshold)",
+          "OQ-030": "OQ-V1-JM-04 (cross-instance juror eligibility)",
+          "OQ-031": "OQ-V1-JM-05 (re-jury auto vs admin trigger)",
+          "OQ-032": "OQ-V1-JM-06 (original-reporter appeal scope)"
+        }
+      }
+    },
+    {
+      "id": "NOT2",
+      "severity": "noted",
+      "affected_prds": ["admin-dashboard", "jury-mechanics", "reputation-tuning", "sponsor-liability", "federation-inbound"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:30:00Z",
+      "subject": "~28 new governance_log entry_kind constants across 5 PRDs, no shared registry",
+      "context": "Each PRD enumerates its new ENTRY_KIND_* strings. admin-dashboard: 2. jury-mechanics: 6. reputation-tuning: 5 + 2 for allowlist. sponsor-liability: 5. federation-inbound: 8+. Total ~28 new constants. No PRD verifies non-collision with v0 constants or each other. String uniqueness is critical (governance_log dispatches by entry_kind).",
+      "proposed_resolutions": [
+        "A. Single shared section in admin-dashboard §3 enumerating ALL new v1 entry_kind constants across PRDs with collision check. admin-dashboard becomes authoritative registry.",
+        "B. Each PRD lists own; v1-impl phase does collision-check pre-merge via lint rule.",
+        "C. Create .claude/rules/governance-log-entry-kind-registry.md with canonical list. Impl pass must append + check."
+      ],
+      "proposed_resolution": "C",
+      "rationale": "A adds cross-PRD edit burden to admin-dashboard beyond its charter. B defers entirely to impl (risky - two PRDs could ship with same string). C is the lightest-touch correct solution: registry rule auto-loads in -p mode, every impl session reads it before appending entry_kind consts. Defer to post-PRD-edit; create rule file in the v1-impl phase prep.",
+      "resolution": "C",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:15:00Z",
+      "status": "tracked-via-gh-issue",
+      "gh_issue": "https://github.com/barrie-cork/lemmy/issues/41",
+      "gh_issue_title": "v1/v2 governance_log entry_kind registry — cross-PRD hygiene",
+      "landing_window": "v1-impl-prep, AFTER Phase 6 merge to governance-v0, BEFORE first v1 PRD /prp-plan run",
+      "verified_baseline": "2026-04-19 @ governance-v0 3bbf419da — 19 v0 ENTRY_KIND_* constants at governance_log.rs:50-68 (verified by user grep during issue-drafting session)"
+    },
+    {
+      "id": "NOT3",
+      "severity": "noted",
+      "affected_prds": ["reputation-tuning"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:35:00Z",
+      "subject": "reputation-tuning ADR-010 compliance via feature flag vs snapshot columns",
+      "context": "Handover claim: 'all 5 PRDs honour ADR-010 no-retroactive-invalidation via snapshot columns'. Verification: jury-mechanics/sponsor-liability/admin-dashboard all have explicit snapshot columns. reputation-tuning uses feature flag (feature.reputation_v1_decay_enabled) instead. Feature-flag compliance is WEAKER than snapshot: a pre-flip snapshot recompute under v0 decay, post-flip under v1 decay - the same reputation_event row's effective delta changes retroactively between recomputes.",
+      "proposed_resolutions": [
+        "A. Accept feature-flag posture as v1-acceptable (document delta explicitly in reputation-tuning §9 backwards-compat). Per-event-source snapshotting would require storing applied_delta per snapshot, which is v2-scope.",
+        "B. Add snapshot versioning column to reputation_snapshot: calculator_version INT. v0 rows tagged 1; v1 rows tagged 2. Recompute MUST use same calculator version as original write. Extra complexity; probably too much for v1.",
+        "C. Promote to blocking; resolve snapshot strategy now."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "ADR-010 is no-retroactive-invalidation-of-in-flight-JURIES. Reputation snapshots aren't 'in-flight' in the same procedural-legitimacy sense - they're a derived rolling view. Feature flag is sufficient IF PRD documents the weaker compliance explicitly. Strongly resolved-in-edit-pass: add paragraph to reputation-tuning §9 framing feature-flag posture relative to jury-mechanics' snapshot-column posture.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "NOT4",
+      "severity": "noted",
+      "affected_prds": ["admin-dashboard"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:40:00Z",
+      "subject": "admin-dashboard §3.2 ConfigKeyMetadata: compile-time struct vs runtime registry ambiguous",
+      "context": "§3.2 describes 'compile-time metadata' via Rust struct with &'static str fields. §6.1 references 'CONFIG_KEY_METADATA' as if a runtime queryable table. Implementation unclear: every new key PR-against-rust-array (compile-time) OR DB migration adds metadata row (runtime)?",
+      "proposed_resolutions": [
+        "A. Commit explicitly to compile-time: CONFIG_KEY_METADATA as &'static [ConfigKeyMetadata] array alongside SEEDED_KEYS_WITH_CONSTS. Parity test every_seeded_key_has_metadata enforces. Clearer; matches Watch-1 parity invariant.",
+        "B. Runtime table config_key_metadata alongside governance_config. Migration per new key.",
+        "C. Hybrid: Rust array is source-of-truth; rendered to a DB view for UI convenience. Adds sync step."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "Compile-time matches existing Watch-1 parity contract (SEEDED_KEYS_WITH_CONSTS is compile-time). Consistency > flexibility. Clarifying text added to §3.2 during edit pass. §6.1 reference updated to 'compile-time CONFIG_KEY_METADATA array'.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    },
+    {
+      "id": "NOT5",
+      "severity": "noted",
+      "affected_prds": ["admin-dashboard", "sponsor-liability"],
+      "raised_by": "v1-planning-session",
+      "raised_at": "2026-04-19T14:45:00Z",
+      "subject": "No PRD defines deprecation/migration path for admin-config-write.sh relative to OQ-018 endpoint timing",
+      "context": "admin-dashboard §8.4 says 'v1.1 removes the script'. sponsor-liability §10 introduces 12 new keys that currently must be set via admin-config-write.sh until OQ-018 HTTP endpoint lands. If script deprecated before OQ-018 ships, ops teams stranded.",
+      "proposed_resolutions": [
+        "A. admin-dashboard §8.4 rewrite: script deprecation is GATED on OQ-018 HTTP endpoint shipping, not on v1.1 milestone alone. Explicit condition: 'admin-config-write.sh deprecated in release that ships OQ-018 endpoint; v1.1 is target but contingent.'",
+        "B. sponsor-liability adds own ops section referencing script. Distributes the ops burden.",
+        "C. Leave as-is; v1-impl resolves."
+      ],
+      "proposed_resolution": "A",
+      "rationale": "One-line fix in admin-dashboard §8.4. Makes the gating explicit. Partially removed by OQ-018 being tightly-coupled to admin-dashboard's charter anyway.",
+      "resolution": "A",
+      "resolved_by": "v1-planning-session",
+      "resolved_at": "2026-04-19T19:00:00Z",
+      "status": "done"
+    }
+  ],
+
+  "session_summary_2026_04_19_pm": {
+    "edit_pass_completed": "2026-04-19T19:00:00Z",
+    "edits_applied": {
+      "blocking": ["B1 done in morning session", "B2 done in morning session", "B3", "B4", "B5", "B6"],
+      "non_blocking": ["N1", "N2", "N3", "N4", "N5"],
+      "noted_done": ["NOT1", "NOT3", "NOT4", "NOT5"],
+      "noted_deferred": ["NOT2 — filed as GH issue #41 (https://github.com/barrie-cork/lemmy/issues/41) 2026-04-19 PM per user decision; graduated from 'noted' to 'tracked deliverable'"]
+    },
+    "prds_touched": [
+      "v1-admin-dashboard.prd.md — §3.1 registry overhauled; §3.2 compile-time commit; §5.2 +7 rows; §5.3 phantom row dropped; §8.4 OQ-018 gate; §10.1 cross-ref; §11 resolutions; OQ renames",
+      "v1-jury-mechanics.prd.md — §5.3 three-phase flowchart + R1/R2/R3 cascade; §9.1 9-step combined pseudocode; §15 resolutions; OQ renames",
+      "v1-reputation-tuning.prd.md — 9 key renames; §5.3 evidence threshold + v1-impl verification note; §9.1 feature-flag-vs-snapshot compliance paragraph; §14 resolutions",
+      "v1-sponsor-liability.prd.md — 10 key renames (flat liability.*); §9.3 reduced to pointer; §11 heading + §11.4 rewritten; §18 resolutions",
+      "v1-federation-inbound.prd.md — §1 frontmatter hard-gate line; §8 heading renamed; §8.0 new (7 preconditions); §8.2 SQL DO preamble; §15.2 prescriptive rewrite; §16 resolutions"
+    ],
+    "completion_signal_met": true,
+    "completion_note": "Each of the 5 PRDs contains a 'Resolutions applied (2026-04-19)' section enumerating the B/N/NOT items that touched it. Verifiable via: grep -E '^## (§)?[0-9]+.* Resolutions applied' .claude/PRPs/prds/v1-*.prd.md",
+    "no_commit_or_push_per_handover": "Edit pass complete; PRDs remain DRAFT-status on governance-v0; no commits made this session; 4 unpushed wave1-* branches untouched"
+  }
+}

--- a/.claude/PRPs/v1-planning-queue.json
+++ b/.claude/PRPs/v1-planning-queue.json
@@ -138,7 +138,7 @@
       "resolved_at": "2026-04-19T14:55:00Z",
       "edit_scope": {
         "federation-inbound": "Insert new §8.0 'Dependencies' subsection before §8.1: Phase 6 merge as hard gate, explicit preconditions list (tables exist, enum types exist, specific columns assumed per §15.2 carry-forwards, Phase 6 entry_kind consts present, source_instance is TEXT not FK). §8.2 SQL: prepend DO block checking federation_attestation table exists and remote_sanction_notice.received_at column exists; RAISE EXCEPTION otherwise. §15.2 DQ-6.1/DQ-6.2 paragraphs: rewrite to reference §8.0 as canonical preconditions list; prescriptive tone. Rename §8 heading to 'Dependencies, database & migration changes'. §1 frontmatter scheduling line: 'Hard-gated on Phase 6 PR merge; no implementation before gate satisfied. Plan-level review can proceed in parallel.' Add §16 Resolutions applied entry.",
-        "admin-dashboard": "§10.1 cross-references: add one-line note under federation-inbound consumer row: 'depends on Phase 6 merge - see v1-federation-inbound-v1.prd.md §8.0 for hard-gate conditions.'"
+        "admin-dashboard": "§10.1 cross-references: add one-line note under federation-inbound consumer row: 'depends on Phase 6 merge - see v1-federation-inbound.prd.md §8.0 for hard-gate conditions.'"
       }
     },
     {


### PR DESCRIPTION
<!-- Plan-only PR: v1-AD-a sub-phase A of admin-dashboard keystone. No Rust changes. -->

## Phase

- [ ] Phase 1 — Schema + Diesel foundation
- [ ] Phase 2a — `governance_case` + `jury_queue` views
- [ ] Phase 2b — `governance_modlog` views
- [ ] Phase 3 — `api_common` DTOs
- [ ] Phase 4 — First five endpoints + golden-path e2e
- [ ] Phase 5 — Reputation snapshot + remaining six endpoints
- [ ] Phase 6 — Federation outbound + advisory inbound
- [x] Other (tooling / docs / CI / upstream rebase)

Plan-only landing of v1-AD-a (sub-phase A of the v1 admin-dashboard keystone). Impl branch `phase-v1-AD-a` cuts post-merge; ralph execution is a separate PR.

## Summary

Lands the v1-AD-a plan file — the foundation sub-phase of the v1 admin-dashboard keystone (OQ-018). The plan specifies 4 idempotent migrations (rule-set versioning, sponsor allowlist reservation, applied_config_snapshot column on `moderation_case`, v1 config key seed), a compile-time `CONFIG_KEY_METADATA` registry per NOT4 2026-04-19 (`&'static [ConfigKeyMetadata]`, not a DB table), two new `ENTRY_KIND_ADMIN_CONFIG_*` constants, and initialisation of `.claude/rules/governance-log-entry-kind-registry.md` (closes #41 as a side-effect on merge).

## Definition of Done

From `docs/brehon-law-inspired-network/IMPLEMENTATION-PLAN-v0.md` §3.

This is a plan-only PR (markdown in `.claude/PRPs/plans/`, no Rust compile path). The rows below are marked n/a accordingly; the runtime DoD for v1-AD-a lives inside the plan file at §15 "Validation commands" and executes on the `phase-v1-AD-a` impl branch post-merge.

- [ ] Tasks in this PR match numbered tasks in the relevant phase section — n/a (this PR lands the task list itself; enforced at `/prp-ralph` time on `phase-v1-AD-a`)
- [ ] `cargo check --workspace` passes locally (or via the Windows wrapper) — n/a (no Rust changes)
- [ ] `cargo clippy --workspace --tests -- -D warnings` clean — n/a
- [ ] `cargo +nightly fmt -- --check` clean — n/a
- [ ] Woodpecker is green on this push — n/a (markdown-only PR)
- [ ] Integration tests hit a real Postgres (no DB mocks) — n/a (plan phase; tests added in impl PR)

## ADR impact matrix

Answer every row. "n/a" is fine where a row is genuinely irrelevant.

| ADR | Touched? | Notes |
|---|---|---|
| ADR-008 append-only `governance_log` / hash chain | no | Plan adds 2 new `ENTRY_KIND_*` consts in task 7; `governance_log::append` signature and hash-chain mechanics unchanged. |
| ADR-013 `CaseStatus::EmergencyRemove` exhaustive match | no | Plan §12 "NOT building" explicitly excludes `CaseStatus` enum edits and match-arm changes from v1-AD-a scope. |
| ADR-015 pseudonymised actor IDs / `scrub()` on public strings | no | v1-AD-a writes no `governance_log` rows; redaction path untouched. |
| ADR-010 v0 scope — adds an endpoint or dependency? | no | v1-AD-a is post-v0 per ADR-010; adds zero HTTP endpoints in this sub-phase and zero new crate dependencies. askama/actix-web-lab gated behind OQ-V1-AD-01/02 for later sub-phases. |
| ADR-006 inbound federation signals advisory-only | no | Plan reserves `federation.*` namespace in `governance_config` only; zero `crates/apub/` changes in v1-AD-a. |
| New ADR added or existing ADR superseded? | no | Plan opens 3 new OQs (OQ-V1-AD-01/02/03) in task 9. No ADRs added, superseded, or contradicted. |

## Validation commands run locally

Paste exit codes or "n/a":

```text
cargo check --workspace                exit: n/a (plan-only PR, no Rust)
cargo clippy --workspace --tests ...   exit: n/a
cargo test --test e2e                  exit: n/a
cargo +nightly fmt -- --check          exit: n/a
```

Plan-authoring verification ran at commit time against `governance-v0` HEAD `3bbf419da`:

```text
parametric EXPECTED_SEED_COUNT_V1_AD references     14 hits (all parametric)
literal 28 residual drift                            0 offending hits
literal 62 residual drift                            0 offending hits
MD040 untagged fences                                0 (post-fix f363db1c8)
```

Task-level `cargo check` / `cargo test` / `diesel migration` validation runs under `/prp-ralph` on `phase-v1-AD-a` post-merge, per plan §15.

## Risk / rollback

- Migration reversible via `diesel migration redo`? n/a — no migrations in this PR. The 4 migrations land in `phase-v1-AD-a`'s implementation PR, each with `down.sql` mirroring the v0 `2026-04-18-000000-0000_add_governance_config` rollback pattern documented in plan §10.
- If merged and wrong, what's the rollback? Revert the plan commit. Plan has no runtime side-effect; `phase-v1-AD-a` branch not yet cut. Worst-case blast radius is "plan file needs re-authoring" — zero production impact.

## AI review acknowledgement

- [x] CodeRabbit walkthrough read; each finding acted on or acknowledged (commit `f363db1c8`: 1 minor MD040 fence tags + 3 major fixes — 61/62 drift unified, task 7 SQL ownership note, entry-kind collision-check domain corrected)
- [x] `governance-ai-review` workflow comment read (advisory only) — not expected to fire on plan-only PRs per `feedback_ai_review_413_oversize.md`
- [x] `adr-compliance` workflow green, or any red flags discussed in-thread — ADR impact matrix above asserts no ADR touched

<!--
  Reviewer checklist (do not fill in — for the maintainer at merge time):
  [ ] Branch protection satisfied
  [ ] Hash-chain verification test still passing
  [ ] No new v2-scope dependencies introduced (Keycloak/OpenFGA/Vault/HSM/KMS)
  [ ] Every user-visible string scrubbed before reaching the governance log
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive v1 planning and handover materials (planning queue JSON, session handovers and bootstrap).
  * Added PRDs for v1 Admin Dashboard, Federation Inbound (advisory), Jury Mechanics, Reputation Tuning, Sponsor Liability, and an issue-triage report.
  * Added a detailed admin-dashboard implementation plan covering config key metadata, governance-log entry kinds, seeding/parity rules, migration steps and rollout acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->