### PR TITLE
fix(tests): tighten route-gate probe — reject 404 (closes #36)

### DIFF
--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -2378,10 +2378,11 @@ async fn all_mvp_endpoints_return_non_404() -> Result<(), Box<dyn Error>> {
     ("POST", "/api/v4/governance/report",                        "{}", &[200, 400, 401]),
     ("POST", "/api/v4/governance/endorsement",                   "{}", &[200, 400, 401]),
     ("POST", "/api/v4/governance/appeal",                        "{}", &[200, 400, 401]),
-    // 404 allowed here: empty test DB has no case_id=1; the route is wired
-    // (responds with handler's NotFound mapping) but resource doesn't exist.
-    // Other routes use validation errors (400/401) for unseeded state, not 404.
-    ("GET",  "/api/v4/governance/case?case_id=1",                "",   &[200, 400, 401, 404]),
+    // Use a malformed `case_id` so the wired route returns 400 (Query
+    // deserialisation fails on non-numeric input). 404 is excluded from
+    // the allowlist so a dropped route registration fails this probe
+    // instead of silently looking like "empty DB". GH #36.
+    ("GET",  "/api/v4/governance/case?case_id=not_a_number",     "",   &[400, 401]),
     ("GET",  "/api/v4/governance/cases",                         "",   &[200, 400, 401]),
     ("GET",  "/api/v4/governance/modlog",                        "",   &[200, 400, 401]),
     ("GET",  "/api/v4/governance/reputation/me",                 "",   &[200, 400, 401]),


### PR DESCRIPTION
## Summary

Fix CodeRabbit PR #32 finding — `all_mvp_endpoints_return_non_404` accepts 404 for `GET /api/v4/governance/case`, so a silently-dropped route registration would still pass the probe.

## Change

One line in `crates/server/tests/e2e.rs:2384` (plus 3 lines of updated comment):

- **Before:** `("GET", "/api/v4/governance/case?case_id=1", "", &[200, 400, 401, 404])`
- **After:**  `("GET", "/api/v4/governance/case?case_id=not_a_number", "", &[400, 401])`

`case_id=not_a_number` fails `Query<GetGovernanceCase>` deserialisation (`ModerationCaseId` is an integer newtype), so a wired route returns 400 at the Actix boundary. A dropped route registration now fails the assertion instead of slipping through as 404.

Choice of **Option A** (malformed query) from CR — keeps the probe self-contained, no fixture seed needed.

## Validation

- `cargo test --test e2e --workspace --features full all_mvp_endpoints_return_non_404 -- --exact` — **1 passed / 0 failed / 18 filtered out** (32.57s).
- Full compile green (`cargo test --no-run` clean exit).
- No DTO / handler / migration change.

## Closes

- closes #36

## Design-doc touchpoints

- `docs/brehon-law-inspired-network/IMPLEMENTATION-PLAN-v0.md` §6.1 (route-registration gate intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened API endpoint validation testing for the governance case endpoint to ensure invalid query parameters are properly rejected with appropriate error responses rather than returning 404 status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->