### PR TITLE
v0-polish-1: critical governance bugs — GH #48 #35 #34 #33

### DIFF
--- a/.claude/PRPs/plans/v0-polish-plan.md
+++ b/.claude/PRPs/plans/v0-polish-plan.md
@@ -56,8 +56,9 @@ GitHub issues under `barrie-cork/lemmy` carry current state per item. This file 
 10. **GH #37** — `cargo-test-e2e` workflow silently overrides `rust-toolchain.toml` (ops / risk:low)
     - CI uses stable instead of 1.95. Known workflow bug.
 
-11. **GH #49** — `task-hopper.sh` `TH_ISSUE_URL` env propagation (risk:low)
-    - Already fixed in PR #46 at `9aa1a778a`. **Verify and close without reopening the file.**
+11. ~~**GH #49** — `task-hopper.sh` `TH_ISSUE_URL` env propagation (risk:low)~~
+    - ~~Already fixed in PR #46 at `9aa1a778a`. **Verify and close without reopening the file.**~~
+    - **STRUCK 2026-04-19.** GH #49 was closed `2026-04-19T17:47:00Z` (32 min post PR #46 merge). No action required. Plan count 23 → 22 items.
 
 12. **GH #38 / #39 / #50 / #51 / #52** — minor docs fixes
     - #38 fork-local design-doc citations + broken relative link in Phase 5c docs
@@ -109,9 +110,9 @@ Five PR groupings, chosen to balance CodeRabbit review load against integration 
 | **polish-N topic** | 13–21 | `polish/<topic>` per item | One PR per topic: ts-rs regen, redaction harden, OQ-006 tuning, README, clippy sweep, udeps, elevated-CodeRabbit, renames, DQ #37 layering revisit. Topics are unrelated; don't bundle. |
 | **polish-tag** | 23 | `polish/v0-tag` | After all above ship, cut release commit + tag `v0.0.0`. |
 
-**Items 8, 9, 10, 11 not yet grouped.** Decide at kickoff:
+**Items 8, 9, 10 not yet grouped.** Decide at kickoff:
 - Options: one `polish/ops-misc` PR, or absorb into polish-3 docs if they stay docs-only.
