### PR TITLE
chore(prp-plan): Phase 5 HIGH-complexity parallel-Explore opt-in

### DIFF
--- a/.claude/commands/prp-core/prp-plan.md
+++ b/.claude/commands/prp-core/prp-plan.md
@@ -273,6 +273,16 @@ Example (adjust to the phase):
 
 For complex phases, launch one more `Explore` agent focused on how existing Lemmy architecture behaves at the integration points identified in Phase 2.
 
+**HIGH-complexity escalation (opt-in).** When (a) `Complexity == HIGH` per Phase 1 AND (b) ≥3 crates are affected per Phase 1's Affected crates list, launch **up to 2 parallel `Explore` agents alongside** the integration-point agent above, in a single message:
+
+1. **Cross-cutting audit agent** — scope: return a per-concern verdict of `TOUCHED` / `NOT_TOUCHED` / `UNCLEAR` with one-sentence evidence for each of: (1) governance log hash chain (append + sha2 trigger + ed25519), (2) `actor_pseudonym` + `redaction::scrub` ([ADR-015](docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)), (3) `CaseStatus::EmergencyRemove` exhaustive match ([ADR-013](docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)), (4) AGPLv3 source disclosure ([ADR-011](docs/brehon-law-inspired-network/99-decisions-and-open-questions.md)), (5) the seven PM plugin hook call sites per `.claude/rules/pm-plugin-hooks-stable.md`, (6) the v0 11-endpoint scope per [05 §2](docs/brehon-law-inspired-network/05-mvp-and-delivery-plan.md). Grep-only; no cargo.
+
+2. **Failure-mode + enum-hole scan agent** — scope: scan the crates identified in Phase 1 for (a) existing `match` expressions on `CaseStatus` / governance enums that the plan's new call sites must mirror, (b) unindexed read paths along the proposed query shape, (c) existing n+1 patterns in neighbouring view crates the plan will mirror. Return concrete file:line references; no speculation on the new design.
+
+Reuse the Phase 2 **Agent brief template** (above) verbatim — swap `{scope from Phase 1}` for each agent's scope line here. Per `feedback_subagent_model_and_effort.md`, set `model="opus"` on each call and include an explicit "Run at maximum effort — deepest reasoning, most thorough exploration" directive in each brief.
+
+On LOW or MEDIUM complexity, or when <3 crates are affected, **skip this escalation entirely** — the single integration-point agent above is sufficient.
+
 **Then analyse:**
 - ARCHITECTURE_FIT: does this respect the plane separation in [03 §4](docs/brehon-law-inspired-network/03-architecture.md)? Is governance code in the governance crate paths, not in `crates/server/`?
 - EXECUTION_ORDER: dependency order of tasks (schema → model → view → DTO → handler → route)


### PR DESCRIPTION
## Summary

Adds one conditional 10-line paragraph to `/prp-core:prp-plan`'s Phase 5 (ARCHITECT) that launches up to 2 parallel `Explore` agents — a **cross-cutting audit agent** and a **failure-mode + enum-hole scan agent** — alongside the existing integration-point agent, gated on `Complexity==HIGH` AND ≥3 crates affected. LOW/MEDIUM path is byte-for-byte unchanged; Phase 6 is untouched.

## Why

Asked whether Phases 5–6 of `/prp-plan` could benefit from subagents. Read latest Claude Code docs on the `Agent` tool via ref-context MCP (parallel subagents in one message; `model=` override; `isolation: \"worktree\"`). Surveyed fork-local conventions:

- Phase 2 already uses up to 3 parallel `Explore` agents — canonical
- No `prp-core/*.md` command currently spawns subagents during plan GENERATION
- `feedback_subagent_model_and_effort.md` mandates `model=\"opus\"` + max-effort directive
- `pre-phase-harness-audit.md` says cargo validation is a Phase-0 activity, not planning

Ran two Plan-agent passes (minimalism lens vs. skepticism lens). Both agreed:
- **Phase 6 stays inline** — synthesis over Phases 2–5 + template assembly; subagents would fragment voice and risk the plan-file write becoming non-atomic.
- **Phase 5 default stays single-agent** — synthesis across 7 analysis bullets only happens in one head; splitting by default duplicates Phase 2 work.
- **Opt-in escalation for HIGH complexity** — cost of missing an ADR-013 / ADR-015 cross-cut is high enough to justify parallel structured audit input when scope is wide.

## What's in this PR

One file changed, one hunk:

\`\`\`
.claude/commands/prp-core/prp-plan.md | 10 ++++++++++
\`\`\`

The paragraph:
- Gates on `Complexity==HIGH` AND `≥3 crates` (from Phase 1 output)
- Reuses the Phase 2 **Agent brief template** verbatim by pointer — no new templates
- Cites `feedback_subagent_model_and_effort.md` for the `model=\"opus\"` + max-effort convention (inheritance, not re-statement)
- Names the 6 Brehon cross-cutting concerns explicitly (hash chain, actor_pseudonym, EmergencyRemove, AGPLv3, PM plugin hooks, v0 11-endpoint scope)
- No cargo execution, no new agent definitions, no worktree isolation

## What's NOT in this PR (explicitly)

- No Phase 6 changes (design agents agreed subagents backfire there)
- No new `.claude/agents/*.md` file — uses built-in `Explore` subagent
- No rule or memory changes — cites them, does not edit them
- No edit to any other `prp-core/*.md` command

## Verification

1. `git diff --stat` — exactly one hunk in the 272–305 range
2. LOW/MEDIUM invocation: gate fails → falls through to existing single-agent path, same as before
3. HIGH + ≥3 crates invocation: three parallel `Agent` calls launch in one message (integration-point + cross-cutting audit + failure-mode scan); plan file still writes atomically even if one agent fails
4. Rollback is a single-hunk revert

## Confidence

9/10 for one-pass utility — single-file, single-paragraph, additive, opt-in. Only uncertainty is whether `HIGH` + `≥3 crates` is the right gate; tunable after first live run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strategic design phase workflow to introduce conditional escalation paths for high-complexity architectural reviews, enabling parallel exploratory analysis with focused audit and pattern-scanning deliverables when scope warrants enhanced investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->