-- Item 11 (#49) is already fixed in PR #46 — just verify and close without code changes.
+- Item 11 (#49) struck above — already closed 2026-04-19.
 
 ## Rules for all polish PRs
 

--- a/.claude/PRPs/polish-runlog/00-polish-intake.md
+++ b/.claude/PRPs/polish-runlog/00-polish-intake.md
@@ -132,3 +132,44 @@ Once triage agents return, the advisor writes a concrete PR sequence
 - **Any splits:** **none.** #51 is genuinely docs-only — it edits `question`/`answer` string fields on an already-resolved DQ entry, not schema or active state. Keep with the sweep.
 - **Ordering constraint:** **none between the 5 issues.** One constraint vs. other polish PRs: #52 should pick **Option B** (prose-only carve-out, per issue body's "faster to land and matches how the rule was actually used in Phase 6") — Option A would extend `scripts/brehon/task-hopper.sh`, pulling the sweep out of docs-only scope. If a later polish wave decides on Option A, reopen as a separate code PR.
 - **Parallel-safety vs polish-1:** docs-sweep touches zero files that polish-1 (`#48 #35 #34 #33`) touches. `governance_log::append`, `submit_jury_vote`, `federation_outbox`, `request_appeal`, `admin_assign_jury` are all `.rs` handler sources. Docs-sweep is safe to run in parallel with polish-1 in a separate worktree.
+
+---
+
+## Session save (2026-04-19T17:50Z)
+
+**Status:** 4 of 5 polish-1 commits shipped; validation + e2e tests still TODO.
+
+**Branch:** `polish/critical-bugs` — pushed, tip at `5cb868827`.
+
+### Commits on branch (chronological)
+
+| SHA | Subject | Scope |
+|---|---|---|
+| `a25e6bbe0` | chore(runlog): v0-polish kickoff — Impl1+Impl2 assignments | runlog |
+| `4a406cd74` | chore(runlog): T1 triage findings | runlog |
+| `1bb622e8a` | fix(governance-log): wrap append INSERT+UPDATE in run_transaction | #48(a)+#35 |
+| `93c8922eb` | fix(governance): log case_decided before federation_sanction_sent | #48(b) |
+| `034409128` | fix(governance): appeal window compares closed_at to now | #34 |
+| `5cb868827` | fix(governance): exclude declining juror from replacement pool | #33 |
+
+### NOT yet done (for next session)
+
+- **Validation sweep.** Need to run:
+  1. `cargo check --workspace --features full`
+  2. `cargo clippy --workspace --no-deps --features full -- -D warnings`
+  3. `cargo test --test e2e --no-run -p lemmy_server`
+  4. `cargo test --test e2e -p lemmy_server` (expect 14 passed / 0 failed / 3 ignored)
+- **e2e regression tests.** #34 and #33 fixes need dedicated tests per plan §"PR structure" commit 5:
+  - `appeal_golden_path_after_decide` — decide a case, immediately call `request_appeal`, expect 200
+  - `decline_replacement_does_not_pick_decliner` — assign juror A, A declines, trigger replacement, assert A not in new panel
+- **PR creation.** After validation green, `gh pr create --repo barrie-cork/lemmy --base governance-v0 --head polish/critical-bugs` with body referencing GH #48, #35, #34, #33.
+- **#48(c) deferral note.** The hidden `actor_pseudonym` write in `federation_outbox.rs:159-160` is NOT fixed here — defer to polish-N per plan. Add a comment at the call site clarifying the idempotency invariant.
+
+### Impl2 progress (external)
+
+Impl2 is working `polish/docs-sweep` branch separately (GH #38/#39/#50/#51/#52). No file overlap with Impl1's scope. Check `origin/polish/docs-sweep` when resuming to confirm landing status.
+
+### Open concerns
+
+- **#48(a) behavioural change.** Wrapping `governance_log::append` INSERT+UPDATE in `conn.run_transaction` is load-bearing on the "nested run_transaction becomes SAVEPOINT" semantic. Diesel-async docs confirm this, but the e2e suite is the authoritative check. If `governance_log_hash_chain_holds` or `sanction_notice_round_trip` fails, the tx wrap may be interacting badly with caller-owned tx reborrows.
+- **#34 semantic shift.** The old guard rejected every Decided case. Switching to `closed_at > now()` means existing Decided cases in test fixtures that have `closed_at` stamped by a fixture helper (not `submit_jury_vote`) may now accept where they previously rejected. Any test that relied on "appeal must fail" post-decide is now broken. Audit `tests/e2e.rs` for `request_appeal` and expected-failure assertions.

--- a/.claude/PRPs/polish-runlog/00-polish-intake.md
+++ b/.claude/PRPs/polish-runlog/00-polish-intake.md
@@ -43,3 +43,92 @@ Agents will return triage notes; advisor will then pick a starting PR and sequen
 
 Once triage agents return, the advisor writes a concrete PR sequence
 (starting with polish-1) and spawns impl agents per PR.
+
+---
+
+## Research findings
+
+### T1 — issue triage
+
+**Verified against `gh issue list --repo barrie-cork/lemmy --state all` + auto-memory, 2026-04-19.**
+
+#### Plan items verified correct (OPEN, plan-to-issue mapping valid)
+
+- Item 1 → **#48** OPEN, labels `bug` + `risk:high`. Title matches plan's "atomicity + causal-ordering + hidden-write sweep".
+- Item 2 → **#35** OPEN, labels `bug` + `risk:high`. Title matches "NOTIFY trigger fires on INSERT before signature UPDATE".
+- Item 3 → **#34** OPEN, labels `bug` + `risk:high`. Title matches "request_appeal unreachable for Decided cases".
+- Item 4 → **#33** OPEN, labels `bug` + `risk:critical`. Title matches "declining juror can be picked as own replacement".
+- Items 5, 6, 7 → **#54** OPEN (single umbrella issue for PR #46 Bucket C follow-ups). Plan references sub-items `#2p-7`, `#2p-2`, `#2p-3`, `#2p-6` — these are thread anchors within #54's body, not separate issues. Valid.
+- Item 8 → **#36** OPEN, labels `bug` + `risk:medium`. Matches "404 allowed in e2e route-registration gate".
+- Item 9 → **#47** OPEN, labels `bug` + `risk:low`. Matches "task-hopper.schema.json lifecycle invariants".
+- Item 10 → **#37** OPEN, labels `ops` + `risk:low`. Matches "cargo-test-e2e workflow silently overrides rust-toolchain.toml". Note: this is a CodeRabbit follow-up on PR #32 (merged `3bbf419da`); PR #32 added the workflow but did NOT fix the toolchain pin — so #37 is correctly still open.
+- Item 12 → **#38, #39, #50, #51, #52** all OPEN, all labelled `documentation` + `risk:low`. Mapping valid.
+- Item 22 → **#53** OPEN, labels `enhancement` + `v1` + `risk:low`. Tagged v1-deferred but still bundled in polish plan as 🔵 trivial — intentional per plan line 93.
+
+#### Drift / stale references
+
+- **Item 11 (plan line 60):** cites **#49** and claims "Already fixed in PR #46 at `9aa1a778a`. Verify and close without reopening the file." Status: **#49 is already CLOSED** (`closedAt 2026-04-19T17:47:00Z`, stateReason `COMPLETED`) — closed 32 min after PR #46 merged. **Action: strike item 11 from the plan — no action needed.** The "verify and close" step is done.
+
+#### Memory reconciliation
+
+- **`project_pr46_phase_6_review_response.md` line 73** — claim "Awaiting CodeRabbit re-review on `8ee45a3ca`. On green … merge PR #46 into governance-v0" — STATUS: **superseded**. `gh pr view 46` confirms **MERGED** at `08065e1a1` (`mergedAt 2026-04-19T17:15:37Z`, base `governance-v0`). Merge commit hash matches plan line 3.
+- **`project_phase_6_handoff_ready.md`** — describes overnight Phase 6 run state at `15f8cbbd0`. Phase 6 has since shipped and merged. Historical; no action required.
+- **`feedback_coderabbit_block_merge_critical.md`** — process rule, still accurate. Pattern held on PR #46 execution (both Critical findings #15 and #19 fixed in-PR at `41f1d0379` + `d70610980`). No reconciliation needed.
+- **MEMORY.md index lines 40 + 49** — still reference "pending CI gates before merge" (PR #10) and "awaiting CodeRabbit re-review" (PR #46). Both PRs now merged. Stale but not load-bearing for polish intake.
+
+#### Additional OPEN issues NOT in plan (advisory)
+
+- **#45** OPEN (no labels) — `sponsor_liability_with_founder_multiplier accept_jury_assignment NotFound flake`. Test flake. Decide if it blocks v0 tag (test determinism) or defers to v1.
+- **#43** OPEN (no labels) — `phase1_migrations_round_trip needs revert-list extension for federation tables (task 70 carry-forward)`. Test infra carry-forward from Phase 6. Likely v1.
+- **#42** OPEN (no labels) — `ineligible_user_cannot_be_picked_for_jury cross-test contamination under --test-threads=1`. Test isolation. Likely v1 but could fold into item 17 clippy/test-harness sweep.
+- **#6** OPEN (labels `governance/plan-drift` + `risk:high`) — "Plan drift — 2026-04-17 (11 row(s))". **Stale.** Pre-dates Phase 5c completion (shipped all 11 MVP endpoints per `project_phase_5c_complete.md`). **Action: re-run plan-drift check on current `governance-v0` HEAD `08065e1a1`; if all 11 endpoints wired, close #6.** Docs-hygiene close — fold into polish-3 or pre-tag verify step.
+- **#40, #41, #30, #11–#29, #31, #53** — all `v1` labelled. Correctly excluded per plan line 146.
+
+#### Recommendations
+
+1. **Strike plan item 11 (#49)** — already closed; "verify and close" step is done. Reduces plan from 23 to 22 items.
+2. **Add "verify-and-close #6"** to polish-3 docs sweep or as a standalone pre-tag check — plan-drift report 2 days stale; likely no-ops post Phase 5c+6.
+3. **Triage #45, #43, #42 at polish-1 kickoff.** `#42` and `#43` feel v1; `#45` flake may warrant a cheap fix if reproducible.
+4. **Memory-index refresh (low priority, post-polish-week)** — update `MEMORY.md` lines 40 + 49; reflect PR #10 + PR #46 merged state in their summary fields.
+5. **No other drift** — plan item → issue mapping is otherwise clean. GH #54 umbrella-subitem convention (`#2p-N`) is valid.
+
+### T3 — docs-sweep scope
+
+**Verified against worktree HEAD `a25e6bbe0` on `polish/critical-bugs` (tip of `governance-v0` + kickoff runlog commit), 2026-04-19.**
+
+#### File inventory
+
+| Issue | File(s) | Type | Line-range estimate |
+|---|---|---|---|
+| #38 | `crates/api/api/src/governance/accept_jury_assignment.rs` (lines 7, 12 — `//!` docstring) | Rust doc-comment only | ~2 lines |
+| #38 | `crates/db_views/governance_case/src/impls.rs` (lines 171, 187 — `///` docstring) | Rust doc-comment only | ~2 lines |
+| #38 | `.claude/PRPs/reports/phase-5c-complete-report.md` (line 27 — relative link) | md | 1 line |
+| #39 | `docs/brehon-law-inspired-network/SUBSCRIPTIONS.md` (§43-area, gap semantics) | md | ~15–25 lines (split one paragraph into 3 bullets) |
+| #50 | `.claude/PRPs/plans/phase-6-federation.plan.md` (fences at 97 + 848; enum names at 480/492/493) | md (ASCII + SQL fences) | 5 lines (2 fences + 3 enum-name swaps) |
+| #51 | `.claude/decision-queue.json` (entry `id: 38`, DQ-6.7 `question`/`answer` text) | json (string fields only) | ~3–6 lines of string-value rewrites |
+| #52 | `.claude/rules/task-hopper.md` (lines 152, 177, 181 area) | md (auto-loads in -p mode) | ~15–25 lines (Option B carve-out or Option A rewrite) |
+
+#### Code-surface check
+
+- **All files markdown/json documentation:** mostly — #38 touches 2 `.rs` files but the edits are entirely inside `//!` / `///` doc-comment blocks (grep-verified: only `plan §11.4`, `plan §11.7`, `line 377` matches appear inside doc-comment lines). No code semantics, no `#[doc = ...]` attributes that would feed macros. **Cargo-clean: yes.**
+- **Rule files touched (auto-load in -p mode):** `.claude/rules/task-hopper.md` (#52). This file auto-loads when `claude -p` reads the rules dir. Edits are prose-only wording changes (no hook YAML, no slash-command invocation strings that scripts would grep). Low risk, but Option A (route recovery through `task-hopper.sh escalate`) would couple the doc edit to a script change — confirm the sweep uses **Option B** (prose-only "advisor-only repair" carve-out) to keep this in docs-only scope.
+- **Hidden-code risks:**
+  - **#50 SQL snippet (lines 475–499):** `CREATE TABLE federation_attestation (...)` is in a `sql` code fence inside the plan doc. Not executed; no tooling greps this plan for DDL. Safe.
+  - **#50 ASCII fences (97 + 848):** tagging `text` is a markdownlint-only concern. No ripgrep / MD040 CI wiring consumes these tags for logic. Safe.
+  - **#39 SUBSCRIPTIONS.md:** contains a SQL block (lines 33–38) as reference, but #39 edits the prose *following* it. No change to SQL. Safe.
+  - **#51 decision-queue.json:** schema-wise this is a free-form `answer` string plus `question` string on an already-resolved entry (`answered_by: impl-self-resolved`). No `task-hopper.schema.json`-adjacent field. Per memory `feedback_python_utf8_encoding_windows.md`, use the Edit tool directly (not Python) to preserve `§` and `—`.
+  - **#38 Rust doc edits:** `cargo doc` consumes these — a malformed link in a docstring would fail `cargo doc`, but the edits here are plain-text "plan §11.X" → "Phase 5c task N" substitutions. Safe. No `cargo check` exposure (docstrings are not compiled).
+
+#### Overlaps
+
+- **None.** Each issue touches disjoint files. Closest proximity:
+  - #51 (`.claude/decision-queue.json`) and #52 (`.claude/rules/task-hopper.md`) both live under `.claude/` but are separate files.
+  - #50 and #38 both touch the PRPs tree (`.claude/PRPs/plans/` vs `.claude/PRPs/reports/`) but distinct files.
+- No same-file collision → edit order is free.
+
+#### Recommendation
+
+- **Single PR shape:** **yes.** One branch `polish/docs-sweep` off `governance-v0`, one commit `chore(docs): v0-polish docs sweep — #38 #39 #50 #51 #52` (or per-issue commits if task-per-commit is preferred for CodeRabbit review; diff stays small either way — ~60–90 lines total across 7 files).
+- **Any splits:** **none.** #51 is genuinely docs-only — it edits `question`/`answer` string fields on an already-resolved DQ entry, not schema or active state. Keep with the sweep.
+- **Ordering constraint:** **none between the 5 issues.** One constraint vs. other polish PRs: #52 should pick **Option B** (prose-only carve-out, per issue body's "faster to land and matches how the rule was actually used in Phase 6") — Option A would extend `scripts/brehon/task-hopper.sh`, pulling the sweep out of docs-only scope. If a later polish wave decides on Option A, reopen as a separate code PR.
+- **Parallel-safety vs polish-1:** docs-sweep touches zero files that polish-1 (`#48 #35 #34 #33`) touches. `governance_log::append`, `submit_jury_vote`, `federation_outbox`, `request_appeal`, `admin_assign_jury` are all `.rs` handler sources. Docs-sweep is safe to run in parallel with polish-1 in a separate worktree.

--- a/.claude/PRPs/polish-runlog/00-polish-intake.md
+++ b/.claude/PRPs/polish-runlog/00-polish-intake.md
@@ -1,0 +1,45 @@
+# Post-Phase-6 polish — intake runlog
+
+**Started:** 2026-04-19T17:20Z
+**Base:** `governance-v0` @ `08065e1a1` (PR #46 merge)
+**Source memory:** `project_brehon_post_phase6_cleanup.md` (advisor-side homeserver)
+**Target:** ship v0.0.0 tag after all polish PRs land on `governance-v0`
+
+---
+
+## Shipping strategy (from memory)
+
+| PR | Items | Branch | Priority |
+|---|---|---|---|
+| **polish-1 critical bugs** | 1–3 (+ maybe 4) | `polish/critical-bugs` | 🔴 blocks tag |
+| **polish-2 Bucket C** | 5–7 | `polish/bucket-c` | 🟠 ship if cheap |
+| **polish-3 docs** | 12 | `polish/docs-sweep` | 🟠 low risk |
+| **polish-N topic** | 13–21 | `polish/<topic>` per item | 🟡 evaluate |
+| **polish-tag** | 23 | `polish/v0-tag` | 🟢 last |
+
+Rules: base `governance-v0`, merge (not squash), CR critical-only discipline.
+
+---
+
+## Phase 0 — triage (in progress)
+
+Running parallel research agents to answer:
+
+1. **Which issues are still open?** Cross-reference memory's issue list (#33, #34, #35, #36, #37, #38, #39, #47, #48, #49, #50, #51, #52, #53, #54) against `gh issue list` current state. Some may already be closed (memory notes #49 should be closeable).
+2. **What's the current code state for polish-1 items (#48, #35, #34, #33)?** Read the files, assess fix difficulty, confirm memory's scope against what's actually there.
+3. **What trivial docs items (#38, #39, #50, #51, #52) can be bundled?** Confirm each exists + check cost.
+
+Agents will return triage notes; advisor will then pick a starting PR and sequence the work.
+
+---
+
+## Agent assignments
+
+- **Agent-T1 (issues)** — `gh issue list --state open --repo barrie-cork/lemmy` full dump + verify claims in memory
+- **Agent-T2 (polish-1 code)** — read `governance_log::append`, `submit_jury_vote` post-decision block, `federation_outbox::send_local_sanction_notice`, `request_appeal` guard, `admin_assign_jury` pool filter
+- **Agent-T3 (docs bundle)** — read each of #38/#39/#50/#51/#52, confirm scope, estimate combined diff size
+
+## Next
+
+Once triage agents return, the advisor writes a concrete PR sequence
+(starting with polish-1) and spawns impl agents per PR.

--- a/.claude/PRPs/polish-runlog/00-polish-intake.md
+++ b/.claude/PRPs/polish-runlog/00-polish-intake.md
@@ -92,6 +92,55 @@ Once triage agents return, the advisor writes a concrete PR sequence
 4. **Memory-index refresh (low priority, post-polish-week)** — update `MEMORY.md` lines 40 + 49; reflect PR #10 + PR #46 merged state in their summary fields.
 5. **No other drift** — plan item → issue mapping is otherwise clean. GH #54 umbrella-subitem convention (`#2p-N`) is valid.
 
+### T2 — polish-1 scope
+
+**Verified against worktree HEAD `65bfdb683` on `polish/critical-bugs`, 2026-04-19.** All four issue fixes have already landed as commits on this branch (`1bb622e8a`, `93c8922eb`, `034409128`, `5cb868827`); the analysis below maps the fix surfaces that **were** needed and confirms landed state, so the PR-grouping recommendation reflects what actually shipped.
+
+#### #48 — governance_log atomicity / causal / hidden-write
+- **Code surface:**
+  - (a) atomicity — `crates/db_schema/src/source/governance/governance_log.rs:165-226` (INSERT + UPDATE in `append`)
+  - (b) causal order — `crates/api/api/src/governance/submit_jury_vote.rs:452-494` (`case_decided` append vs. `send_local_sanction_notice` call)
+  - (c) hidden pseudonym write — `crates/api/api/src/governance/federation_outbox.rs:159-160` (`actor_pseudonym_helper::get_or_create` with no matching log entry)
+- **Fix shape:** (a) wrap INSERT+UPDATE in `conn.run_transaction(|conn| { ... }.scope_boxed())` with the reborrow pattern so nested callers collapse to a SAVEPOINT; (b) append `case_decided` **before** the `if FederatedRecommendation { send_local_sanction_notice }` block so the hash chain records the local determination ahead of any derived federation signal; (c) **deferred** — current `get_or_create` is idempotent under the unique constraint and introducing a read-only variant or bespoke ADR-015 entry_kind is larger than the polish-1 scope can carry without an ADR touch.
+- **Blast:** (a) `governance_log.rs` +~40 LoC (transaction wrap + doc update); (b) `submit_jury_vote.rs` ~30 LoC move with causality comment; (c) one-line comment at call site. No migration. Tests that exercise `governance_log::append` transitively cover (a); `sanction_notice_round_trip` is the causal-order regression for (b).
+
+#### #35 — NOTIFY trigger fires on INSERT before signature UPDATE
+- **Code surface:** `migrations/2026-04-20-000100-0000_fix_governance_log_notify_trigger_after_sign/up.sql` — already replaces the original `AFTER INSERT` trigger with `AFTER UPDATE OF signature` gated by `OLD.signature IS NULL AND NEW.signature IS NOT NULL`. The trigger fix migration **pre-existed on `governance-v0`** (landed via PR #46 re-review Bucket C); the polish-1 branch adds no new migration.
+- **Fix shape:** trigger already fires only at the NULL→NOT NULL signature transition (option A from the issue body). Combined with #48(a) atomicity wrap, the NOTIFY-before-signed-row window closes completely: subscribers can only observe the post-UPDATE state, and the INSERT+UPDATE now commit together.
+- **Overlap with #48:** **high** — resolution requires both the trigger change (already shipped) **and** the atomicity wrap (#48(a)). Without the atomicity wrap, a crash between INSERT and UPDATE still leaves an unsigned row that the trigger never fires for (subscribers silently miss the event). The #48(a) tx wrap closes that gap; the commit message `1bb622e8a` cites both `#48 #35` for this reason. **One shared test** (`governance_log_hash_chain_holds` + a NOTIFY LISTEN probe added in commit 5) covers both.
+
+#### #34 — request_appeal unreachable for Decided cases
+- **Code surface:** `crates/api/api_crud/src/governance/request_appeal.rs:107-115` — the `within_window` guard.
+- **Fix shape:** replace `if case.closed_at.is_some() { NotFound }` with `let within_window = case.closed_at.map(|c| c > Utc::now()).unwrap_or(false); if !within_window { NotFound }`. Semantic: appeal allowed iff `closed_at` is set and in the future; NULL `closed_at` on a Decided case is a data error and rejects.
+- **Blast:** ~6 LoC plus e2e regression. No migration. Touches no `governance_log` code and no federation code; isolated to the appeal handler.
+- **Overlap with #48/#35:** **none in code** — different crate (`api_crud` vs `api`) and different module. Overlap is purely **thematic** (both are PR #10 CR unresolved threads blocking v0 tag).
+
+#### #33 — declining juror self-replacement
+- **Code surface:** `crates/api/api/src/governance/decline_jury_assignment.rs:135-142` — `exclude_person_ids` build-up before the `select_eligible_jurors` call at line 147.
+- **Fix shape:** after the `jury_assignment::table.filter(...).select(person_id).load(conn)` that produces `current_assignees`, unconditionally push `caller_id` onto the mutable vec before passing it as the exclude list. The `ne(Declined)` filter removed the declining juror's row from the query results, so the caller's id has to be re-injected explicitly.
+- **Blast:** 2 LoC (rename to `mut` binding + `push(caller_id)`) plus e2e regression. No migration. Touches only the decline handler.
+- **Overlap:** **none in code** — touches neither `governance_log::append`, the `submit_jury_vote` decision block, nor the `request_appeal` handler. Same crate (`api`) as #48(b) but a different module entirely.
+
+#### Recommendation
+
+**Bundle: Option A (all four in one PR: `polish/critical-bugs`).**
+
+Justification, in order of weight:
+
+1. **#48(a) and #35 are inseparable.** The NOTIFY trigger fix already shipped on `governance-v0` via PR #46, but it only becomes correct once the INSERT+UPDATE are atomic. Splitting them reintroduces the observable gap (unsigned row) until the second PR merges. A single PR with the shared test is the minimum safe shape.
+2. **#48(b) shares the outer transaction with #48(a).** Both writes live inside `submit_jury_vote.rs`'s post-decision `run_transaction`; re-ordering the `case_decided` append is a 1-commit change that a reviewer naturally reads alongside the atomicity wrap.
+3. **#34 and #33 are tiny and mechanical.** #34 is a 6-line guard inversion; #33 is a 2-line push. Bundling them into a governance-invariants PR adds ~10 LoC of production code plus ~60 LoC of e2e fixtures. Reviewer cost is lower than a second round-trip (CodeRabbit run + human re-review) on two separate PRs.
+4. **All four share the thematic umbrella** ("governance invariants that survived Phase 5c / PR #10 CR review and must be green before v0 tag") — the PR body can cite all four issues with one validation matrix. CodeRabbit is configured for governance-v0-targeted reviews (`.coderabbit.yaml`); a single focused PR gives CR one review pass.
+5. **Task-per-commit history is preserved.** The polish-1 branch's 4 fix commits (one per issue) are merge-able without squash, keeping the retro link between each CR finding and its fix, which matches `phase-branch.md` rule intent.
+
+**Split justification if any:** none recommended. #33 is the weakest candidate for bundling (different module, no shared surface with the other three); the only reason to split it would be if its regression test turns out to be expensive or reveals a deeper jury-selection bug that drags scope. If that happens mid-validation, **cut a new `polish/jury-self-exclude` branch from `polish/critical-bugs@93c8922eb`** (cherry-pick the #33 commit off) and ship the remaining three first.
+
+**Open questions to surface via DQ:** none from code analysis alone. The session-save at lines 172-175 already flags two real concerns that belong in the DQ or the PR body, not here:
+- Whether the `run_transaction`-inside-`run_transaction` SAVEPOINT semantic holds across **all** `governance_log::append` call sites under e2e load (`governance_log_hash_chain_holds` is the authoritative check).
+- Whether any existing e2e test asserts "request_appeal must fail after decide" and now false-reds under the #34 semantic shift (audit needed before merge).
+
+Both are validation-phase concerns, not scoping concerns.
+
 ### T3 — docs-sweep scope
 
 **Verified against worktree HEAD `a25e6bbe0` on `polish/critical-bugs` (tip of `governance-v0` + kickoff runlog commit), 2026-04-19.**

--- a/.claude/PRPs/polish-runlog/00-polish-intake.md
+++ b/.claude/PRPs/polish-runlog/00-polish-intake.md
@@ -222,3 +222,41 @@ Impl2 is working `polish/docs-sweep` branch separately (GH #38/#39/#50/#51/#52).
 
 - **#48(a) behavioural change.** Wrapping `governance_log::append` INSERT+UPDATE in `conn.run_transaction` is load-bearing on the "nested run_transaction becomes SAVEPOINT" semantic. Diesel-async docs confirm this, but the e2e suite is the authoritative check. If `governance_log_hash_chain_holds` or `sanction_notice_round_trip` fails, the tx wrap may be interacting badly with caller-owned tx reborrows.
 - **#34 semantic shift.** The old guard rejected every Decided case. Switching to `closed_at > now()` means existing Decided cases in test fixtures that have `closed_at` stamped by a fixture helper (not `submit_jury_vote`) may now accept where they previously rejected. Any test that relied on "appeal must fail" post-decide is now broken. Audit `tests/e2e.rs` for `request_appeal` and expected-failure assertions.
+
+---
+
+## External validation report from /prp-debug session (2026-04-19T19:13Z)
+
+A `/prp-debug` session was running issue #48 RCA in parallel and reached this worktree to apply the same fix. Independent convergence: the debug session's edits matched `2ced0761d` (#48 finding 2) verbatim — both shapes were identical. **Coordination breakdown noted:** the session-save above marked `#48(c)` as "defer to polish-N" but the actual commit landed on this branch the same evening; the debug session entered the worktree without a runlog pre-flight check. Mitigation rule: `.claude/rules/multi-session-worktree-safety.md` (added on `plan/v1-admin-dashboard` worktree this session).
+
+**Validation result that matters.** Debug session ran `cargo-test.bat --test e2e --no-run -p lemmy_server` against polish worktree tip @ `2ced0761d` (with the unstaged #34/#33 regression tests applied on top). **Three compile errors in `crates/server/tests/e2e.rs`:**
+
+1. **Line 3357 — `2ced0761d`'s pseudonym-seed bug.** The fixture-seed block uses bare `?` on `LemmyResult` inside a `Result<_, Box<dyn Error>>` test fn:
+
+   ```rust
+   lemmy_api::governance::actor_pseudonym_helper::get_or_create(
+     &mut context_a.pool(),
+     admin_pid,
+   ).await?;
+   ```
+
+   `LemmyError` does not implement `std::error::Error`, so `?` cannot bridge to `Box<dyn Error>`. Fix by mirroring the `seed_person_with_apub` pattern at line ~3304:
+
+   ```rust
+   lemmy_api::governance::actor_pseudonym_helper::get_or_create(
+     &mut context_a.pool(),
+     admin_pid,
+   )
+   .await
+   .map_err(|e| -> Box<dyn Error> { format!("seed admin pseudonym: {e}").into() })?;
+   ```
+
+2. **Line 3877 — missing `use diesel::QueryDsl;`** in `appeal_inside_window_succeeds_expired_rejects` test (#34 regression). The `moderation_case::table.filter(...)` call fails with `not an iterator` because `.filter` needs `QueryDsl` in scope. Add it to the test's `use diesel::{...}` block alongside `Connection`, `ExpressionMethods`, `PgConnection`.
+
+3. **Line 3883 — same missing import**, same test, second `diesel::update(...)` call. Same fix as #2 (one import covers both call sites).
+
+Wrapper exit-code masking: `cargo-test.bat` returned 0 to the bash status capture despite cargo failing with the three errors above. Wrapper itself looks correct (`setlocal enabledelayedexpansion` + `exit /b !errorlevel!` are present), so the masking happens between cmd and bash — likely the `cmd //c` invocation. Worth investigating separately; **assume the wrapper exit code is unreliable until confirmed.** For now: always tail the captured log and grep for `^error` even when the wrapper says exit 0.
+
+**Tail of validation log:** `.claude/test-fix2.log` in this worktree has the full output.
+
+**Recommendation for next polish-1 work.** Apply the three fixes above before opening the v0-polish PR. They are 4 line edits total — should land as one commit titled `fix(tests): wire LemmyError mapping + missing QueryDsl import on v0-polish e2e regressions`.

--- a/.claude/PRPs/polish-runlog/01-polish-1-plan.md
+++ b/.claude/PRPs/polish-runlog/01-polish-1-plan.md
@@ -1,0 +1,121 @@
+# polish-1 critical-bugs — plan
+
+**Base:** `governance-v0` @ `08065e1a1` (PR #46 merge)
+**Branch:** `polish/critical-bugs` (to cut)
+**Target:** ship 4 production-code fixes in one PR. Est. ~3–4 hours including validation.
+**Sequence (per T1 + T2 + owner comments on each issue):** #35 + #48(a) → #48(b) → #34 → #33 → validate.
+
+---
+
+## Scope (post-triage)
+
+### #48 (a) + #35 — `governance_log::append` atomicity
+
+**Location:** `crates/db_schema/src/source/governance/governance_log.rs:165-210`
+
+**Current shape:** get_conn → INSERT (line 181-185) → compute signature → UPDATE (line 195-198). If UPDATE fails, orphan row with `signature = NULL`. The NOTIFY trigger already fires `AFTER UPDATE OF signature` (fixed in migration `2026-04-20-000100`), so #35 is implicitly resolved once the two writes are atomic — subscribers will still observe only signed rows.
+
+**Fix:** wrap INSERT+UPDATE in `conn.run_transaction(...)`. Safe: callers (e.g. `federation_outbox.rs:187-193`, `admin_assign_jury.rs:165-174`) invoke `append` from inside their own outer `run_transaction` already; nested `run_transaction` on a diesel-async conn becomes a SAVEPOINT, not a new tx (documented in `sponsor_liability.rs:34-35` — but we're NOT nesting from the caller; `append`'s own tx would be the first tx when called from the bare-pool context).
+
+**Caller audit:** confirm nobody passes `append` a conn that's already in a `run_transaction` closure and expects the outer tx to cover it. Per T2: all callers run `append` inside their outer tx via `&mut conn.into()` reborrow. If `append` wraps INSERT+UPDATE in its own tx while already inside one, diesel-async will SAVEPOINT — safe. But this is a real behavioural change; need e2e-run to confirm.
+
+**Acceptance:** `governance_log_hash_chain_holds` still passes.
+
+### #48 (b) — causal ordering in `submit_jury_vote`
+
+**Location:** `crates/api/api/src/governance/submit_jury_vote.rs:466-488`
+
+**Fix:** move the `governance_log::append("case_decided", ...)` block (lines 478-488) ABOVE the `if matches!(map_decision_to_sanction(...), Some((SanctionScope::FederatedRecommendation, _)))` federation-send block (lines 466-476). Both already share the outer `run_transaction`; moving doesn't change atomicity.
+
+**Acceptance:** `governance_log_hash_chain_holds` still passes. Manually inspect e2e chain dump for `sanction_notice_round_trip` — `case_decided` entry_kind must precede `federation_sanction_sent` by hash-link order.
+
+### #48 (c) — hidden `get_or_create` write (DEFER)
+
+**Location:** `crates/api/api/src/governance/federation_outbox.rs:159-160`
+
+Per T2: no `get_or_require` variant exists; current `get_or_create` is idempotent under unique constraint. Cost of introducing read-only variant is low but not strictly required. **Defer to polish-N or post-tag.** Add one-line comment at call site clarifying invariant instead.
+
+### #34 — `request_appeal` guard inversion
+
+**Location:** `crates/api/api_crud/src/governance/request_appeal.rs:104-107`
+
+**Current shape:** `if case.closed_at.is_some() { return NotFound }`. Comment says "closed_at must still be null" — but `submit_jury_vote.rs:327-332` always stamps `closed_at = decided_at + 7 days` when flipping to `Decided`. So every Decided case is unreachable by this guard.
+
+**Fix:** compare against `now()`:
+```rust
+let now_ts = diesel::dsl::now;  // already in use — or use chrono::Utc::now()
+let within_window = case.closed_at.map(|c| c > chrono::Utc::now()).unwrap_or(false);
+if !within_window {
+  return Err(LemmyErrorType::NotFound.into());
+}
+```
+Semantics: appeal allowed iff `closed_at > now()`. NULL `closed_at` on a `Decided` case is a data error — reject.
+
+**Acceptance:** add e2e coverage: decide a case → immediately call request_appeal → expect 200 (or whatever the success shape is). Mirror `report_to_modlog_golden_path`.
+
+### #33 — declining juror self-replacement guard
+
+**Location:** `crates/api/api/src/governance/decline_jury_assignment.rs:106-143`
+
+Per T2 reading: flow is (i) flip declining juror's assignment row to `Declined` (line 106-112); (ii) load `current_assignees` filtering `status != Declined AND status != Expired` (line 132-138); (iii) call `select_eligible_jurors(conn, &case, Some(&current_assignees), ...)` which excludes `current_assignees` and case-principals from the pool.
+
+T2 says: declining juror is naturally excluded because their row was just flipped to `Declined`, so they're not in `current_assignees`.
+
+T1 says: PR #10 CodeRabbit flagged this at decline_jury_assignment.rs:132-138 as a real 5-LOC bug; fix is explicit self-exclude + e2e extension.
+
+**Who's right?** The caller_id is the declining juror; `select_eligible_jurors` excludes `case.target_person_id`, `case.creator_id`, and caller-provided `exclude_person_ids`. If `current_assignees` correctly excludes the declining juror, they're excluded. BUT: `select_eligible_jurors` may filter on raw person_id regardless of case-history; if the pool query is `SELECT p.id FROM person p WHERE p.id != ALL($2) AND <other filters>`, and `$2` = `current_assignees` which excludes the just-declined, then the declining juror IS a candidate for *their own replacement*.
+
+**The bug:** the declining juror is not in `current_assignees` (their status is `Declined`, not `Pending`/`Accepted`), so `select_eligible_jurors` can legitimately pick them back.
+
+**Fix:** push the declining juror's `caller_id` onto the exclude list before calling `select_eligible_jurors`:
+```rust
+let mut exclude_list = current_assignees.clone();
+exclude_list.push(caller_id);
+let replacements = select_eligible_jurors(conn, &case, Some(&exclude_list), &mut cache).await?;
+```
+
+**Acceptance:** extend `ineligible_user_cannot_be_picked_for_jury` or add new e2e: assign juror A, A declines, trigger replacement selection, assert A is not in the new panel.
+
+---
+
+## PR structure
+
+Commit list (one per issue, in sequence):
+
+1. `fix(governance-log): wrap append INSERT+UPDATE in run_transaction (GH #48 #35)` — atomicity + NOTIFY timing (shared fix)
+2. `fix(governance): log case_decided before federation_sanction_sent (GH #48)` — causal ordering
+3. `fix(governance): appeal window compares closed_at to now (GH #34)` — guard inversion
+4. `fix(governance): exclude declining juror from replacement pool (GH #33)` — self-exclude
+5. `test(governance): e2e coverage for #34 appeal + #33 self-exclude` — regression tests
+
+#48(c) deferred — commit note explains.
+
+---
+
+## Validation sequence
+
+After all 4 fixes + tests:
+
+1. `cargo check --workspace --features full`
+2. `cargo clippy --workspace --no-deps --features full -- -D warnings`
+3. `cargo test --test e2e --no-run -p lemmy_server`
+4. `cargo test --test e2e -p lemmy_server`
+
+Expect 14 → 16 passed (plus 3 ignored), 0 failed.
+
+---
+
+## Execution plan
+
+- Impl1 (me): work all 5 commits in sequence on `polish/critical-bugs` in the advisor worktree
+- Single-impl — Phase 6 Bucket C coordination overhead isn't needed for a 4-file, 5-commit PR
+- DQ for anything surprising during impl
+
+---
+
+## Next steps after polish-1 merges
+
+- polish-3 docs sweep (~40 lines across 5 files; immediate parallel work candidate)
+- polish-2 Bucket C residual (#2p-7 TOCTOU + #2p-2/#2p-3 defensive)
+- polish-N individual items (#36, #47, #37, #38, etc.)
+- polish-tag v0.0.0

--- a/.claude/PRPs/polish-runlog/02-impl-assignments.md
+++ b/.claude/PRPs/polish-runlog/02-impl-assignments.md
@@ -1,0 +1,72 @@
+# polish-1/polish-3 — impl assignments
+
+**Created:** 2026-04-19T17:40Z
+**Two-impl split.** Phase 6 lessons: file-level claims via runlog, explicit push gates, single source-of-truth for sequencing.
+
+---
+
+## Impl1 (me) — polish-1 critical bugs
+
+**Branch:** `polish/critical-bugs` (cut from `governance-v0` @ `08065e1a1`)
+
+**Scope (4 fixes + 1 test commit):**
+1. #48(a) + #35 — `crates/db_schema/src/source/governance/governance_log.rs` — wrap append INSERT+UPDATE in `run_transaction`
+2. #48(b) — `crates/api/api/src/governance/submit_jury_vote.rs` — move `case_decided` log above federation send
+3. #34 — `crates/api/api_crud/src/governance/request_appeal.rs` — guard compares `closed_at` to `now()` instead of `is_some()`
+4. #33 — `crates/api/api/src/governance/decline_jury_assignment.rs` — explicit self-exclude before `select_eligible_jurors`
+5. `crates/server/tests/e2e.rs` — regression tests for #34 + #33
+
+**Files owned by Impl1** (DO NOT TOUCH from other impl):
+- `crates/db_schema/src/source/governance/governance_log.rs`
+- `crates/api/api/src/governance/submit_jury_vote.rs`
+- `crates/api/api_crud/src/governance/request_appeal.rs`
+- `crates/api/api/src/governance/decline_jury_assignment.rs`
+- `crates/server/tests/e2e.rs`
+
+**DQs expected:** if any acceptance test fails, or if `run_transaction` wrapping breaks a caller, file DQ and stop.
+
+**Push gate:** Impl1 pushes `polish/critical-bugs` branch independently. No coordination with Impl2 needed — separate branch, separate PR.
+
+---
+
+## Impl2 — polish-3 docs sweep
+
+**Branch:** `polish/docs-sweep` (cut from `governance-v0` @ `08065e1a1`)
+
+**Scope (1 bundled commit):**
+- #38 — `.claude/PRPs/plans/phase-6-federation.plan.md` line 506 + Phase 5c report line 27: relative-path audit (fork-local design-doc citations)
+- #39 — `docs/brehon-law-inspired-network/SUBSCRIPTIONS.md` — add 4-6 line paragraph on serial-id gap semantics under rollback (near "Catch-up on subscriber start" section)
+- #50 — `.claude/PRPs/plans/phase-6-federation.plan.md` MD040 fence language tags (lines 93, 97, 127, 199, 202, 222, 262, 281, 309, 328, 346, 363, 393, 620, 741, 848, 877, 910, 914, 928) + enum typename fixes around line 493 (`*_enum` → plain names)
+- #51 — `.claude/decision-queue.json` entry id=38 — update "question" and "answer" text to reflect in-flight-conn resolution instead of fresh-pool-conn language
+- #52 — `.claude/rules/task-hopper.md:152` — reconcile agent-edit contradiction ("Agents never hand-edit" vs "Advisor may hand-edit for tuning/recovery")
+
+**Files owned by Impl2** (DO NOT TOUCH from other impl):
+- `.claude/PRPs/plans/phase-6-federation.plan.md` (covers #38 + #50)
+- `docs/brehon-law-inspired-network/SUBSCRIPTIONS.md` (#39)
+- `.claude/decision-queue.json` (#51) — UTF-8 encoding on Python open() per `feedback_python_utf8_encoding_windows`
+- `.claude/rules/task-hopper.md` (#52)
+- `.claude/PRPs/reports/phase-5c-*.md` if #38's broken link lives there
+
+**Commit shape:** one commit `chore(docs): v0-polish docs sweep — GH #38 #39 #50 #51 #52`. ~40 lines across 5 files.
+
+**Validation:** no cargo validation needed (docs-only). `bash -n` if any shell in scope (none here).
+
+**Push gate:** Impl2 pushes `polish/docs-sweep` branch independently.
+
+---
+
+## Coordination
+
+- **No file overlap** between Impl1 and Impl2 — parallel branches, parallel PRs.
+- **Runlog is single source of truth** — update `.claude/PRPs/polish-runlog/99-<timestamp>-<impl>-<action>.md` after each meaningful milestone (or append to `03-progress.md` — decide at first commit).
+- **If either impl needs to touch a file outside their list**, file a claim note in the runlog BEFORE staging.
+- **PR creation:** each impl opens its own PR targeting `governance-v0`. Format follows `phase-branch.md` rule. No draft (CodeRabbit skips drafts).
+- **Both PRs merge independently** once reviewed; no merge order constraint between polish-1 and polish-3.
+
+---
+
+## Out-of-scope reminders
+
+- polish-2 Bucket C residual (#2p-7 TOCTOU + #2p-2/#2p-3 defensive) — later PR, not now
+- polish-N individual (#36, #47, #37) — later PRs
+- v1-tagged issues (#22–#31, #40, #41, #53) — do not pull into v0 polish

--- a/crates/api/api/src/governance/actor_pseudonym_helper.rs
+++ b/crates/api/api/src/governance/actor_pseudonym_helper.rs
@@ -5,6 +5,11 @@
 //! payload. Every governance write that needs to attribute an action to
 //! an actor MUST call [`get_or_create`] to materialise a stable, opaque
 //! pseudonym and use that instead.
+//!
+//! Call sites that must not allocate (because the row creation would be
+//! an unlogged side effect on a hot governance path) should call [`get`]
+//! and treat `None` as a hard error — see `federation_outbox.rs` for the
+//! canonical example.
 
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, insert_into};
 use diesel_async::RunQueryDsl;
@@ -13,6 +18,24 @@ use lemmy_db_schema_file::{PersonId, schema::actor_pseudonym};
 use lemmy_diesel_utils::connection::{DbPool, get_conn};
 use lemmy_utils::error::LemmyResult;
 use uuid::Uuid;
+
+/// Return the caller's pseudonym if one already exists for `person_id`,
+/// or `None` if not. Performs no INSERT — use this on governance hot
+/// paths where allocating a pseudonym would be a hidden side effect
+/// without a paired `governance_log` entry (GH #48 finding 2).
+pub async fn get(
+  pool: &mut DbPool<'_>,
+  person_id: PersonId,
+) -> LemmyResult<Option<String>> {
+  let conn = &mut get_conn(pool).await?;
+  let existing = actor_pseudonym::table
+    .filter(actor_pseudonym::person_id.eq(person_id))
+    .select(actor_pseudonym::pseudonym)
+    .first::<String>(conn)
+    .await
+    .optional()?;
+  Ok(existing)
+}
 
 /// Return the caller's pseudonym, inserting a fresh UUIDv4 row on first
 /// use. Idempotent under concurrent insertion: if a racing writer wins

--- a/crates/api/api/src/governance/decline_jury_assignment.rs
+++ b/crates/api/api/src/governance/decline_jury_assignment.rs
@@ -126,21 +126,25 @@ async fn process_decline(
   )
   .await?;
 
-  // 5. Build the exclude list: all active assignees on this case. The
-  //    declining juror's row is now Declined so they are naturally
-  //    excluded by the `ne(Declined)` filter; no special-case.
-  let current_assignees: Vec<PersonId> = jury_assignment::table
+  // 5. Build the exclude list: all active assignees on this case PLUS
+  //    the declining juror. Filtering `jury_assignment` by
+  //    `ne(Declined)` excludes the declining juror's row from the
+  //    active-assignee query, so without the explicit push below they
+  //    would remain eligible and `select_eligible_jurors` could pick
+  //    them as their own replacement (GH #33).
+  let mut exclude_person_ids: Vec<PersonId> = jury_assignment::table
     .filter(jury_assignment::case_id.eq(data.case_id))
     .filter(jury_assignment::status.ne(JuryAssignmentStatus::Declined))
     .filter(jury_assignment::status.ne(JuryAssignmentStatus::Expired))
     .select(jury_assignment::person_id)
     .load(conn)
     .await?;
+  exclude_person_ids.push(caller_id);
 
   // 6. Try to pick ONE replacement. `select_eligible_jurors` returns up
   //    to panel_size; we take the head only.
   let replacements =
-    select_eligible_jurors(conn, &case, Some(&current_assignees), &mut cache).await?;
+    select_eligible_jurors(conn, &case, Some(&exclude_person_ids), &mut cache).await?;
   let replacement_id = replacements.into_iter().next();
 
   // 7. If a replacement exists, insert a Selected row + emit a

--- a/crates/api/api/src/governance/federation_outbox.rs
+++ b/crates/api/api/src/governance/federation_outbox.rs
@@ -132,10 +132,13 @@ use lemmy_utils::error::{LemmyErrorType, LemmyResult};
 ///
 /// Returns `NotFound` if no local admin exists (ADR-010 violation in
 /// production; in tests it means `seed_person` was not called with
-/// `admin = true`). Propagates DB errors and AP-construction errors
-/// from the builder. Any error here triggers `?` propagation up
-/// through `submit_jury_vote::process_vote`, which rolls back the
-/// entire post-decision tx.
+/// `admin = true`), or if the admin's `actor_pseudonym` row has not
+/// yet been allocated (GH #48 finding 2 — test fixtures that exercise
+/// this path on a fresh DB must seed the admin pseudonym up front).
+/// Propagates DB errors and AP-construction errors from the builder.
+/// Any error here triggers `?` propagation up through
+/// `submit_jury_vote::process_vote`, which rolls back the entire
+/// post-decision tx.
 pub async fn send_local_sanction_notice(
   case_id: ModerationCaseId,
   conn: &mut AsyncPgConnection,
@@ -148,16 +151,21 @@ pub async fn send_local_sanction_notice(
   let admin_id = admin_person.id;
   let apub_actor: ApubPerson = admin_person.into();
 
-  // Step 1.5 — derive the admin's pseudonym for the federation_sanction_sent
-  // log entry on the in-flight conn. ADR-015 requires the actor_pseudonym
-  // column to identify the actor that performed the action; the federation
-  // send is performed by the local admin, not by the deciding juror. The
-  // helper insert is idempotent under the `(person_id)` unique constraint
-  // (see actor_pseudonym_helper docs), so executing it inside the outer
-  // tx is safe even if the admin pseudonym row already exists from prior
-  // governance writes.
-  let admin_pseudonym =
-    actor_pseudonym_helper::get_or_create(&mut (&mut *conn).into(), admin_id).await?;
+  // Step 1.5 — read the admin's pseudonym for the federation_sanction_sent
+  // log entry. ADR-015 requires the actor_pseudonym column to identify
+  // the actor that performed the action; the federation send is performed
+  // by the local admin (ADR-010), not by the deciding juror. We use the
+  // strict `get` (not `get_or_create`) here per GH #48 finding 2: a
+  // hidden INSERT into `actor_pseudonym` would create a governance-
+  // relevant row without a paired `governance_log` entry, breaking the
+  // ADR-008 audit-trail invariant. The admin's pseudonym is established
+  // by the bootstrap path (or by any prior governance write the admin
+  // was attributed to), so by the time this hot path runs, the row must
+  // already exist; missing it is an ADR-010/ADR-015 invariant violation
+  // that should fail loudly rather than silently allocate.
+  let admin_pseudonym = actor_pseudonym_helper::get(&mut context.pool(), admin_id)
+    .await?
+    .ok_or(LemmyErrorType::NotFound)?;
 
   // Step 2 — build the plan on the IN-FLIGHT conn so the build sees
   // the just-inserted `sanction` row from

--- a/crates/api/api/src/governance/submit_jury_vote.rs
+++ b/crates/api/api/src/governance/submit_jury_vote.rs
@@ -463,18 +463,12 @@ async fn process_vote(
   // (admin Person, not the juror — ADR-015 attribution) so we pass
   // only the conn + context here. See federation_outbox.rs head-of-
   // module DQ-6.7 note for the parameter rationale.
-  if matches!(
-    map_decision_to_sanction(winning_decision),
-    Some((SanctionScope::FederatedRecommendation, _)),
-  ) {
-    crate::governance::federation_outbox::send_local_sanction_notice(
-      data.case_id,
-      conn,
-      context,
-    )
-    .await?;
-  }
-
+  // Log the case decision FIRST so the hash chain records the local
+  // determination before any federation broadcast that results from it
+  // (ADR-008 causality). Previously `federation_sanction_sent` appeared
+  // ahead of its triggering `case_decided` entry because the send block
+  // ran before this append. Both writes share the outer `run_transaction`,
+  // so moving one above the other doesn't change atomicity.
   governance_log::append(
     &mut conn.into(),
     "case_decided",
@@ -486,6 +480,18 @@ async fn process_vote(
     None,
   )
   .await?;
+
+  if matches!(
+    map_decision_to_sanction(winning_decision),
+    Some((SanctionScope::FederatedRecommendation, _)),
+  ) {
+    crate::governance::federation_outbox::send_local_sanction_notice(
+      data.case_id,
+      conn,
+      context,
+    )
+    .await?;
+  }
 
   Ok(SubmitJuryVoteResponse {
     vote_recorded: true,

--- a/crates/api/api_crud/src/governance/request_appeal.rs
+++ b/crates/api/api_crud/src/governance/request_appeal.rs
@@ -8,13 +8,16 @@
 //! - No automatic re-jury. The case flips `Decided → Appealed` and sits
 //!   until `admin_close_case` runs. The larger-jury appeal flow is a v1
 //!   item per ADR-010.
-//! - Appeal window is implicit: while `case.closed_at IS NULL`. Once
-//!   `admin_close_case` stamps `closed_at`, further appeals on the case
-//!   are rejected.
+//! - Appeal window is explicit: while `case.closed_at > now()`. `submit_jury_vote`
+//!   stamps `closed_at = decided_at + 7 days` when flipping a case to
+//!   `Decided`, so every Decided case has an open window for 7 days.
+//!   `admin_close_case` may stamp `closed_at = now()` earlier to short-circuit
+//!   the window; appeals after `closed_at` are rejected.
 //!
 //! `CaseStatus` is matched exhaustively per ADR-013 (no `_ =>`).
 
 use actix_web::web::{Data, Json};
+use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper, insert_into, update};
 use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
 use lemmy_api::governance::{
@@ -101,8 +104,13 @@ async fn process_appeal(
     }
   }
 
-  // 3. Appeal window: closed_at must still be null.
-  if case.closed_at.is_some() {
+  // 3. Appeal window: closed_at must be in the future. `submit_jury_vote`
+  // stamps closed_at = decided_at + 7d on Decided-flip, so every Decided
+  // case has a real 7-day window that `is_some()` alone would reject. Also
+  // reject NULL closed_at on a Decided case as a data error — the flip
+  // path must populate it (GH #34).
+  let within_window = case.closed_at.map(|c| c > Utc::now()).unwrap_or(false);
+  if !within_window {
     return Err(LemmyErrorType::NotFound.into());
   }
 

--- a/crates/db_schema/src/source/governance/governance_log.rs
+++ b/crates/db_schema/src/source/governance/governance_log.rs
@@ -58,7 +58,7 @@ use serde_with::skip_serializing_none;
 use {
   crate::source::governance::redaction::scrub_json,
   diesel::{ExpressionMethods, QueryDsl, SelectableHelper},
-  diesel_async::RunQueryDsl,
+  diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt},
   ed25519_dalek::{Signer, SigningKey},
   lemmy_diesel_utils::connection::{DbPool, get_conn},
   lemmy_utils::error::{LemmyErrorType, LemmyResult},
@@ -178,29 +178,51 @@ pub async fn append(
     actor_pseudonym,
   };
 
-  let row = diesel::insert_into(governance_log::table)
-    .values(&form)
-    .returning(GovernanceLog::as_returning())
-    .get_result::<GovernanceLog>(conn)
-    .await?;
+  // ADR-008 atomicity: INSERT + signature UPDATE must commit together
+  // so subscribers never observe a row with `signature = NULL`, and a
+  // crash between the two writes can't leave a permanent unsigned row.
+  // When `append` is called from inside a caller's outer tx (via
+  // `&mut (&mut *conn).into()` reborrow — see federation_outbox.rs:187
+  // or admin_assign_jury.rs:165), diesel-async promotes this inner
+  // `run_transaction` to a SAVEPOINT, so a signing failure here rolls
+  // back the two log writes while preserving the caller's other work
+  // up to their own retry/rollback decision.
+  //
+  // The NOTIFY trigger (`governance_log_notify_trigger`) already fires
+  // AFTER UPDATE OF signature per migration `2026-04-20-000100`, so
+  // atomic INSERT+UPDATE also resolves GH #35: subscribers observe the
+  // row only once the transaction commits with signature populated.
+  conn
+    .run_transaction(|conn| {
+      async move {
+        let row = diesel::insert_into(governance_log::table)
+          .values(&form)
+          .returning(GovernanceLog::as_returning())
+          .get_result::<GovernanceLog>(conn)
+          .await?;
 
-  // Sign the trigger-computed entry_hash. The 32-byte SHA-256 digest is
-  // what goes on the wire; the resulting 64-byte signature rides in the
-  // `signature` column.
-  let signature = signing_key.sign(&row.entry_hash).to_bytes().to_vec();
+        // Sign the trigger-computed entry_hash. The 32-byte SHA-256
+        // digest is what goes on the wire; the resulting 64-byte
+        // signature rides in the `signature` column.
+        let signature = signing_key.sign(&row.entry_hash).to_bytes().to_vec();
 
-  // The signature-gate trigger allows exactly one NULL→non-NULL
-  // transition on `signature` and rejects any other column change, so
-  // the .set(...) clause must contain only `signature`.
-  diesel::update(governance_log::table.filter(governance_log::id.eq(row.id)))
-    .set(governance_log::signature.eq(&signature))
-    .execute(conn)
-    .await?;
+        // The signature-gate trigger allows exactly one NULL→non-NULL
+        // transition on `signature` and rejects any other column
+        // change, so the .set(...) clause must contain only
+        // `signature`.
+        diesel::update(governance_log::table.filter(governance_log::id.eq(row.id)))
+          .set(governance_log::signature.eq(&signature))
+          .execute(conn)
+          .await?;
 
-  Ok(GovernanceLog {
-    signature: Some(signature),
-    ..row
-  })
+        Ok(GovernanceLog {
+          signature: Some(signature),
+          ..row
+        })
+      }
+      .scope_boxed()
+    })
+    .await
 }
 
 /// Load the ed25519 signing key from `GOVERNANCE_LOG_SIGNING_KEY`.

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -3325,6 +3325,19 @@ async fn sanction_notice_round_trip() -> Result<(), Box<dyn Error>> {
     Url::parse("http://instance-a.test/u/target")?,
   ).await?;
 
+  // Seed the admin's actor_pseudonym row up front. In production this row
+  // is created the first time the admin appears in a governance write
+  // (e.g. by `admin_assign_jury`); this test bypasses the assign-jury path
+  // (lines below seed `JuryAssignment` rows directly), so the row would
+  // not yet exist when `submit_jury_vote` reaches the federation publish.
+  // GH #48 finding 2 turned `federation_outbox::send_local_sanction_notice`
+  // into a strict `get` — missing-row is now a hard error rather than a
+  // silent INSERT — so the fixture must materialise the row here.
+  lemmy_api::governance::actor_pseudonym_helper::get_or_create(
+    &mut context_a.pool(),
+    admin_pid,
+  ).await?;
+
   // Re-load target Person to capture the generated ap_id (which we just set
   // above — but we re-load through the model so the test asserts against
   // the round-tripped DB value, not the in-memory one).

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -2455,7 +2455,14 @@ async fn all_mvp_endpoints_return_non_404() -> Result<(), Box<dyn Error>> {
   let target_jwt = mint_jwt(&context, target_lu_id).await?;
 
   // Seed a Decided case for the appeal test + an Open case for list_cases.
+  //
+  // The Decided case needs `closed_at` in the future so that the #34 appeal
+  // window guard (`closed_at > now()`) allows the target to appeal. The
+  // production path (`submit_jury_vote` decided-flip) stamps
+  // `closed_at = decided_at + 7d`; we mirror that here with a direct
+  // UPDATE since `ModerationCaseInsertForm` doesn't carry `closed_at`.
   {
+    use diesel::ExpressionMethods;
     use diesel_async::RunQueryDsl;
     use lemmy_db_schema::source::governance::moderation_case::ModerationCaseInsertForm;
 
@@ -2486,6 +2493,17 @@ async fn all_mvp_endpoints_return_non_404() -> Result<(), Box<dyn Error>> {
     };
     diesel::insert_into(moderation_case::table)
       .values(&open_form)
+      .execute(&mut async_conn)
+      .await?;
+
+    // Stamp closed_at in the future on every Decided seeded case so the
+    // #34 appeal window guard admits the appeal. Scope the UPDATE to
+    // status=Decided so it only touches the decided_form row even if
+    // other tests extend this seed later.
+    let future = chrono::Utc::now() + chrono::Duration::days(7);
+    diesel::update(moderation_case::table)
+      .filter(moderation_case::status.eq(CaseStatus::Decided))
+      .set(moderation_case::closed_at.eq(Some(future)))
       .execute(&mut async_conn)
       .await?;
   }
@@ -3336,7 +3354,8 @@ async fn sanction_notice_round_trip() -> Result<(), Box<dyn Error>> {
   lemmy_api::governance::actor_pseudonym_helper::get_or_create(
     &mut context_a.pool(),
     admin_pid,
-  ).await?;
+  ).await
+    .map_err(|e| -> Box<dyn Error> { format!("seed admin pseudonym: {e}").into() })?;
 
   // Re-load target Person to capture the generated ap_id (which we just set
   // above — but we re-load through the model so the test asserts against
@@ -3715,6 +3734,450 @@ async fn sanction_notice_round_trip() -> Result<(), Box<dyn Error>> {
 
   // -- 14. Touch the unused juror locals to keep `_ = jurors` lints happy.
   let _ = (jurors, admin_pid, RemoteSanctionNoticeId(advisory.id.0));
+
+  Ok(())
+}
+
+// ============================================================================
+// v0-polish — GH #34 regression: appeal allowed inside closed_at window
+// ============================================================================
+//
+// Before the #34 fix, `request_appeal`'s window guard was
+// `if case.closed_at.is_some() { NotFound }` — which rejected every
+// Decided case because `submit_jury_vote` always stamps
+// `closed_at = decided_at + 7d` on Decided-flip. The fix inverts the
+// guard to `within_window = closed_at > now()`, admitting appeals only
+// while the window is actually open. This test seeds a Decided case
+// with `closed_at = now() + 1d`, calls `request_appeal` as the target,
+// and asserts a `RequestAppealResponse` is returned with a fresh
+// `appeal_id`. A parallel assertion covers the expired-window branch by
+// seeding a second case with `closed_at = now() - 1d` and expecting a
+// `NotFound` error.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn appeal_inside_window_succeeds_expired_rejects() -> Result<(), Box<dyn Error>> {
+  use actix_web::web::{Data, Json};
+  use chrono::{Duration, Utc};
+  use diesel::{Connection as _, ExpressionMethods, PgConnection, QueryDsl};
+  use diesel_async::{AsyncConnection as _, AsyncPgConnection, RunQueryDsl};
+  use lemmy_api_common::governance::RequestAppeal;
+  use lemmy_api_crud::governance::request_appeal::request_appeal;
+  use lemmy_api_utils::{context::LemmyContext, request::client_builder};
+  use lemmy_db_schema::source::{
+    governance::moderation_case::ModerationCaseInsertForm, instance::Instance,
+    local_user::{LocalUser, LocalUserInsertForm}, person::{Person, PersonInsertForm},
+    secret::Secret,
+  };
+  use lemmy_db_schema_file::{
+    PersonId,
+    enums::{CaseSeverity, CaseStatus, CaseTargetType},
+    schema::moderation_case,
+  };
+  use lemmy_db_views_local_user::LocalUserView;
+  use lemmy_diesel_utils::{
+    connection::{ActualDbPool, build_db_pool_for_tests},
+    traits::Crud,
+  };
+  use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
+  use reqwest_middleware::ClientBuilder;
+
+  unsafe {
+    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+    std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY",
+      "0000000000000000000000000000000000000000000000000000000000000001");
+  }
+
+  let (_container, host_port) = governance_fixtures::start_postgres()
+    .await
+    .map_err(|e| -> Box<dyn Error> { format!("start_postgres: {e}").into() })?;
+  let db_url = governance_fixtures::db_url(host_port);
+  unsafe { std::env::set_var("LEMMY_DATABASE_URL", &db_url); }
+
+  {
+    let mut sync_conn = PgConnection::establish(&db_url)?;
+    governance_fixtures::apply_all_schema(&mut sync_conn)
+      .map_err(|e| -> Box<dyn Error> { format!("apply_all_schema: {e}").into() })?;
+  }
+
+  let pool: ActualDbPool = build_db_pool_for_tests();
+  let client = client_builder(&SETTINGS).build()?;
+  let middleware_client = ClientBuilder::new(client).build();
+  let secret = Secret { id: 0, jwt_secret: String::new().into() };
+  let rate_limit = RateLimit::with_debug_config();
+  let context = Data::new(LemmyContext::create(
+    pool,
+    middleware_client.clone(),
+    middleware_client,
+    secret,
+    rate_limit,
+  ));
+
+  let instance = Instance::read_or_create(&mut context.pool(), "test.invalid").await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  async fn seed_target(
+    ctx: &LemmyContext,
+    instance_id: lemmy_db_schema_file::InstanceId,
+    name: &str,
+  ) -> Result<PersonId, Box<dyn Error>> {
+    let person_form = PersonInsertForm::test_form(instance_id, name);
+    let person = Person::create(&mut ctx.pool(), &person_form).await
+      .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+    let mut lu_form = LocalUserInsertForm::test_form(person.id);
+    lu_form.accepted_application = Some(true);
+    LocalUser::create(&mut ctx.pool(), &lu_form, vec![]).await
+      .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+    Ok(person.id)
+  }
+
+  let target_a = seed_target(&context, instance.id, "appeal_target_open").await?;
+  let target_b = seed_target(&context, instance.id, "appeal_target_expired").await?;
+  let target_a_view = LocalUserView::read_person(&mut context.pool(), target_a).await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+  let target_b_view = LocalUserView::read_person(&mut context.pool(), target_b).await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  // Seed two Decided cases: case_a has closed_at in the future (+1d), case_b
+  // has closed_at in the past (-1d). `ModerationCaseInsertForm` doesn't carry
+  // `closed_at`, so we UPDATE after insert — same trick as the seed block in
+  // `all_mvp_endpoints_return_non_404`.
+  let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+
+  let case_a_form = ModerationCaseInsertForm {
+    community_id: None,
+    creator_id: None,
+    target_type: CaseTargetType::Person,
+    target_post_id: None,
+    target_comment_id: None,
+    target_person_id: Some(target_a),
+    target_community_id: None,
+    target_remote_url: None,
+    reason_code: "probe_open".to_string(),
+    severity: CaseSeverity::Low,
+    status: CaseStatus::Decided,
+    threshold_score: 1,
+  };
+  let case_a: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&case_a_form)
+      .get_result(&mut async_conn)
+      .await?;
+
+  let case_b_form = ModerationCaseInsertForm {
+    target_person_id: Some(target_b),
+    reason_code: "probe_expired".to_string(),
+    ..case_a_form
+  };
+  let case_b: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&case_b_form)
+      .get_result(&mut async_conn)
+      .await?;
+
+  let future = Utc::now() + Duration::days(1);
+  diesel::update(moderation_case::table.filter(moderation_case::id.eq(case_a.id)))
+    .set(moderation_case::closed_at.eq(Some(future)))
+    .execute(&mut async_conn)
+    .await?;
+
+  let past = Utc::now() - Duration::days(1);
+  diesel::update(moderation_case::table.filter(moderation_case::id.eq(case_b.id)))
+    .set(moderation_case::closed_at.eq(Some(past)))
+    .execute(&mut async_conn)
+    .await?;
+
+  // Case A: closed_at in the future → appeal succeeds.
+  let resp_a = request_appeal(
+    Json(RequestAppeal { case_id: case_a.id, reason: "try me".to_string() }),
+    context.clone(),
+    target_a_view,
+  )
+  .await
+  .map_err(|e| -> Box<dyn Error> { format!("request_appeal (open window): {e}").into() })?
+  .into_inner();
+  assert!(
+    resp_a.appeal_id.0 > 0,
+    "GH #34: appeal with closed_at in future must succeed (appeal_id positive)",
+  );
+  assert_eq!(resp_a.case_id, case_a.id, "response case_id round-trips");
+
+  // Case B: closed_at in the past → appeal fails with NotFound.
+  let resp_b = request_appeal(
+    Json(RequestAppeal { case_id: case_b.id, reason: "expired".to_string() }),
+    context.clone(),
+    target_b_view,
+  )
+  .await;
+  assert!(
+    resp_b.is_err(),
+    "GH #34: appeal with closed_at in past must fail (window expired)",
+  );
+
+  Ok(())
+}
+
+// ============================================================================
+// v0-polish — GH #33 regression: declining juror not picked as own replacement
+// ============================================================================
+//
+// Before the #33 fix, `decline_jury_assignment` flipped the caller's
+// assignment to Declined, then built `exclude_person_ids` from all
+// `jury_assignment` rows where status != Declined && status != Expired.
+// That filter removed the declining juror's own (just-flipped) row from
+// the query, so the caller was eligible to be picked as their own
+// replacement — a quorum-threatening self-selection bug.
+//
+// The fix pushes `caller_id` onto the exclude vec after the query. This
+// test seeds a small pool (5 jurors on the panel + 1 extra eligible),
+// has one juror on the panel decline, and asserts the replacement is
+// the sixth eligible — never the decliner. The JuryAssignment rows on
+// the case after the decline are inspected directly at the DB level
+// (status=Selected ∩ person_id=decliner must be zero).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn declining_juror_not_picked_as_own_replacement() -> Result<(), Box<dyn Error>> {
+  use actix_web::web::{Data, Json};
+  use chrono::{Duration, Utc};
+  use diesel::{
+    Connection as _, ExpressionMethods, PgConnection, QueryDsl,
+  };
+  use diesel_async::{AsyncConnection as _, AsyncPgConnection, RunQueryDsl};
+  use lemmy_api::governance::{
+    admin_assign_jury::admin_assign_jury,
+    decline_jury_assignment::decline_jury_assignment,
+    reputation_snapshot::run_snapshot_batch,
+  };
+  use lemmy_api_common::governance::{AdminAssignJury, DeclineJuryAssignment};
+  use lemmy_api_utils::{context::LemmyContext, request::client_builder};
+  use lemmy_db_schema::source::{
+    community::{Community, CommunityInsertForm},
+    governance::moderation_case::ModerationCaseInsertForm,
+    instance::Instance,
+    local_user::{LocalUser, LocalUserInsertForm},
+    person::{Person, PersonInsertForm},
+    secret::Secret,
+  };
+  use lemmy_db_schema_file::{
+    PersonId,
+    enums::{
+      CaseSeverity, CaseStatus, CaseTargetType, JuryAssignmentStatus, ReputationDimension,
+    },
+    schema::{jury_assignment, moderation_case, reputation_event},
+  };
+  use lemmy_db_views_local_user::LocalUserView;
+  use lemmy_diesel_utils::{
+    connection::{ActualDbPool, build_db_pool_for_tests},
+    traits::Crud,
+  };
+  use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
+  use reqwest_middleware::ClientBuilder;
+
+  unsafe {
+    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+    std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY",
+      "0000000000000000000000000000000000000000000000000000000000000001");
+  }
+
+  let (_container, host_port) = governance_fixtures::start_postgres()
+    .await
+    .map_err(|e| -> Box<dyn Error> { format!("start_postgres: {e}").into() })?;
+  let db_url = governance_fixtures::db_url(host_port);
+  unsafe { std::env::set_var("LEMMY_DATABASE_URL", &db_url); }
+
+  {
+    let mut sync_conn = PgConnection::establish(&db_url)?;
+    governance_fixtures::apply_all_schema(&mut sync_conn)
+      .map_err(|e| -> Box<dyn Error> { format!("apply_all_schema: {e}").into() })?;
+  }
+
+  let pool: ActualDbPool = build_db_pool_for_tests();
+  let client = client_builder(&SETTINGS).build()?;
+  let middleware_client = ClientBuilder::new(client).build();
+  let secret = Secret { id: 0, jwt_secret: String::new().into() };
+  let rate_limit = RateLimit::with_debug_config();
+  let context = Data::new(LemmyContext::create(
+    pool,
+    middleware_client.clone(),
+    middleware_client,
+    secret,
+    rate_limit,
+  ));
+
+  let instance = Instance::read_or_create(&mut context.pool(), "test.invalid").await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  async fn seed_person(
+    ctx: &LemmyContext,
+    instance_id: lemmy_db_schema_file::InstanceId,
+    name: &str,
+    is_admin: bool,
+  ) -> Result<PersonId, Box<dyn Error>> {
+    let person_form = PersonInsertForm::test_form(instance_id, name);
+    let person = Person::create(&mut ctx.pool(), &person_form).await
+      .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+    let mut lu_form = if is_admin {
+      LocalUserInsertForm::test_form_admin(person.id)
+    } else {
+      LocalUserInsertForm::test_form(person.id)
+    };
+    lu_form.accepted_application = Some(true);
+    LocalUser::create(&mut ctx.pool(), &lu_form, vec![]).await
+      .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+    Ok(person.id)
+  }
+
+  // Six eligibles — panel is 5; the 6th is the only viable replacement so
+  // self-exclusion is the load-bearing assertion. If the fix is absent, the
+  // decliner would be one of two candidates in the pool
+  // (decliner + sixth-eligible) and randomness could mask the bug; with 6
+  // eligibles and panel_size=5, the sixth is the unique replacement.
+  let mut eligibles = Vec::new();
+  for i in 0..6 {
+    eligibles.push(seed_person(&context, instance.id, &format!("juror_{i}"), false).await?);
+  }
+  let admin = seed_person(&context, instance.id, "decline_admin", true).await?;
+  let target = seed_person(&context, instance.id, "decline_target", false).await?;
+  let admin_view = LocalUserView::read_person(&mut context.pool(), admin).await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  // Seed reputation so jury_eligible resolves true for everyone.
+  {
+    use lemmy_db_schema::source::governance::reputation_event::ReputationEventInsertForm;
+    let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+    for &pid in &eligibles {
+      let form = ReputationEventInsertForm {
+        person_id: pid,
+        community_id: None,
+        dimension: ReputationDimension::JuryReliability,
+        delta: 60,
+        source_case_id: None,
+        source_report_id: None,
+        reason: "founder_seed".to_string(),
+        expires_at: Some(Utc::now() + Duration::days(30)),
+      };
+      diesel::insert_into(reputation_event::table)
+        .values(&form)
+        .execute(&mut async_conn)
+        .await?;
+    }
+  }
+
+  // Override jury config: zero age requirement; disable fallback so any
+  // failure surfaces loudly.
+  {
+    let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+    diesel::sql_query(
+      "INSERT INTO governance_config (scope, key, value_type, value_int, valid_from) \
+       VALUES ('instance', 'jury.age_requirement_days', 'int', 0, now())"
+    ).execute(&mut async_conn).await?;
+    diesel::sql_query(
+      "INSERT INTO governance_config (scope, key, value_type, value_bool, valid_from) \
+       VALUES ('instance', 'jury.fallback_on_small_pool', 'bool', false, now())"
+    ).execute(&mut async_conn).await?;
+  }
+
+  run_snapshot_batch(&context).await
+    .map_err(|e| -> Box<dyn Error> { format!("run_snapshot_batch: {e}").into() })?;
+
+  // Community for the case (target_person_id case so eligibility filter
+  // excludes the target from the panel).
+  let community_form = CommunityInsertForm::new(
+    instance.id,
+    "declinecomm".to_string(),
+    "Decline Community".to_string(),
+    "decline-pubkey".to_string(),
+  );
+  let _community = Community::create(&mut context.pool(), &community_form).await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  // Seed a JurySelection case ready for admin_assign_jury.
+  let case_id = {
+    let mut pool = context.pool();
+    let conn = &mut lemmy_diesel_utils::connection::get_conn(&mut pool).await
+      .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+    let form = ModerationCaseInsertForm {
+      community_id: None,
+      creator_id: None,
+      target_type: CaseTargetType::Person,
+      target_post_id: None,
+      target_comment_id: None,
+      target_person_id: Some(target),
+      target_community_id: None,
+      target_remote_url: None,
+      reason_code: "decline_probe".to_string(),
+      severity: CaseSeverity::Low,
+      status: CaseStatus::Open,
+      threshold_score: 1,
+    };
+    let case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+      diesel::insert_into(moderation_case::table)
+        .values(&form)
+        .get_result(conn)
+        .await?;
+    case.id
+  };
+
+  // Assign jury. 5 eligibles selected; one eligible remains as the unique
+  // replacement candidate.
+  let assign_resp = admin_assign_jury(
+    Json(AdminAssignJury { case_id }),
+    context.clone(),
+    admin_view,
+  )
+  .await
+  .map_err(|e| -> Box<dyn Error> { format!("admin_assign_jury: {e}").into() })?
+  .into_inner();
+  assert_eq!(assign_resp.assigned_person_ids.len(), 5, "5 jurors assigned");
+
+  let decliner_id = assign_resp.assigned_person_ids[0];
+  let decliner_view = LocalUserView::read_person(&mut context.pool(), decliner_id).await
+    .map_err(|e| -> Box<dyn Error> { format!("{e}").into() })?;
+
+  // Decline.
+  let decline_resp = decline_jury_assignment(
+    Json(DeclineJuryAssignment { case_id, reason: Some("cannot serve".to_string()) }),
+    context.clone(),
+    decliner_view,
+  )
+  .await
+  .map_err(|e| -> Box<dyn Error> { format!("decline_jury_assignment: {e}").into() })?
+  .into_inner();
+  assert!(decline_resp.declined, "declined=true in response");
+  let replacement_id = decline_resp.replacement_person_id
+    .expect("GH #33: replacement must be selected (6th eligible is available)");
+  assert_ne!(
+    replacement_id, decliner_id,
+    "GH #33: decliner must NOT be picked as own replacement",
+  );
+
+  // DB-level assertions: decliner has exactly one Declined row; the
+  // replacement has a Selected row; no Selected row exists for the
+  // decliner on this case.
+  let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+
+  let decliner_selected_count: i64 = jury_assignment::table
+    .filter(jury_assignment::case_id.eq(case_id))
+    .filter(jury_assignment::person_id.eq(decliner_id))
+    .filter(jury_assignment::status.eq(JuryAssignmentStatus::Selected))
+    .count()
+    .get_result(&mut async_conn)
+    .await?;
+  assert_eq!(
+    decliner_selected_count, 0,
+    "GH #33: no Selected row should exist for the decliner on this case",
+  );
+
+  let replacement_selected_count: i64 = jury_assignment::table
+    .filter(jury_assignment::case_id.eq(case_id))
+    .filter(jury_assignment::person_id.eq(replacement_id))
+    .filter(jury_assignment::status.eq(JuryAssignmentStatus::Selected))
+    .count()
+    .get_result(&mut async_conn)
+    .await?;
+  assert_eq!(
+    replacement_selected_count, 1,
+    "replacement must have a Selected row",
+  );
 
   Ok(())
 }


### PR DESCRIPTION
## Summary

Five fixes addressing four governance-invariant bugs that survived Phase 5c / PR #10 CodeRabbit review. All four were flagged as blocking v0 tag.

| GH | Severity | Fix |
|---|---|---|
| **#48(a) + #35** | risk:high | Wrap `governance_log::append` INSERT+UPDATE in `conn.run_transaction` so the NOTIFY trigger (now fires on `AFTER UPDATE OF signature` post PR #46) sees a fully-signed row atomically. Closes the "unsigned row visible to subscribers" window that #35 called out. |
| **#48(b)** | risk:high | Emit `case_decided` governance_log entry **before** `send_local_sanction_notice` in `submit_jury_vote::process_vote`. Hash-chain causality: local determination logged before any derived federation signal. |
| **#48(c)** | risk:high | Add strict `actor_pseudonym_helper::get()` (no INSERT). Swap `federation_outbox::send_local_sanction_notice`'s `get_or_create(admin_id)` → `get(admin_id)?.ok_or(NotFound)` so a missing admin pseudonym fails loudly instead of silently allocating a governance-relevant row without a paired `governance_log` entry (ADR-008 audit trail invariant). |
| **#34** | risk:high | Replace `request_appeal` window guard `if case.closed_at.is_some() { NotFound }` with `within_window = closed_at > now()`. Old guard rejected **every** Decided case because `submit_jury_vote` stamps `closed_at = decided_at + 7d` on decide. |
| **#33** | risk:critical | Explicit `exclude_person_ids.push(caller_id)` in `decline_jury_assignment` before calling `select_eligible_jurors`. The previous `ne(Declined)` filter removed the just-flipped Declined row from the active-assignees query, allowing the decliner to be picked as their own replacement. |

## Validation

- `cargo check --workspace --features full` ✓
- `cargo clippy --workspace --no-deps --features full -- -D warnings` ✓
- `cargo test --test e2e --workspace --features full` → **16 passed / 0 failed / 3 ignored (375.10s)**
  - New regression tests: `appeal_inside_window_succeeds_expired_rejects` (#34) and `declining_juror_not_picked_as_own_replacement` (#33) both green
  - `all_mvp_endpoints_return_non_404` B.3 appeal probe updated to stamp `closed_at` in future (required by the #34 guard inversion)
  - `sanction_notice_round_trip` updated to seed admin pseudonym upfront (required by the #48(c) strict `get()`)
  - #48(a) verified under load via `governance_log_hash_chain_holds` + `report_to_modlog_golden_path` — nested `run_transaction` → SAVEPOINT semantic holds across all call sites
  - 3 ignored: #42, #43, #45 — pre-existing flakes with GH-tracked deflake TODOs (not this PR)

## Test plan

- [x] All new fixes covered by passing regression tests
- [x] No semantic drift masked: existing `all_mvp_endpoints_return_non_404` + `sanction_notice_round_trip` fixture updates explicitly documented in commit messages
- [x] No migration required for any fix
- [x] No ADR touch required (all changes enforce existing ADR-008 / ADR-010 / ADR-013 invariants)

## Scope note

Per polish plan, only the critical bugs in this PR. Separate polish PRs for Bucket C follow-ups (#54 subset) and the #38/#39/#50/#51/#52 docs sweep are tracked in `.claude/PRPs/polish-runlog/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed appeal eligibility to be time-based within a 7-day window after case closure, rather than rejecting all closed cases.
  * Prevented declining jurors from being selected as their own replacements in jury assignment.
  * Improved governance log persistence with transactional integrity to prevent orphaned records.
  * Corrected federation sanction notice sequencing to maintain causal ordering with governance events.

* **Tests**
  * Added regression tests for appeal window validation and jury replacement logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->