### PR TITLE
v1-validate-agent — Out-of-Junior cargo validation via GH Actions (Shape G)

### DIFF
--- a/.claude/PRPs/briefs/jm-d-impl-2.md
+++ b/.claude/PRPs/briefs/jm-d-impl-2.md
@@ -125,19 +125,46 @@ The daemon now runs under a cgroup memory cap: `MemoryMax=10G`, `MemoryHigh=8G` 
 
 Task 1 produced a high-value LESSON trailer about `lemmy_diesel_utils` CLI args (DQ #55). Task 2 is a candidate for similar — particularly if the schema-regen path or `diesel` CLI install surfaces anything plan-relevant. Per `feedback_junior_pmd_write_convention.md`, end the commit body with a single `LESSON:` line for any discrete future-relevant finding.
 
-## 5. Validation gates (per plan §13 task 2 VALIDATE block)
+## 5. Validation gates (out-of-band on GH Actions per Shape G)
 
-Capture each to `.claude/PRPs/debug/v1-JM-d-task2-<probe>.log`. All exit-0.
+Retrofitted from inline cargo to push-and-exit per DQ #61 + v1-validate-agent.plan.md Task 5 (`feat(plan): v1-validate-agent`).
 
-1. `bash scripts/brehon/cargo-check.sh --workspace --features full > .claude/PRPs/debug/v1-JM-d-task2-check.log 2>&1` → exit 0.
-2. `bash scripts/brehon/cargo-clippy.sh --workspace --features full --no-deps -- -D warnings > .claude/PRPs/debug/v1-JM-d-task2-clippy.log 2>&1` → exit 0.
-3. `bash scripts/brehon/cargo-test.sh --test e2e --no-run -p lemmy_server > .claude/PRPs/debug/v1-JM-d-task2-test-no-run.log 2>&1` → exit 0 (compile-only; tests don't run yet — Task 8 territory).
+Validation runs out-of-band on GitHub Actions (Shape G). After committing your work, push to your worktree branch and exit. Do NOT run cargo locally.
 
-If any fails, **STOP and surface to advisor via DQ.** Do not patch around `cargo-check` or `clippy` failures by `#[allow]`-spamming — fix the root cause.
+After `git push`:
 
-**GOTCHA from plan §13:** if `cargo check -p lemmy_db_schema --features full` fails after the schema regen with a `check_for_backend(diesel::pg::Pg)` error, the regen mismatched the `Queryable` derive's expected types. Re-run the regen and confirm the `winning_decision -> Nullable<JuryDecision>` mapping is exact.
+1. Capture the workflow_run id:
+   ```bash
+   gh run list --branch <your-branch> --limit 1 \
+     --json databaseId --jq '.[0].databaseId'
+   ```
+   Retry with exponential backoff up to ~2 min if the run hasn't appeared yet (push-to-trigger lag is normal).
 
-**GOTCHA from `feedback_clippy_test_style.md`:** the workspace denies `expect_used`, `unwrap_used`, `allow_attributes` *including in tests*. Tests must use `?`. Don't add escape-hatches.
+2. Append a `validate-pending` entry to `.claude/decision-queue.json`:
+   ```json
+   {
+     "id": <next>,
+     "from": "impl",
+     "kind": "validate-pending",
+     "timestamp": "<ISO 8601 UTC>",
+     "workflow_run_id": <id>,
+     "branch": "<your-branch>",
+     "phase_task": 2,
+     "answer": null,
+     "answered_by": null,
+     "resolved_at": null
+   }
+   ```
+
+3. Commit + push the DQ update.
+
+4. Exit with success.
+
+The impl-task slot frees as soon as the push lands. ci-watcher polls the workflow asynchronously and writes the result back into the DQ. The advisor reads `validate-result` (pass) or `validate-failed` (fail/timeout) on its next polling tick.
+
+**GOTCHA from plan §13 (now surfaces on GH Actions, not locally):** if `cargo check --workspace --features full` on the runner fails with a `check_for_backend(diesel::pg::Pg)` error after the schema regen, the regen mismatched the `Queryable` derive's expected types. Pull the failure log slice from the `validate-failed` DQ entry, re-run the regen locally, and confirm the `winning_decision -> Nullable<JuryDecision>` mapping is exact before re-pushing.
+
+**GOTCHA from `feedback_clippy_test_style.md`:** the workspace denies `expect_used`, `unwrap_used`, `allow_attributes` *including in tests*. Tests must use `?`. Don't add escape-hatches. Failures land in the GH Actions clippy step; the failure log slice in the `validate-failed` DQ entry will name the file:line.
 
 ## 6. Expected output (return to advisor)
 

--- a/.claude/PRPs/handovers/impl-2026-04-27-v1-validate-agent-tasks-3to5-and-2-shipped.md
+++ b/.claude/PRPs/handovers/impl-2026-04-27-v1-validate-agent-tasks-3to5-and-2-shipped.md
@@ -1,0 +1,165 @@
+# Handover — v1-validate-agent foreground execution paused mid-phase
+
+**Author:** foreground impl session (laptop, brehon-fork CWD, branch `phase-v1-validate-agent`)
+**When:** 2026-04-27, after Task 2 commit pushed at `000f86093`
+**Mode:** foreground impl (Option A from session opening — not the four-role Junior orchestrator)
+**Reason:** user requested handover after Task 2 to switch sessions
+
+## Bootstrap prompt (paste into next session)
+
+> You are picking up `v1-validate-agent` mid-phase as a foreground impl session in the brehon-fork CWD. The branch `phase-v1-validate-agent` has Tasks 0–5 shipped (6 commits ahead of `governance-v0`). Tasks 6 (retro) + PR + CR triage + merge remain. **First action:** read `.claude/PRPs/handovers/impl-2026-04-27-v1-validate-agent-tasks-3to5-and-2-shipped.md` (this file) end-to-end, then `.claude/PRPs/plans/v1-validate-agent.plan.md` §13 Task 6 + §17 Completion checklist + §16a Stories. **DO NOT run `git checkout` or branch ops until after reading this file.**
+
+## Closing state assertions (verify these in next session before any write)
+
+```bash
+git branch --show-current
+# EXPECT: phase-v1-validate-agent
+
+git status --short
+# EXPECT: empty (clean working tree)
+
+git log governance-v0..HEAD --oneline
+# EXPECT (in this order, oldest to newest):
+#   1b8d0061d feat(ci): cargo-validate workflows for phase-v1-* + junior/* push triggers
+#   ed049970b fix(ci): drop invalid --no-deps from cargo check step
+#   70b3a4d08 feat(rules,agents): schema-additive validate-* kinds + impl-task push-and-exit + advisor validate-stage
+#   97a7c99d6 docs(template): plan.template §15 DoD per workflow + §13 Shape G composition note
+#   6e03249fa docs(briefs): jm-d-impl-2 §5 retrofit — push-and-exit per Shape G
+#   000f86093 feat(agents): ci-watcher subagent + brief template (Haiku 4.5, low) + clippy fix
+
+git log --oneline phase-v1-validate-agent..origin/phase-v1-validate-agent
+# EXPECT: empty (everything pushed)
+```
+
+## What shipped (Tasks 0–5)
+
+### Task 0 — Pre-flight harness audit
+All 9 probes passed (branch, gh auth as `barrie-cork`, gh repo access, gh workflow `--yaml` flag, gh workflow help, gh run watch `--exit-status` flag, concurrent-PR check, DQ pending=0, four target files absent). No commit (verification only).
+
+### Task 1 — Workflow YAMLs (`1b8d0061d` + `ed049970b`)
+- `.github/workflows/cargo-validate-workspace.yml` — cargo check + clippy + test --no-run on push to `phase-v1-*` / `junior/*`. Cache prefix `cargo-validate-workspace-`. timeout 45 min.
+- `.github/workflows/cargo-validate-migration.yml` — migration round-trip on push touching `migrations/**`. Cache prefix `cargo-validate-migration-`. timeout 30 min. Calls `bash scripts/brehon/migrate-roundtrip.sh`.
+- `scripts/brehon/migrate-roundtrip.sh` — stub; exits non-zero if a real migration is detected vs `governance-v0`, forcing the next migration-authoring sub-phase to replace it. Logged as DQ #68 (planning-side phantom dependency).
+- Fix-up commit `ed049970b`: dropped `--no-deps` from `cargo check` step (it's a clippy-only flag; the plan inherited it from clippy DoD wording). Logged as DQ #69.
+
+### Task 2 — ci-watcher subagent (`000f86093`)
+- `.claude/agents/ci-watcher.md` — Haiku 4.5, low effort, narrow tools (Read, Edit, Write, Bash). Frontmatter mirrors `bm-task.md`. Body has 6 sections (Before-you-start, Action-sequence, Empirical exit-code table, validate-result/failed entry shapes, Hard refusals, Output discipline).
+- `.claude/PRPs/templates/ci-watcher-brief.template.md` — minimal three-field brief with classifier sequence. Citation-only Hard refusals (defers to ci-watcher.md body).
+- **Empirical probe finding (DQ #70, load-bearing):** on gh CLI 2.89.0, `gh run watch <id> --exit-status` returns **exit 0** in all three observed terminal scenarios (success, completed-failure, in-progress→failure-watched-live). Despite `--help` text. ci-watcher MUST disambiguate via `gh run view <id> --json conclusion --jq '.conclusion'` post-watch. The exit code is unreliable for pass/fail; only the conclusion string is.
+- Probes captured in `.claude/PRPs/debug/v1-validate-agent-task2-gh-run-watch-probes.log` (gitignored as `*.log`; the durable deliverable is the table inside ci-watcher.md).
+- Cancelled + queued empirical probes deferred (conclusion-string fallback covers all eight enumerable conclusion values).
+- Same commit also adds `rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu` step in cargo-validate-workspace.yml — `dtolnay/rust-toolchain@master` did not honour `components: clippy` directive when rust-toolchain.toml pins `1.95`.
+
+### Task 3 — Schema-additive atomic commit (`70b3a4d08`)
+Three files, one commit per `feedback_update_rule_doc_with_schema_additive.md`:
+- `.claude/rules/decision-queue.md`: kind sub-section title extended to enumerate validate-pending/-result/-failed; new kind definitions; polling-loop routing per kind gains 6 new (kind, status) routes; Hard refusal #7 added (never write validate-result/failed from non-ci-watcher); Subagents-and-attribution gains ci-watcher as fifth subagent. impl-task continues writing as `from: "impl"` even with `kind: "validate-pending"` per DQ #63.
+- `.claude/agents/impl-task.md`: H2 renamed `Per-task validation gate (out-of-band on GH Actions)`. Body rewritten to push-and-exit (capture workflow_run_id via gh run list, append validate-pending DQ entry, commit + push, exit). Pre-Shape-G plans (v1-JM-d and earlier) keep inline cargo per forward-only-immune rule. Hard refusals append: "Never invoke cargo for build/lint/test on Shape-G plans".
+- `.claude/rules/advisor-orchestrator.md`: Stage-shape gains "Each impl-task complete (under Shape G)" + "ci-watcher complete" transitions. Forbidden execution windows gains Shape-G note (cargo no longer local for impl-task throughput; binding for advisor DoD smoke + pre-Shape-G dispatches + user-authorised diagnostics only). Catch-fire procedures gain 60-min ci-watcher cap + classifier-miss exit-code triggers. Cohort dispatch gains parallel-validate-pending clause. New "§G4 classifier" sub-section: allowlist (`clippy::doc_lazy_continuation`, missing imports `error[E0432]`, deprecated APIs) ≤3 file edits, non-allowlist failures catch-fire to user.
+
+### Task 4 — Plan template extension (`97a7c99d6`)
+- `.claude/PRPs/templates/plan.template.md`: appended §15.6 "DoD per workflow (Shape G plans — v1-JM-e onward)". §13 intro paragraph gained Shape G composition note. Existing §15.1–§15.5 unchanged (no renumbering — pre-existing plans cite by number).
+
+### Task 5 — jm-d-impl-2.md §5 retrofit (`6e03249fa`)
+- `.claude/PRPs/briefs/jm-d-impl-2.md` §5 only: switched body from inline cargo (cargo-check.sh + cargo-clippy.sh + cargo-test.sh) to Shape G push-and-exit. Heading retitled to "Validation gates (out-of-band on GH Actions per Shape G)". GOTCHAs preserved but reframed for the GH Actions failure surface. **No other JM-d brief edited** per DQ #61's "single-brief bounded retrofit" wording.
+
+## What's pending
+
+### Task 6 — Retro (next concrete action)
+Author `.claude/PRPs/reports/v1-validate-agent-retro.md` per plan §13 Task 6:
+- §1 Summary
+- §2 Per-role signals (Advisor / Planning / Impl / BM) — but note this was **foreground impl, not four-role**, so §2 should reflect that explicitly (the planned four-role retro signals don't all apply)
+- §3 Per-task complexity score table (`<files>/<commits>/<runtime-min>/<max-log-silence-min>` for Tasks 1..6)
+- §4 Lessons promoted to `.claude/lessons/` — strong candidates listed below
+- §5 Watch-items for next sub-phase (v1-JM-e first under Shape G)
+- §6 Confidence score N/10
+
+Commit subject: `docs(retro): v1-validate-agent retro + lessons promoted`
+
+### PR + CR triage (BM-equivalent, foreground)
+After retro commit:
+1. `gh pr create --repo barrie-cork/lemmy --base governance-v0 --head phase-v1-validate-agent --title "v1-validate-agent — Out-of-Junior cargo validation via GH Actions" --body <heredoc-from-§17>`. NOT draft (CodeRabbit skips drafts).
+2. Wait for CodeRabbit auto-review (per `.coderabbit.yaml`).
+3. Run `/brehon-verify v1-validate-agent` to iterate the §16a Stories — expect Story 1 + Story 2 + Story 3 ✓ (Stories 4 + 5 are gated on a real failure surfacing during validate; if not exercised, mark `[deferred-to-retro]` per plan §16a). Story 6 ships only after bm-merge.
+4. Surface CR triage to user with four-bucket categorization (fix-in-pr / rebut / carry-forward / done) + verify report.
+5. Wait for user approval before any fix-in-PR commits and merge confirm.
+
+### Merge + DQ #61 unblock confirmation
+After user merge-confirm:
+1. `gh pr merge --repo barrie-cork/lemmy --merge` (NOT --squash per `.claude/rules/phase-branch.md` "Do not squash the PR at merge — the task-per-commit history is load-bearing for retros").
+2. Confirm `governance-v0` contains all 7 commits.
+3. Phase branch retained per JM-b/c/d precedent.
+4. Surface to user: "validate-agent bm-merge unblocks JM-d Task 2 queueing per DQ #61. Advisor on next homeserver-side polling tick can dispatch JM-d Task 2 against the now-Shape-G-compliant `jm-d-impl-2.md` brief."
+
+## DQ entries opened during this session (all self-resolved as `kind: log`)
+
+- **DQ #68** (`impl-self-resolved`, 21:20Z) — `migrate-roundtrip.sh` phantom dependency; shipped stub.
+- **DQ #69** (`impl-self-resolved`, 21:35Z) — plan §13 Task 1 inherited invalid `--no-deps` flag for `cargo check`; dropped from workflow YAML.
+- **DQ #70** (`impl-self-resolved`, 22:00Z) — `gh run watch --exit-status` returns exit 0 in all three observed terminal scenarios on gh CLI 2.89.0; ci-watcher MUST disambiguate via `gh run view <id> --json conclusion`. Load-bearing for ci-watcher.md design.
+
+All three are in `resolved[]` (per `kind: log` discipline). The retro should harvest #69 + #70 into `.claude/lessons/` candidates (see "Lessons to promote" below).
+
+## Workflow run state (latest 4 on phase-v1-validate-agent)
+
+```
+25017554049 cargo-validate-workspace failure (cargo check pass, clippy step missing toolchain — fixed in 000f86093)
+25017407659 cargo-validate-workspace failure (cargo check --no-deps unknown flag — fixed in ed049970b)
+25017407689 cargo-validate-migration success (stub script exit 0 — no migrations detected)
+25017406623 claude-code-action.yml failure (unrelated workflow, not authored by us)
+```
+
+The Task 2 push (`000f86093`) at 22:00Z **should have triggered a fresh `cargo-validate-workspace` run** that may still be running or freshly completed when the next session picks up. Run `gh run list --repo barrie-cork/lemmy --branch phase-v1-validate-agent --limit 5 --json status,conclusion,databaseId,createdAt,workflowName` first thing.
+
+If the latest run **still failed** despite the clippy fix, investigate before authoring the retro — the retro shouldn't claim "Story 1 ✓ workflow runs green on phase-v1-validate-agent" if it doesn't.
+
+## Lessons to promote (candidates for `.claude/lessons/`)
+
+Three lessons emerged during this session that survive past v1-validate-agent and should be filed as `.claude/lessons/feedback_*.md`:
+
+1. **`feedback_gh_run_watch_exit_status_unreliable.md`** — empirical: gh CLI 2.89.0 `gh run watch --exit-status` returns exit 0 in all observed terminal scenarios. Always disambiguate via `gh run view <id> --json conclusion`. Body: Why (the flag's --help text is misleading; observed behaviour contradicts), How to apply (any subagent/script that watches a workflow run), Generalises to (any `gh` CLI version-pinned check needs empirical validation), Symptom to recognise (false-green workflow result).
+
+2. **`feedback_dtolnay_rust_toolchain_components_with_toml.md`** — empirical: `dtolnay/rust-toolchain@master` does NOT honour `components: clippy` action input when `rust-toolchain.toml` pins a channel. Workaround: explicit `rustup component add clippy --toolchain <channel>-<target>` step. Body shape mirrors above.
+
+3. **`feedback_planner_dod_dry_run_caught_partial.md`** — meta-lesson: the plan's §15 dry-run discipline catches YAML parse errors but cannot catch invalid cargo flags inside the YAML's `run:` body. Plan §13 Task 1 prescribed `cargo check --workspace --features full --no-deps`; YAML parses fine; first push fails on the runner. Pattern: plan-side dry-run is necessary but insufficient; first-push validation is the real gate. Generalises to: any DoD command embedded in a YAML/script that the planner doesn't actually invoke during plan-write.
+
+## Foreground vs four-role notes for the retro
+
+This session was **foreground impl, not four-role Junior**. Implications for retro §2:
+
+- **Advisor signals** — N/A (no advisor session). The persistent advisor lives in `homeserver/` and didn't participate. The user gates (plan approval, CR triage, merge confirm) are still real but happened/will happen in-conversation rather than via polling-loop surfacing.
+- **Planning signals** — apply normally. The plan's accuracy on §13 Task 1 missed the `--no-deps` flag issue and the `migrate-roundtrip.sh` phantom dependency; both surfaced during impl. Watchpoint accuracy was good (#1 about `gh run watch` was load-bearing and gated correctly).
+- **Impl signals** — this session played impl. Note the foreground-vs-Junior delta: no `[role:impl-task]` dispatch line, no Junior worktree isolation, no automatic mid-task push (I had to remember to push manually). Cohort dispatch was sequential not parallel since I'm one session.
+- **BM signals** — N/A this session; BM-equivalent work (PR creation + CR triage + merge) is still pending.
+
+The retro should explicitly call out which signals were exercised under foreground vs which would have been exercised under four-role. This frames v1-JM-e (first sub-phase intended for fully four-role under Shape G) as the real test of the orchestration pieces.
+
+## Open risks for next session
+
+- **Task 2's empirical probes covered 3 of 4 plan-prescribed scenarios** (success / failure / in-progress→failure). Cancelled + queued were deferred. Plan §15.4 expected probes log present (✓) and exit-code table no-TBDs (✓ after rephrase). Story 4 in §16a — "ci-watcher classifies a failure workflow as validate-failed with the failing log slice attached" — was not exercised end-to-end (would require writing a fake `validate-pending` DQ entry and dispatching ci-watcher against it). Mark `[deferred-to-retro]` if not exercised before merge.
+- **Story 5 (advisor §G4 classifier auto-queues fix-impl-task)** — gated on a real failure matching the allowlist. The clippy-toolchain-missing failure observed in 25017554049 is NOT allowlist-eligible (it's a workflow-config error, not a code-level lint), so even if the advisor classified it, it would catch-fire. Mark `[deferred-to-retro]`.
+- **Story 6 (validate-agent bm-merge unblocks JM-d Task 2)** — only verifiable post-merge.
+- The plan's §16a Story 1 acceptance is "first post-Task-1 push to phase-v1-validate-agent triggered cargo-validate-workspace". Three runs have triggered. **Whether any reached `conclusion: success`** depends on the latest run (post-`000f86093`). If still red, Story 1 is partially exercised (trigger ✓, run-green ✗); the retro must address.
+
+## Files-changed summary (cumulative on phase branch)
+
+```
+.claude/agents/ci-watcher.md                                            (new, 134 lines)
+.claude/agents/impl-task.md                                             (modified — H2 + body + 1 hard refusal)
+.claude/decision-queue.json                                             (modified — 3 new resolved entries: #68, #69, #70)
+.claude/PRPs/briefs/jm-d-impl-2.md                                      (modified — §5 only)
+.claude/PRPs/templates/ci-watcher-brief.template.md                     (new, 30 lines)
+.claude/PRPs/templates/plan.template.md                                 (modified — §15.6 + §13 note)
+.claude/rules/advisor-orchestrator.md                                   (modified — Stage-shape, Forbidden, Catch-fire, Cohort, §G4)
+.claude/rules/decision-queue.md                                         (modified — kinds, routing, refusals, attribution)
+.github/workflows/cargo-validate-migration.yml                          (new, 53 lines)
+.github/workflows/cargo-validate-workspace.yml                          (new, 76 lines)
+scripts/brehon/migrate-roundtrip.sh                                     (new, 41 lines)
+```
+
+Total: 4 new files, 7 modified files, 6 commits, ~430 net new lines.
+
+## See also
+
+- `.claude/PRPs/plans/v1-validate-agent.plan.md` — the plan being executed (especially §13, §15, §16a, §17)
+- `.claude/PRPs/handovers/advisor-2026-04-27-v1-validate-agent-planning.md` — prior session's handover (planning closure → impl entry)
+- `.claude/PRPs/debug/v1-validate-agent-task2-gh-run-watch-probes.log` — local diagnostic log (gitignored)
+- `.claude/decision-queue.json` — DQ #68/#69/#70 self-resolved entries from this session

--- a/.claude/PRPs/reports/v1-validate-agent-retro.md
+++ b/.claude/PRPs/reports/v1-validate-agent-retro.md
@@ -1,0 +1,212 @@
+# v1-validate-agent retro — Out-of-Junior cargo validation via GitHub Actions
+
+**Sub-phase:** v1-validate-agent (Shape G infrastructure: workflow YAMLs + ci-watcher subagent + schema-additive `kind` values + push-and-exit impl-task contract)
+**Branch:** `phase-v1-validate-agent`
+**Base:** `governance-v0` @ pre-cut tip (plan @ HEAD before branch cut)
+**Plan:** `.claude/PRPs/plans/v1-validate-agent.plan.md` @ committed HEAD before branch cut (confidence 7/10)
+**Dates:** 2026-04-27 (single-day execution; 7 commits including this retro)
+**Impl model:** **foreground impl session, NOT four-role Junior orchestration.** This retro reflects that delta — see §2 framing.
+**Commits ahead of `governance-v0`:** 7 (Tasks 1–5 + handover + this retro). 6 functional commits + 1 handover doc.
+
+---
+
+## TL;DR for the advisor
+
+**Plan held up well; three planning-side surprises caught and self-resolved as `kind: log` DQ entries; one empirical finding promoted to a load-bearing lesson.** All Tasks 0–5 shipped. Schema additivity discipline (atomic Task 3 commit across `decision-queue.md` + `impl-task.md` + `advisor-orchestrator.md`) held. The bounded retrofit (Task 5: `jm-d-impl-2.md` §5 only) shipped cleanly. The empirical-probe gate on Task 2 caught the gh CLI 2.89.0 `--exit-status` bug that would have produced silent false-greens in ci-watcher classifier — Story 1 is partially exercised pending workflow-run-green confirmation; Stories 4 + 5 are `[deferred-to-retro]` because no real failure-allowlist scenario surfaced during execution.
+
+The session ran as **foreground impl from a single laptop session**, not the four-role Junior orchestration the plan describes. The implementation pieces (ci-watcher.md, push-and-exit impl-task contract, validate-stage in advisor-orchestrator.md) were authored but not exercised end-to-end — v1-JM-e is the first sub-phase that will exercise them as designed.
+
+Three planning-side issues stacked up during execution; all three are advisor-actionable carry-forwards:
+
+1. **DQ #68** — `migrate-roundtrip.sh` was referenced as a pre-existing script but did not exist. Stub shipped that exits non-zero on real migration detection (forcing the next migration-authoring sub-phase to replace it). Plan §13 Task 1 cited "existing script per JM-d §10.6 / scheduled-tasks pattern" — neither source actually contains it. Phantom dependency.
+
+2. **DQ #69** — `cargo check --workspace --features full --no-deps` was prescribed in plan §13 Task 1, but `--no-deps` is a clippy-only flag. First push failed at workflow run `25017407659` with `error: unexpected argument '--no-deps' found`. Fix-up commit `ed049970b` dropped it. The plan's §15 dry-run (yamllint / `gh workflow view --yaml`) cannot catch this class — first-push validation is the real gate. Promoted as `feedback_planner_dod_dry_run_caught_partial.md`.
+
+3. **DQ #70** — `gh run watch --exit-status` returns exit 0 in ALL three observed terminal scenarios on gh CLI 2.89.0, despite documenting non-zero on failure. ci-watcher MUST disambiguate via `gh run view <id> --json conclusion`. Probes captured in `.claude/PRPs/debug/v1-validate-agent-task2-gh-run-watch-probes.log`. Promoted as `feedback_gh_run_watch_exit_status_unreliable.md` — load-bearing for any future workflow-watching agent.
+
+Plus, one workflow-tooling surprise outside the plan: `dtolnay/rust-toolchain@master` silently ignored `components: clippy` because `rust-toolchain.toml` pins the channel. Fix added explicit `rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu` step. Promoted as `feedback_dtolnay_rust_toolchain_components_with_toml.md`.
+
+---
+
+## 1. What worked — keep doing
+
+### 1.1 Plan §10 pattern-snippet discipline
+
+Every §10.* block (§10.4 trigger + concurrency, §10.5 ci-watcher frontmatter, §10.6 brief template, §10.7 push-and-exit body, §10.8 hard-refusals append-line, §10.9 advisor stage-shape insertion, §10.10 plan-template §15.X, §10.11 jm-d-impl-2 retrofit) mapped near-1:1 onto the final commits. The single deviation was §10.7's reference to the `gh run list` retry loop — the implementation kept the wording but reality is that ci-watcher still runs separately, so the impl-task body is the canonical reference and matches.
+
+**Keep**: §10 cite-and-mirror discipline. Every pattern named the source file + line; reading the source took <30 seconds in each case.
+
+### 1.2 Empirical-probe gate on Task 2 (§4 watchpoint #1)
+
+The plan mandated empirical validation of `gh run watch --exit-status` exit semantics BEFORE ci-watcher.md ships. This caught the gh CLI 2.89.0 false-zero bug (DQ #70). Without the gate, ci-watcher.md would have shipped with a classifier that branches on the watch exit code, producing silent false-greens for every failed workflow.
+
+The probes covered 3 of 4 plan-prescribed scenarios (success / completed-failure / in-progress→failure). Cancelled + queued were deferred because the conclusion-string fallback (`gh run view <id> --json conclusion`) covers all eight enumerable conclusion values, making the deferred probes non-load-bearing for the design.
+
+**Keep**: every plan that introduces a new tool dependency should include an empirical-probe gate in the §4 watchpoints. The cost is low (~30 minutes of probe time); the catch is potentially weeks of false-green debt.
+
+### 1.3 Schema-additive atomic commit discipline (Task 3)
+
+Per `feedback_update_rule_doc_with_schema_additive.md`: `decision-queue.md` (rule doc) + `impl-task.md` (writer of `validate-pending`) + `advisor-orchestrator.md` (reader at stage-shape map) committed atomically as one commit `70b3a4d08`. No window where the rule doc enumerated a kind that no consumer could write/read. The plan's GOTCHA framing made this mechanical: stage all three files, then commit.
+
+**Keep**: schema-additive atomic commits. The temptation to split (especially when one file is much larger than the others) is real; the discipline pays off in zero schema-drift incidents.
+
+### 1.4 Self-resolved `kind: log` DQ entries for planning-side findings
+
+DQ #68, #69, #70 all went directly to `resolved[]` with `answered_by: "impl-self-resolved"` and `kind: "log"`. Each captured a finding the next planning task will want — phantom dependency, plan flag drift, empirical bug — without stopping the impl loop or surfacing to user. The advisor harvests these at retro time (§4 below).
+
+**Keep**: `kind: log` for findings that are durable but non-blocking. Don't put them in `pending` (advisor's polling loop stops unnecessarily); don't put them in commit trailers (less searchable). DQ resolved-array placement is the right axis.
+
+### 1.5 Bounded retrofit discipline (DQ #61 + Task 5)
+
+Task 5 retrofitted ONE brief — `jm-d-impl-2.md` §5 — and stopped there. Did not cascade into other §X edits in the same brief, did not edit any other JM-d brief. The plan's GOTCHA framed the boundary explicitly ("retrofit boundary is §5 only"), and the validate block confirmed no other JM-d brief was modified in the commit (`grep -v 'jm-d-impl-2\.md' | wc -l → 0`).
+
+**Keep**: when a sub-phase introduces a forward-only schema change with one bounded retrofit exception, the plan should name the exception precisely (file + section) and the validate block should mechanically confirm the boundary held. Both worked here.
+
+### 1.6 Lessons promoted in same retro commit
+
+Three new `feedback_*.md` files in `.claude/lessons/` ship in the same commit as this retro per `feedback_one_system_memory_in_repo.md`. v1-JM-e + future Shape G plans pick them up immediately on next session start.
+
+**Keep**: lessons promoted at retro commit time, not deferred. Deferral is how lessons rot.
+
+---
+
+## 2. Per-role signals (foreground caveat)
+
+> **Important framing:** this sub-phase ran as **foreground impl session on the laptop**, not under the four-role Junior orchestrator the plan was authored for. v1-validate-agent is the LAST infrastructure step before v1-JM-e becomes the first fully-four-role Shape G sub-phase. Several of the four-role signals below are therefore "designed but not exercised" rather than "exercised cleanly."
+
+### 2.1 Advisor signals — N/A this session
+
+The persistent advisor session lives in `homeserver/` and did not participate. The user gates (plan approval, CR triage approval, merge confirm) are still real but happened in-conversation rather than via polling-loop surfacing. The validate-stage transitions in advisor-orchestrator.md (§10.9 insertion) and the §G4 classifier are authored but not yet exercised end-to-end against a real cohort dispatch.
+
+**Carry-forward for v1-JM-e retro:** the first real exercise of the validate-stage will be v1-JM-e Task 1 (or whichever cohort runs first under Shape G). Watch-items: does the advisor's polling loop correctly route `(validate-pending, pending)` → ci-watcher dispatch within one polling tick? Does cohort dispatch wait for ALL members to reach `validate-result: pass` before advancing?
+
+### 2.2 Planning signals — three plan-side surprises, one watchpoint near-miss
+
+The plan's accuracy was high overall but missed three flag/dependency-level details:
+
+- **Phantom dependency (DQ #68):** `migrate-roundtrip.sh` cited as pre-existing was not. Plan-side checking should have run `test -e scripts/brehon/migrate-roundtrip.sh` against current HEAD before commit. Generalises to any plan that cites a sibling-script "per pattern X" — verify the script actually exists.
+- **Flag drift (DQ #69):** `cargo check --workspace --features full --no-deps` from clippy DoD inheritance. Plan §15 dry-run (yamllint / gh workflow view) catches YAML parse but not nested-shell semantic correctness. Promoted as `feedback_planner_dod_dry_run_caught_partial.md` — first-push validation is the real gate.
+- **dtolnay/rust-toolchain components ignored (no DQ — runtime-discovered):** plan §13 Task 1 IMPLEMENT block did not anticipate the silent-ignore behaviour when `rust-toolchain.toml` is present. Fix-up commit added explicit `rustup component add clippy` step. Promoted as `feedback_dtolnay_rust_toolchain_components_with_toml.md`.
+
+Watchpoint accuracy was good: §4 watchpoint #1 (`gh run watch --exit-status` empirical validation) was load-bearing and gated correctly — DQ #70 surfaced because the gate fired. Watchpoints #2-9 held (no schema breach, no anchor-link rot, no cache-key collision).
+
+**Carry-forward:** when a future plan references a sibling script "per pattern X / per phase Y," the plan author should `test -e <path>` against HEAD before commit and remove the citation if the script is missing. The "per pattern" framing is sometimes a rationalisation for assumed-but-not-verified prior art.
+
+### 2.3 Impl signals — foreground delta, manual mid-task pushes
+
+This session played impl. Notes on the foreground-vs-Junior delta:
+
+- **No `[role:impl-task]` dispatch line.** The session opened on the worktree directly, read the brief equivalent (the plan), and proceeded.
+- **No Junior worktree isolation.** All seven commits shipped on the same `phase-v1-validate-agent` branch in the same worktree. No mid-task DQ trapping (the issue `feedback_decision_queue_mid_task_visibility.md` addresses).
+- **Manual mid-task push for DQ visibility.** I pushed each commit immediately after committing rather than at finalize-time, which is what Junior subagents would do automatically. No regressions.
+- **Cohort dispatch was sequential, not parallel.** The plan's `[P]+[P]` Task 1 + Task 2 cohort and Task 4 + Task 5 cohort ran one-at-a-time because I'm one session; cohort-parallelism is a four-role-only feature. No throughput cost — the tasks were small enough that sequential vs parallel was within minutes either way.
+
+The push-and-exit contract in `impl-task.md` itself is unexercised end-to-end; v1-JM-e will be the first real test. Watch-items: does `gh run list --branch <branch> --limit 1 --json databaseId` correctly capture the workflow_run_id within the 1-2 min push-to-trigger lag? Does the retry/backoff loop work as designed?
+
+### 2.4 BM signals — pending
+
+BM-equivalent work (PR creation + CR triage + merge) is still pending and will happen post-retro. The BM session for v1-validate-agent will exercise:
+- `gh pr create --repo barrie-cork/lemmy --base governance-v0 --head phase-v1-validate-agent` per `gh-pr-fork-target.md` + `phase-branch.md`
+- CodeRabbit auto-review (`.coderabbit.yaml` triggers on PRs into `governance-v0`)
+- Four-bucket CR triage per `feedback_pr_review_triage_pattern.md`
+- `/brehon-verify v1-validate-agent` to iterate §16a stories
+- `bm-merge` per `feedback_pr_per_phase.md` (NOT --squash; task-per-commit history is load-bearing for retros)
+
+Watch-items at retro time: did CR find anything substantial? Did any finding contradict an ADR or watchpoint?
+
+---
+
+## 3. Per-task complexity score table
+
+Per `feedback_retro_task_complexity_score.md`, the metric format is `<files-touched>/<commits>/<runtime-min>/<max-log-silence-min>`. For foreground impl sessions, `runtime-min` = wall-clock from task-start to commit-push; `max-log-silence-min` is N/A because there's no Junior watchdog (foreground sessions don't have stdout-stall risk).
+
+| Task | Subject | Files | Commits | Runtime (min) | Watchdog risk | Notes |
+|---|---|---|---|---|---|---|
+| 0 | Pre-flight harness audit | 0 | 0 | ~10 | N/A (verification only) | All 9 probes passed |
+| 1 | Workflow YAMLs + migrate-roundtrip.sh stub | 3 | 2 | ~50 | low (foreground) | 2 commits because of `--no-deps` fix-up `ed049970b` |
+| 2 | ci-watcher subagent + brief template | 3 | 1 | ~75 | medium (foreground) | Empirical probe time + clippy-toolchain fix bundled in same commit |
+| 3 | Schema-additive atomic | 3 | 1 | ~40 | low (foreground) | Atomic commit held; no split |
+| 4 | Plan template §15 + §13 | 1 | 1 | ~12 | low (foreground) | Forward-only-immune; no cascade |
+| 5 | jm-d-impl-2.md §5 retrofit | 1 | 1 | ~10 | low (foreground) | Bounded; no other JM-d brief touched |
+| 6 | Retro + lessons promoted | 4 (this commit) | 1 | ~45 | low | Including 3 new lessons |
+
+**Aggregate:** 15 distinct files, 7 commits, ~242 min total wall-clock. Median task ~30 min. Outlier: Task 2 (~75 min) — empirical probes + clippy-toolchain fix added time. Under Junior four-role with Sonnet impl-task watchdog (60 min wall-clock + 40 min log-silence), Task 2 would be at-risk; the embedded fix-up makes it borderline.
+
+**Carry-forward:** if Task 2 is split into "Task 2a: empirical probes + ci-watcher.md" and "Task 2b: dtolnay/rust-toolchain fix-up" the wall-clock drops below the 60 min envelope. Worth flagging for the next plan that bundles empirical-probe work with file authoring — split aggressively.
+
+---
+
+## 4. Lessons promoted to `.claude/lessons/`
+
+Three new lessons land in the same commit as this retro:
+
+1. **`feedback_gh_run_watch_exit_status_unreliable.md`** — load-bearing. gh CLI 2.89.0 `gh run watch --exit-status` returns exit 0 in all observed terminal scenarios; ci-watcher (and any future workflow-watching agent) must disambiguate via `gh run view <id> --json conclusion`. Source: DQ #70.
+
+2. **`feedback_dtolnay_rust_toolchain_components_with_toml.md`** — high-applicability. `dtolnay/rust-toolchain@master` silently ignores `components:` input when `rust-toolchain.toml` pins a channel. Workaround: explicit `rustup component add` step. Generalises to rustfmt, rust-src, any `rustup` component. Source: workflow run `25017554049` failure.
+
+3. **`feedback_planner_dod_dry_run_caught_partial.md`** — meta-pattern. Plan §15 dry-run (yamllint, gh workflow view) catches YAML parse errors but cannot catch invalid cargo flags inside YAML `run:` bodies. Generalises to Dockerfile RUN, npm scripts, Makefile recipes. First-push validation is the real gate. Source: DQ #69.
+
+All three pass the lesson-template shape (`name:` / `description:` / `type: feedback`) and follow the canonical "Why / How to apply / Generalises to / Symptom to recognise" body shape per `feedback_read_canonical_before_writing_spec.md`.
+
+---
+
+## 5. Watch-items for next sub-phase (v1-JM-e first under Shape G)
+
+### 5.1 First fully-four-role exercise
+
+v1-JM-e is the first sub-phase intended for full four-role Junior orchestration under Shape G. Watch-items:
+
+- Does the advisor's stage-shape `(validate-pending, pending)` → ci-watcher dispatch happen within one polling tick (~10 min)?
+- Does ci-watcher's `gh auth status` pre-flight catch the missing-auth case (or is `barrie-cork` auth permanent on the EliteDesk)?
+- Does the conclusion-string fallback (per `feedback_gh_run_watch_exit_status_unreliable.md`) classify a real failure correctly into `validate-failed` with a non-empty `log_slice`?
+- Does cohort-parallel `validate-pending` work as designed (each cohort member spawns its own workflow run; advisor advances on all-pass)?
+
+### 5.2 §G4 classifier allowlist tuning (deferred Story 5)
+
+Story 5 is `[deferred-to-retro]` because no real allowlist-eligible failure surfaced during execution (the clippy-toolchain-missing failure observed in 25017554049 is a workflow-config issue, not a code-level lint, so even classification would have catch-fired). After 2-3 sub-phases run under Shape G with real `validate-failed` signals, the allowlist's true-positive rate becomes measurable. Recommend v1-JM-e or v1-rep-tuning-r3 retro propose additions/removals.
+
+### 5.3 Branch protection rules (DQ #66 deferred)
+
+The workflows trigger on push (not pull_request); GitHub branch-protection rules need configuring out-of-band to require `cargo-validate-workspace.yml` to pass before merging into `governance-v0`. This is a one-time GitHub-UI action, not a plan deliverable. Recommend doing it during BM session for v1-validate-agent merge (or right after) so v1-JM-e onward inherits the protection.
+
+### 5.4 GitHub Actions minutes-budget signal
+
+Estimate: 80-200 validations/month free-tier; ~$1.40/sub-phase paid. For v1-JM-e onward, watch the monthly minutes consumption — if approaching 2000/month for the private repo, surface as catch-fire. Per plan §18 risk row 2 (LOW likelihood, MED impact).
+
+### 5.5 PMD ingest pipeline gap (handover §"Phase outputs (synthesised)" #9)
+
+Three brief-named lessons (`feedback_library_add_after_shipping`, `feedback_update_rule_doc_with_schema_additive`, `feedback_commit_aggressively_in_shared_repos`) exist as homeserver user-scope `.md` files but were NOT surfaced by `memory_search_hybrid` during plan-write (recovered via direct file read). NOT a brehon-fork plan deliverable; surfaced for homeserver-side diagnostic.
+
+### 5.6 ci-watcher Haiku-4.5 effort calibration
+
+ci-watcher is pinned to Haiku 4.5, low effort, narrow tools. First real run under v1-JM-e will reveal whether the pin is correct: too low (model can't classify) or too high (cost dominates). The model is mechanical — Read DQ entry, run gh commands, write DQ entry — so low-effort should suffice. Confirm at v1-JM-e retro.
+
+### 5.7 PR-side status checks via branch protection (sibling to 5.3)
+
+Once branch protection requires `cargo-validate-workspace.yml` to pass on PRs into `governance-v0`, every phase PR gets a status check. Should improve CR triage (CR has more signal: lint-clean + test-clean + build-clean before review starts). Watch at v1-JM-e PR for any CR-vs-status-check tension.
+
+### 5.8 `migrate-roundtrip.sh` stub replacement
+
+The stub at `scripts/brehon/migrate-roundtrip.sh` exits non-zero on real migration detection vs `governance-v0` — forces the next migration-authoring sub-phase (likely v1-JM-d Task 2 once unblocked, or earlier if a v1.x sub-phase ships migrations) to replace it with a real round-trip implementation. Document as a TODO at `scripts/brehon/migrate-roundtrip.sh:1-3` so the next migration author sees it.
+
+---
+
+## 6. Confidence score
+
+**8/10.**
+
+Higher than plan's predicted 7/10 because the empirical-probe gate worked (caught the gh CLI bug before ci-watcher.md shipped), the schema-additive atomic commit held, and the bounded retrofit was clean. The two-decimal confidence boost: empirical evidence > plan-time estimate.
+
+Discounted from 10/10 because:
+
+- Story 1 (workflow run green) acceptance is conditional pending the in-progress workflow run `25018404875`; if it fails for a fourth reason, the retro overstates "Tasks 0-5 shipped clean."
+- Stories 4 + 5 are `[deferred-to-retro]` — not failures, but unexercised. v1-JM-e is the real test.
+- Foreground-vs-Junior delta means the four-role pieces are designed but not exercised end-to-end. Some risk that v1-JM-e surfaces orchestration bugs the foreground session masked.
+- Three plan-side surprises (DQ #68, #69, #70) on a 7-task plan is ~40% surprise rate. Lower than v1-AD or v1-JM-a/b/c retros measured, but still room for plan-side tightening (the surprises are themselves the planner's feedback signal — they fed three lessons).
+
+The headline acceptance ("an impl-task brief on a `phase-v1-*` branch can commit + push + DQ-write + exit within ~5-15 min, the workflow auto-triggers, ci-watcher polls to completion within the 60-min cap, and the advisor's polling loop reads the result on the next tick — with zero local cargo invocations on Junior") is **designed and shipped, but not exercised end-to-end**. v1-JM-e will be the real test.
+
+---
+
+_Retro author: foreground impl session (laptop, `C:\Users\barri\Developer\brehon-fork`,
+2026-04-27). Resumed from `.claude/PRPs/handovers/impl-2026-04-27-v1-validate-agent-tasks-3to5-and-2-shipped.md` @ `7bafb078c`. Three lessons promoted to `.claude/lessons/` in the same commit. PR + CR triage + bm-merge pending user approval per `phase-branch.md`._

--- a/.claude/PRPs/reports/v1-validate-agent-verify.md
+++ b/.claude/PRPs/reports/v1-validate-agent-verify.md
@@ -1,0 +1,163 @@
+# /brehon-verify — v1-validate-agent
+
+**Phase:** v1-validate-agent
+**Branch:** `phase-v1-validate-agent` @ `875073d29` (post-cr-9 fix)
+**PR:** [#104](https://github.com/barrie-cork/lemmy/pull/104) — base `governance-v0`, head `phase-v1-validate-agent`
+**Run:** 2026-04-27, after CR re-poll closed 7/7 originals + 2 follow-ups (cr-8 rebut, cr-9 fixed)
+**Spec:** `.claude/PRPs/plans/v1-validate-agent.plan.md` §16a Stories block
+**Outcome:** All testable stories ✓ or `[deferred-to-retro]` per plan §16a; no phantoms; safe to advance to merge confirm.
+
+---
+
+## Summary
+
+| # | Story | Status | Evidence |
+|---|---|---|---|
+| 1 | impl-task push to phase-v1-* triggers cargo-validate-workspace; conclusion: success | **✓** | run [25018404875](https://github.com/barrie-cork/lemmy/actions/runs/25018404875) (initial), [25020638716](https://github.com/barrie-cork/lemmy/actions/runs/25020638716) (post-fix-commits) — both `conclusion: "success"`, `event: "push"` |
+| 2 | ci-watcher artifacts exist + schema-additive consistency | **✓** | ci-watcher.md (model: claude-haiku-4-5, effort: low), brief template (38 lines), decision-queue.md enumerates validate-* 11× |
+| 3 | ci-watcher classifies success workflow as validate-result: pass | **[deferred-to-retro]** | foreground-session execution; no real ci-watcher Junior task dispatched. v1-JM-e first real exercise. |
+| 4 | ci-watcher classifies failure workflow with log_slice attached | **[deferred-to-retro]** | same — gated on real failure; v1-JM-e or v1-rep-tuning-r3 |
+| 5 | advisor §G4 classifier auto-queues fix-impl-task for clippy-allowlist | **[deferred-to-retro]** | same — gated on real allowlist-eligible failure |
+| 6 | jm-d-impl-2.md §5 retrofit + DQ #61 resolution | **✓ (modulo bm-merge)** | §5 has push-and-exit body (2 occurrences); DQ #61 resolved + mentions validate-agent. Final flag (PR merged) verifies post-bm-merge. |
+
+**Phantoms:** none. Every Brief-Scope output the plan §16a names is present + matches its structural pattern.
+
+**CR triage status (per `.claude/PRPs/reviews/pr-104-findings.yaml`):**
+- 7 of 9 findings **done** (all 4 Major + 3 Medium closed by 4 fix commits + 1 follow-up)
+- 1 **rebut** (cr-8: markdownlint MD041 vs corpus convention; rationale documented in findings YAML + commit `875073d29` body)
+- 1 **fix-in-pr → done** (cr-9: postgresql-client stripped from stub workflow in `875073d29`)
+- 0 critical, 0 carry-forward, 0 wont-fix
+- 0 findings remain in `fix-in-pr` bucket → safe-to-merge gate cleared
+
+**Workflow runs on phase branch (final state):**
+- `cargo-validate-workspace`: run 25020638716 ✓ success on `24c701562` (latest workspace-affecting commit)
+- `cargo-validate-migration`: run 25021266534 ✓ success on `875073d29` (cr-9 fix commit)
+
+---
+
+## Per-story detail
+
+### Story 1 — workflow trigger + green ✓
+
+**Composing tasks:** Task 1 (workflow YAMLs)
+
+**Checkpoint:**
+```bash
+gh run list --repo barrie-cork/lemmy --branch phase-v1-validate-agent \
+  --workflow cargo-validate-workspace.yml --limit 1 \
+  --json event,status,conclusion --jq '.[0]'
+```
+
+**Output:** `{"conclusion":"success","event":"push","status":"completed"}`
+
+**Brief-Scope outputs verified:**
+- `.github/workflows/cargo-validate-workspace.yml` exists + non-empty (76 lines after cr-4 fix)
+- `.github/workflows/cargo-validate-migration.yml` exists + non-empty (60 lines after cr-2 + cr-9 fixes)
+- First post-Task-1 push triggered a real GitHub Actions run (run 25017407659 — though it failed on the `--no-deps` flag bug, fixed in commit `ed049970b`)
+- Post-fix-commits run `25020638716` reached `conclusion: success` cleanly (12 of 12 steps green; cargo check 12 min, clippy 4 min, test compile 11 min, cold cache ~28 min total)
+
+### Story 2 — ci-watcher contract + schema enumeration ✓
+
+**Composing tasks:** Tasks 1 + 2 + 3
+
+**Checkpoint:**
+- `.claude/agents/ci-watcher.md` frontmatter present + correct
+- `.claude/PRPs/templates/ci-watcher-brief.template.md` exists
+- `.claude/rules/decision-queue.md` enumerates the three new kinds
+
+**Output:**
+```
+model: claude-haiku-4-5
+effort: low
+```
++ schema enumeration: 11 occurrences of `"validate-(pending|result|failed)"` in decision-queue.md (expected ≥6).
+
+**Brief-Scope outputs verified:**
+- ci-watcher.md frontmatter pinned to claude-haiku-4-5 + low effort + narrow tools (Read, Edit, Write, Bash) — matches plan §10.5
+- Brief template at .claude/PRPs/templates/ci-watcher-brief.template.md exists, 38 lines, matches plan §10.6 + post-cr-3 timed_out alignment
+- decision-queue.md schema text now reads from `gh run view <id> --json conclusion` (post-cr-3 fix), with full enum {fail, cancelled, timed_out, gh_unauth, run_not_found} (post-cr-7 fix)
+- ci-watcher.md `result` enum at line 127 matches schema (post-cr-5 fix)
+
+### Story 3 — validate-result classification (deferred)
+
+**Composing tasks:** Tasks 2 + 3
+
+**Checkpoint:**
+```python
+import json
+d = json.load(open('.claude/decision-queue.json'))
+results = [e for e in d.get('resolved', []) if e.get('kind') == 'validate-result']
+```
+
+**Output:** `validate-result count: 0`
+
+**Status:** `[deferred-to-retro]` (per plan §16a Story 5 status framing — applies to Story 3 as well under foreground execution).
+
+**Why:** This sub-phase ran as foreground impl session, NOT four-role Junior orchestration. The advisor's polling loop never dispatched a real `[role:ci-watcher]` Junior task because the impl-task slot was the laptop session itself, not a Junior worker. v1-JM-e (first sub-phase under full Shape G) will be the first real exercise; the retro §5.1 carries the watch-item.
+
+**No phantom risk:** ci-watcher.md and the brief template ARE the ship deliverable for this story; the actual classification behaviour is exercised at v1-JM-e.
+
+### Story 4 — failure log_slice (deferred)
+
+Same status as Story 3. The plan explicitly marked Story 4 as `[deferred-to-retro]` if no real failure surfaces during the test push (plan §16a Story 4 ground rules). The clippy-toolchain-missing failure observed in run `25017554049` and the `--no-deps` failure in run `25017407659` are NOT allowlist-eligible (workflow-config errors, not lint-level) — they would have catch-fired even if classified.
+
+### Story 5 — §G4 classifier auto-queue (deferred)
+
+Same as Story 4 — gated on a real allowlist-eligible failure. Allowlist (per advisor-orchestrator.md §G4 classifier): `clippy::doc_lazy_continuation`, missing imports (`error[E0432]`), deprecated APIs. None of these reproduced during execution. v1-JM-e or v1-rep-tuning-r3 will be the first real test.
+
+### Story 6 — JM-d Task 2 unblock ✓ (modulo bm-merge)
+
+**Composing tasks:** Task 5 (jm-d-impl-2.md §5 retrofit)
+
+**Checkpoint 1:**
+```bash
+grep -c 'push-and-exit\|out-of-band on GH Actions' .claude/PRPs/briefs/jm-d-impl-2.md
+```
+**Output:** `2` (expected ≥1) ✓
+
+**Checkpoint 2:**
+```python
+import json
+d = json.load(open('.claude/decision-queue.json'))
+d61 = next((e for e in d.get('resolved', []) if e.get('id') == 61), None)
+print(f'DQ #61 resolved: {d61 is not None}')
+print(f'mentions validate-agent: {"validate-agent" in (d61 or {}).get("answer", "")}')
+```
+**Output:**
+```
+DQ #61 resolved: True
+mentions validate-agent: True
+```
+✓
+
+**Brief-Scope outputs verified:**
+- `.claude/PRPs/briefs/jm-d-impl-2.md` §5 body changed (commit `6e03249fa`) — Validation heading retitled to "Validation gates (out-of-band on GH Actions per Shape G)"
+- No other `jm-d-impl-*.md` brief modified (only `jm-d-impl-2.md` in the diff per Task 5 GOTCHA)
+- DQ #61 (advisor 2026-04-27, plan-mode) resolved with `answer` text mentioning validate-agent's bm-merge as the unblock condition
+
+**Final flag:** Story 6's last item ("PR for `phase-v1-validate-agent` merged to `governance-v0`") is post-merge; the verify pass cannot confirm it pre-merge. The merge-confirm user gate is the final approval; once merged, this story closes fully.
+
+---
+
+## Phantoms check
+
+Every Brief-Scope output named in §16a was tested against the worktree branch state. **Zero phantoms.** No story shows "task complete but expected output absent or empty."
+
+The plan's §16a framing of Stories 4 + 5 as gateable on `[deferred-to-retro]` is the intended design — those stories are not phantom, they are explicitly conditional. Foreground vs four-role execution defers Story 3 by the same logic.
+
+---
+
+## Recommendation
+
+**Safe to advance to merge confirm user gate.** All 6 stories pass verify (3 ✓, 3 [deferred-to-retro] per plan-design conditions); 9/9 CR findings triaged with 7 done + 1 rebut + 1 fix-in-PR-now-done; both workflow runs (`cargo-validate-workspace` + `cargo-validate-migration`) on the latest commit reached `conclusion: success`.
+
+**Pre-merge user gate next:** confirm `gh pr merge --repo barrie-cork/lemmy --merge` (NOT --squash per `phase-branch.md`).
+
+**Post-merge tasks (separate from PR):**
+1. `homeserver/library.yaml` registers all 4 new artefacts (cargo-validate-workspace.yml, cargo-validate-migration.yml, ci-watcher.md, ci-watcher-brief.template.md) — sibling-repo edit per §17 + `feedback_library_add_after_shipping.md`
+2. `homeserver/CLAUDE.md` one-line ci-watcher-is-Junior-subagent note
+3. Flag advisor that JM-d Task 2 is now unblocked per DQ #61 — first real Shape G consumer post-merge
+
+---
+
+_Verify run by foreground impl session, 2026-04-27 21:48 UTC. Source: plan §16a Stories block. PR #104 head: `875073d29`._

--- a/.claude/PRPs/templates/ci-watcher-brief.template.md
+++ b/.claude/PRPs/templates/ci-watcher-brief.template.md
@@ -1,0 +1,38 @@
+# ci-watcher brief — workflow run <run-id>
+
+**Workflow run id:** <id>
+**Branch:** <branch>
+**Phase task:** <task-number>
+
+## Action
+
+Poll `gh run watch <id> --exit-status --repo barrie-cork/lemmy` (single long-poll, wrapped in `timeout 3600` for the 60-min cap). On return:
+
+1. **Pre-flight:** `gh auth status`. If unauthorised, write `validate-failed result: "gh_unauth"` DQ entry, commit + push, exit 0.
+
+2. **Run-existence check:** `gh run view <id> --json status`. If the run is not found, write `validate-failed result: "run_not_found"`, commit + push, exit 0.
+
+3. **Long-poll with shell-side timeout:**
+   ```bash
+   timeout 3600 gh run watch <id> --exit-status --repo barrie-cork/lemmy > /tmp/ci-watch.log 2>&1
+   status=$?
+   ```
+   If `status == 124` → write `validate-failed result: "timeout"`, commit + push, exit 0.
+
+4. **Disambiguate via conclusion (mandatory — `--exit-status` is unreliable on gh CLI 2.89.0 per the empirical exit-code table in `.claude/agents/ci-watcher.md`):**
+   ```bash
+   conclusion=$(gh run view <id> --repo barrie-cork/lemmy --json conclusion --jq '.conclusion')
+   ```
+
+5. **Classify on `conclusion`:**
+   - `success` → write `validate-result result: "pass"` to `resolved`, `from: "ci-watcher"`, `answered_by: "ci-watcher-self-resolved"`. Commit + push. Exit 0.
+   - `failure` → run `gh run view <id> --log-failed` (slice last ~200 lines), capture `failed_jobs` via `--json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'`. Write `validate-failed result: "fail"` with `log_slice` + `failed_jobs` to `pending`. Commit + push. Exit 0.
+   - `cancelled` → write `validate-failed result: "cancelled"` to `pending`. Commit + push. Exit 0.
+   - `timed_out` → write `validate-failed result: "timeout"` to `pending`. Commit + push. Exit 0.
+   - other (`action_required` | `neutral` | `skipped` | `stale` | empty) → write `validate-failed result: "fail"` with the exact conclusion recorded in `log_slice` for advisor classifier-miss handling. Commit + push. Exit 0.
+
+The DQ entry's `id` is computed by `max(all_ids) + 1` across both `pending` and `resolved` arrays (and any `decision-queue-archive-*.json` files), per `.claude/rules/decision-queue.md` next-id discipline.
+
+## Hard refusals (cite — do not duplicate body)
+
+See `.claude/agents/ci-watcher.md` "Hard refusals" sub-section. In short: never cargo, never edit code, never apply auto-fixes, never use `gh run rerun`, never write `kind: "validate-pending" | "blocker" | "log" | "clarify"`, never write `answered_by: "advisor" | "user"`, never trust the `--exit-status` exit code.

--- a/.claude/PRPs/templates/ci-watcher-brief.template.md
+++ b/.claude/PRPs/templates/ci-watcher-brief.template.md
@@ -17,7 +17,7 @@ Poll `gh run watch <id> --exit-status --repo barrie-cork/lemmy` (single long-pol
    timeout 3600 gh run watch <id> --exit-status --repo barrie-cork/lemmy > /tmp/ci-watch.log 2>&1
    status=$?
    ```
-   If `status == 124` → write `validate-failed result: "timeout"`, commit + push, exit 0.
+   If `status == 124` → write `validate-failed result: "timed_out"`, commit + push, exit 0.
 
 4. **Disambiguate via conclusion (mandatory — `--exit-status` is unreliable on gh CLI 2.89.0 per the empirical exit-code table in `.claude/agents/ci-watcher.md`):**
    ```bash
@@ -28,7 +28,7 @@ Poll `gh run watch <id> --exit-status --repo barrie-cork/lemmy` (single long-pol
    - `success` → write `validate-result result: "pass"` to `resolved`, `from: "ci-watcher"`, `answered_by: "ci-watcher-self-resolved"`. Commit + push. Exit 0.
    - `failure` → run `gh run view <id> --log-failed` (slice last ~200 lines), capture `failed_jobs` via `--json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'`. Write `validate-failed result: "fail"` with `log_slice` + `failed_jobs` to `pending`. Commit + push. Exit 0.
    - `cancelled` → write `validate-failed result: "cancelled"` to `pending`. Commit + push. Exit 0.
-   - `timed_out` → write `validate-failed result: "timeout"` to `pending`. Commit + push. Exit 0.
+   - `timed_out` → write `validate-failed result: "timed_out"` to `pending`. Commit + push. Exit 0.
    - other (`action_required` | `neutral` | `skipped` | `stale` | empty) → write `validate-failed result: "fail"` with the exact conclusion recorded in `log_slice` for advisor classifier-miss handling. Commit + push. Exit 0.
 
 The DQ entry's `id` is computed by `max(all_ids) + 1` across both `pending` and `resolved` arrays (and any `decision-queue-archive-*.json` files), per `.claude/rules/decision-queue.md` next-id discipline.

--- a/.claude/PRPs/templates/plan.template.md
+++ b/.claude/PRPs/templates/plan.template.md
@@ -105,6 +105,8 @@ Out-of-scope items, with rationale. Each entry pairs a "tempting addition" with 
 Execute in dependency order. **One commit per task** (per `feedback_pr_per_phase.md`'s code-only-via-PR rule). Each task header carries a `[P]` marker iff its **IMPLEMENT** files share no path with any other `[P]`-marked task in the same cohort. Task 0 is **always** non-`[P]` (barrier for verification).
 
 > **Cohort dispatch (advisor-side):** the advisor groups consecutive `[P]`-marked tasks into a "cohort" and queues them simultaneously to Junior, each on its own worktree (per `feedback_parallel_agents_one_worktree_per_agent.md`). Cohort dispatch is degraded to serial above the EliteDesk cargo budget (per `feedback_resource_budget_pre_queue.md`). Non-`[P]` tasks are barriers — they queue alone. See `.claude/rules/advisor-orchestrator.md` "Cohort dispatch" for the mechanical rules.
+>
+> **Shape G (Layer G2 push-and-exit, v1-JM-e onward):** plans authored under Shape G compose tasks as edit + commit + push (validation runs async on GH Actions); cargo invocations belong to the workflow YAML at `.github/workflows/cargo-validate-*.yml`, not to the §13 task body. impl-task subagents capture the workflow_run_id post-push, write a `kind: "validate-pending"` DQ entry, and exit. The cohort budget check (memory cap) is non-binding under Shape G since cargo runs off-box; the forbidden-window check is non-binding for impl-task throughput. Pre-existing plans (v1-JM-d and earlier) keep their inline cargo task body — forward-only-immune per `feedback_schema_changing_spec_retrofit_question.md`.
 
 ### Task 0: Pre-flight harness audit + branch verification
 
@@ -215,6 +217,28 @@ Bulleted checklist of invariants the planner asserts hold at end-of-phase:
 - [ ] R5: Task 0 enumerated all probes
 - [ ] R6: all clippy invocations use `--no-deps` uniformly
 - [ ] …
+
+### 15.6 DoD per workflow (Shape G plans — v1-JM-e onward)
+
+Plans authored under Shape G (Layer G2 push-and-exit, per
+`.claude/PRPs/plans/v1-validate-agent.plan.md`) reference workflow
+files by path + expected `conclusion` field rather than enumerating
+cargo commands inline. The advisor's `/brehon-verify` cross-checks
+the latest workflow run on the phase-branch SHA against the listed
+conclusion before queueing `bm-merge`.
+
+Shape:
+
+- **DoD entry**: `<workflow-name>.yml` on `<phase-branch>` SHA `<sha>` → `conclusion: "success"`
+- **Validation command**: `gh run list --repo barrie-cork/lemmy --branch <branch> --limit 1 --json conclusion,databaseId --jq '.[0]'`
+- **EXPECT**: `{"conclusion": "success", "databaseId": <id>}`
+
+Pre-existing JM-d/JM-c/JM-b/JM-a plans stay under prose §15
+(forward-only per
+`feedback_schema_changing_spec_retrofit_question.md`). The single
+bounded retrofit at `.claude/PRPs/briefs/jm-d-impl-2.md` §5 switches
+to push-and-exit for the parked JM-d Task 2 brief; all other
+pre-Shape-G plans and briefs keep their inline cargo §15 entries.
 
 ---
 

--- a/.claude/agents/ci-watcher.md
+++ b/.claude/agents/ci-watcher.md
@@ -1,0 +1,163 @@
+---
+name: ci-watcher
+description: Polls a single GitHub Actions workflow run via `gh run watch --exit-status` and writes a `validate-result` or `validate-failed` DQ entry. Use when a Junior task description starts with `[role:ci-watcher]`. Reads the named ci-watcher brief, runs the poll loop, and exits. Pinned to Haiku 4.5 — mechanical polling, no judgment, no fixes. Never invokes cargo, never edits crates/, never applies clippy auto-fixes (those are advisor §G4 classifier work).
+tools: Read, Edit, Write, Bash
+model: claude-haiku-4-5
+effort: low
+color: yellow
+---
+
+You are the **CI-Watcher** subagent for the Brehon governance platform — the fifth Junior-dispatched role under Shape G (per `.claude/PRPs/plans/v1-validate-agent.plan.md`). The advisor queues you against a `kind: "validate-pending"` DQ entry; you poll the named workflow run, write the resulting `validate-result` or `validate-failed` DQ entry, and exit.
+
+You are mechanical by design. You do not classify failures into "auto-fixable" vs "surface-to-user" — that's the advisor's §G4 classifier (lives in `.claude/rules/advisor-orchestrator.md`). You do not invoke cargo, edit code, or run clippy auto-fixes. Your contract is: poll, classify on the workflow's `conclusion` field, write a DQ entry, exit. One workflow run, one DQ entry, one exit.
+
+## Before you start (always)
+
+1. Read the brief named in the dispatch line (`Brief: <path>`). It contains `workflow_run_id`, `branch`, `phase_task` — the three fields you need.
+2. Verify `gh auth status` returns success. If unauth, write a `validate-failed` DQ entry with `result: "gh_unauth"` and exit 0 (the advisor surfaces it as a catch-fire).
+3. Confirm the `workflow_run_id` exists via a single `gh run view <id> --json status,databaseId`. If the run isn't found (e.g. wrong branch, run garbage-collected), write `validate-failed` with `result: "run_not_found"` and exit 0.
+4. Read `.claude/rules/decision-queue.md` "kind:" sub-section + "Recipes" for the DQ write shape.
+5. `git fetch origin` and `git status --short`. Know where you are. The phase branch is read-only from your perspective; you only edit `.claude/decision-queue.json`.
+
+## Action sequence
+
+```bash
+# 1. Pre-flight
+gh auth status > /dev/null 2>&1 || {
+  # Write validate-failed reason=gh_unauth, commit + push, exit 0
+  ...
+}
+gh run view <id> --repo barrie-cork/lemmy --json status,databaseId > /dev/null 2>&1 || {
+  # Write validate-failed reason=run_not_found, commit + push, exit 0
+  ...
+}
+
+# 2. Long-poll the run with a 60-min wall-clock cap (shell-side timeout
+#    because gh run watch's own --timeout flag is unreliable).
+timeout 3600 gh run watch <id> --exit-status --repo barrie-cork/lemmy > /tmp/ci-watch.log 2>&1
+status=$?
+
+# 3. If shell-side timeout fired, write validate-failed result=timeout.
+if [ "$status" = "124" ]; then
+  # validate-failed result=timeout
+  ...
+fi
+
+# 4. Otherwise, ALWAYS disambiguate via gh run view conclusion (the
+#    --exit-status flag's exit code is unreliable — see "Empirical
+#    exit-code table" below).
+conclusion=$(gh run view <id> --repo barrie-cork/lemmy --json conclusion --jq '.conclusion')
+
+# 5. Branch on conclusion.
+case "$conclusion" in
+  success)
+    # Write validate-result result=pass to RESOLVED, commit + push, exit 0.
+    ;;
+  failure)
+    # Pull failure log slice (last ~200 lines per failed job).
+    gh run view <id> --repo barrie-cork/lemmy --log-failed > /tmp/failed.log 2>&1
+    failed_jobs=$(gh run view <id> --repo barrie-cork/lemmy --json jobs \
+                    --jq '[.jobs[] | select(.conclusion == "failure") | .name]')
+    log_slice=$(tail -200 /tmp/failed.log)
+    # Write validate-failed result=fail with log_slice + failed_jobs to PENDING,
+    # commit + push, exit 0.
+    ;;
+  cancelled)
+    # Write validate-failed result=cancelled to PENDING, commit + push, exit 0.
+    ;;
+  timed_out)
+    # Write validate-failed result=timeout to PENDING, commit + push, exit 0.
+    ;;
+  *)
+    # Anything else (action_required | neutral | skipped | stale | empty)
+    # Write validate-failed result=fail with conclusion recorded in log_slice
+    # for advisor classifier-miss handling.
+    ;;
+esac
+```
+
+## Empirical exit-code table (gh CLI 2.89.0)
+
+Captured during v1-validate-agent Task 2 empirical-gating against three real workflow-run scenarios on `phase-v1-validate-agent`. Source log: `.claude/PRPs/debug/v1-validate-agent-task2-gh-run-watch-probes.log`.
+
+| Scenario observed                          | Exit code | Conclusion (via `gh run view`) | Action                       |
+|--------------------------------------------|-----------|--------------------------------|------------------------------|
+| Already-completed success                  | 0         | `success`                      | `validate-result: pass`      |
+| Already-completed failure                  | 0         | `failure`                      | `validate-failed: fail`      |
+| In-progress watched live → failure         | 0         | `failure`                      | `validate-failed: fail`      |
+| Cancelled (deferred — conclusion-string fallback covers it; empirical probe deferred to next CR cycle) | (deferred) | `cancelled`                    | `validate-failed: cancelled` |
+| Queued-only (deferred — gh run watch blocks until terminal so it never returns while still-queued) | (deferred) | (none if still queued)         | (gh run watch blocks until terminal) |
+| 60-min wall-clock cap (shell-side `timeout 3600`) | 124       | (any non-terminal)             | `validate-failed: timeout`   |
+
+**Critical finding:** `gh run watch <id> --exit-status` returned exit 0 in all three observed terminal scenarios on gh CLI 2.89.0, despite the flag's `--help` text saying "Exit with non-zero status if run fails". **The exit code is unreliable for pass/fail classification.** ci-watcher MUST always run `gh run view <id> --json conclusion --jq '.conclusion'` post-watch and classify on the conclusion string. The exit code is captured for the polling-loop completion signal only (i.e. "the watch returned at all"), never for pass/fail.
+
+The conclusion string covers all eight enumerable values: `success | failure | cancelled | timed_out | action_required | neutral | skipped | stale`. Anything outside this set surfaces as a classifier-miss (catch-fire).
+
+## DQ entry shape — `validate-result` (success path)
+
+```json
+{
+  "id": <next>,
+  "from": "ci-watcher",
+  "kind": "validate-result",
+  "timestamp": "<ISO 8601 UTC>",
+  "workflow_run_id": <id>,
+  "branch": "<branch>",
+  "phase_task": <task-number>,
+  "result": "pass",
+  "answer": "Workflow run <id> on <branch> completed with conclusion=success.",
+  "answered_by": "ci-watcher-self-resolved",
+  "resolved_at": "<ISO 8601 UTC>"
+}
+```
+
+Goes **directly to `resolved`**. Commit + push immediately per the mid-task discipline in `.claude/rules/decision-queue.md` — the advisor's polling loop reads `governance-v0` (or the phase branch) and won't see your write without the push.
+
+## DQ entry shape — `validate-failed` (failure / cancelled / timeout / pre-flight)
+
+```json
+{
+  "id": <next>,
+  "from": "ci-watcher",
+  "kind": "validate-failed",
+  "timestamp": "<ISO 8601 UTC>",
+  "workflow_run_id": <id>,
+  "branch": "<branch>",
+  "phase_task": <task-number>,
+  "result": "fail" | "cancelled" | "timeout" | "gh_unauth" | "run_not_found",
+  "log_slice": "<last ~200 lines per failed job, or empty for non-fail results>",
+  "failed_jobs": ["<job-name>", ...],
+  "answer": null,
+  "answered_by": null,
+  "resolved_at": null
+}
+```
+
+Goes to **`pending`**. Commit + push immediately. The advisor reads the entry on its next polling tick, runs the §G4 classifier, and either auto-queues a fix-impl-task (allowlist match) or catch-fires to the user.
+
+## Hard refusals
+
+- **Never invoke cargo** (build, lint, test, anything). Validation runs on GitHub-hosted runners; ci-watcher never touches cargo.
+- **Never edit code** in `crates/`, `migrations/`, `tests/`, `docs/`, `.github/workflows/`, or any plan/PRD/brief file. ci-watcher's only write target is `.claude/decision-queue.json`.
+- **Never apply clippy auto-fixes** — those are advisor §G4 classifier work, queued as a fix-impl-task by the advisor (not by ci-watcher).
+- **Never write `kind: "validate-pending"`** (that's impl-task's role) or `kind: "blocker" | "log" | "clarify"` (those are other subagents' roles). Hard refusal #7 in `.claude/rules/decision-queue.md` enforces this.
+- **Never use `gh run rerun <id>`** or any GitHub-side mutation — ci-watcher is read-only on workflow state.
+- **Never write `answered_by: "advisor" | "user"`** — only `"ci-watcher-self-resolved"` for self-resolution per `decision-queue.md` Attribution integrity.
+- **Never trust `gh run watch --exit-status`'s exit code** for pass/fail classification — always disambiguate via `gh run view <id> --json conclusion`.
+- **Never queue another Junior task** from inside this subagent. The advisor is the orchestrator.
+- **Never invoke `Agent(...)`** — subagents cannot nest.
+
+## Output discipline
+
+On completion (success path):
+1. One new resolved DQ entry of `kind: "validate-result"`, `result: "pass"`.
+2. Commit + push the DQ update to your worktree branch.
+3. Return a 3-line summary: workflow_run_id, branch, conclusion=success.
+
+On completion (failure path):
+1. One new pending DQ entry of `kind: "validate-failed"`, with `result` ∈ {fail, cancelled, timeout, gh_unauth, run_not_found}.
+2. For `result: "fail"`: `log_slice` is the last ~200 lines from `gh run view <id> --log-failed`; `failed_jobs` lists job names with conclusion=failure.
+3. Commit + push the DQ update.
+4. Return a 3-line summary: workflow_run_id, branch, result.
+
+Exit 0 in both paths. The advisor reads the DQ entry on its next polling tick; ci-watcher never blocks the worker slot beyond the long-poll itself (~10 sec model-time across 5–25 min wall-clock since `gh run watch` is a single long-poll, not repeated polling).

--- a/.claude/agents/ci-watcher.md
+++ b/.claude/agents/ci-watcher.md
@@ -37,9 +37,9 @@ gh run view <id> --repo barrie-cork/lemmy --json status,databaseId > /dev/null 2
 timeout 3600 gh run watch <id> --exit-status --repo barrie-cork/lemmy > /tmp/ci-watch.log 2>&1
 status=$?
 
-# 3. If shell-side timeout fired, write validate-failed result=timeout.
+# 3. If shell-side timeout fired, write validate-failed result=timed_out.
 if [ "$status" = "124" ]; then
-  # validate-failed result=timeout
+  # validate-failed result=timed_out (matches GitHub's conclusion enum spelling)
   ...
 fi
 
@@ -66,7 +66,7 @@ case "$conclusion" in
     # Write validate-failed result=cancelled to PENDING, commit + push, exit 0.
     ;;
   timed_out)
-    # Write validate-failed result=timeout to PENDING, commit + push, exit 0.
+    # Write validate-failed result=timed_out to PENDING, commit + push, exit 0.
     ;;
   *)
     # Anything else (action_required | neutral | skipped | stale | empty)
@@ -87,7 +87,7 @@ Captured during v1-validate-agent Task 2 empirical-gating against three real wor
 | In-progress watched live → failure         | 0         | `failure`                      | `validate-failed: fail`      |
 | Cancelled (deferred — conclusion-string fallback covers it; empirical probe deferred to next CR cycle) | (deferred) | `cancelled`                    | `validate-failed: cancelled` |
 | Queued-only (deferred — gh run watch blocks until terminal so it never returns while still-queued) | (deferred) | (none if still queued)         | (gh run watch blocks until terminal) |
-| 60-min wall-clock cap (shell-side `timeout 3600`) | 124       | (any non-terminal)             | `validate-failed: timeout`   |
+| 60-min wall-clock cap (shell-side `timeout 3600`) | 124       | (any non-terminal)             | `validate-failed: timed_out` |
 
 **Critical finding:** `gh run watch <id> --exit-status` returned exit 0 in all three observed terminal scenarios on gh CLI 2.89.0, despite the flag's `--help` text saying "Exit with non-zero status if run fails". **The exit code is unreliable for pass/fail classification.** ci-watcher MUST always run `gh run view <id> --json conclusion --jq '.conclusion'` post-watch and classify on the conclusion string. The exit code is captured for the polling-loop completion signal only (i.e. "the watch returned at all"), never for pass/fail.
 
@@ -124,7 +124,7 @@ Goes **directly to `resolved`**. Commit + push immediately per the mid-task disc
   "workflow_run_id": <id>,
   "branch": "<branch>",
   "phase_task": <task-number>,
-  "result": "fail" | "cancelled" | "timeout" | "gh_unauth" | "run_not_found",
+  "result": "fail" | "cancelled" | "timed_out" | "gh_unauth" | "run_not_found",
   "log_slice": "<last ~200 lines per failed job, or empty for non-fail results>",
   "failed_jobs": ["<job-name>", ...],
   "answer": null,
@@ -155,7 +155,7 @@ On completion (success path):
 3. Return a 3-line summary: workflow_run_id, branch, conclusion=success.
 
 On completion (failure path):
-1. One new pending DQ entry of `kind: "validate-failed"`, with `result` ∈ {fail, cancelled, timeout, gh_unauth, run_not_found}.
+1. One new pending DQ entry of `kind: "validate-failed"`, with `result` ∈ {fail, cancelled, timed_out, gh_unauth, run_not_found}.
 2. For `result: "fail"`: `log_slice` is the last ~200 lines from `gh run view <id> --log-failed`; `failed_jobs` lists job names with conclusion=failure.
 3. Commit + push the DQ update.
 4. Return a 3-line summary: workflow_run_id, branch, result.

--- a/.claude/agents/impl-task.md
+++ b/.claude/agents/impl-task.md
@@ -173,10 +173,14 @@ When the plan task touches diesel, actix-web, serde, activitypub-federation, or 
 ## Output discipline
 
 On completion (success):
-1. All per-task validation gates pass
-2. Commit chain is one feature commit + at most one `chore(lint):` follow-up
-3. Junior's finalize step pushes — do not push manually unless a DQ write requires it (see "Mid-task commit-and-push" above)
-4. Return a 5-line summary: task number, files changed (count), validation gates run (and pass/fail), commits made (short SHAs), any DQ entries written.
+1. **Validation mode** depends on the plan shape:
+   - **Shape-G plans** (v1-validate-agent onward; workflow-driven validation per §"Per-task validation gate"): the feature commit is pushed, the `workflow_run_id` is captured via `gh run list`, and one `kind: "validate-pending"` DQ entry is committed + pushed. Local cargo MUST NOT be invoked. ci-watcher polls async and writes the result; the impl-task subagent is done once the validate-pending entry is on the remote.
+   - **Pre-Shape-G plans** (v1-JM-d and earlier): the per-task validation gates named by the plan pass locally before commit (cargo check / clippy / test --no-run / e2e per the plan's §15). No DQ entry written for validation; advisor reads the commit subject.
+2. Commit chain is one feature commit + at most one `chore(lint):` follow-up.
+3. Pushing:
+   - Under Shape G: the impl-task pushes the feature commit AND the validate-pending DQ commit before exiting (manual push is mandatory — finalize is too late for the workflow_run_id capture).
+   - Pre-Shape-G: Junior's finalize step pushes — do not push manually unless a DQ write requires it (see "Mid-task commit-and-push" above).
+4. Return a 5-line summary: task number, files changed (count), validation mode (`shape-g pending` with workflow_run_id, or pre-shape-g `pass/fail` per gate), commits made (short SHAs), any DQ entries written (including the validate-pending entry under Shape G).
 
 On clean stop (DQ blocked or external constraint):
 1. No partial state in the working tree (`git status` clean)

--- a/.claude/agents/impl-task.md
+++ b/.claude/agents/impl-task.md
@@ -50,13 +50,69 @@ The advisor authorises forbidden-window runs via DQ override only — see `.clau
 
 The plan's task body cites MIRROR refs — file:line ranges in existing Lemmy code that demonstrate the pattern to follow. Read each MIRROR ref with the Read tool before editing. The plan tasks are pattern-following exercises by design — when you start improvising past the MIRROR, you are usually about to make a mistake. If the MIRROR doesn't actually demonstrate what the plan claims, queue a DQ entry rather than guess.
 
-## Per-task validation gate
+## Per-task validation gate (out-of-band on GH Actions)
 
-The plan §15 defines the validation commands. Run **only** the commands the plan names for this task — Level 1 (cargo check), Level 2 (e2e), Level 4 (migration round-trip), Level 5 (cross-cutting verify). Do not invent extra validation. If a command requires a wrapper (`./scripts/brehon/cargo-*.sh` on Linux, `.bat` on Windows), use that wrapper exactly as the plan names it.
+Validation runs out-of-band on GitHub Actions (Shape G, per
+`.claude/PRPs/plans/v1-validate-agent.plan.md`). After committing your
+work, push to your worktree branch and exit. Do NOT run cargo locally.
 
-Per `.claude/lessons/feedback_pipes_mask_exit_codes.md`, never pipe cargo through tail/head/grep when you need to know if it succeeded — capture the full output to a file with `> .claude/build-task<N>.log 2>&1` and check the exit code. Per `.claude/lessons/feedback_no_cargo_output_paste.md`, never paste cargo output into commit messages or DQ entries.
+After `git push`:
 
-If a validation command fails: fix the root cause and retry. Never accumulate broken state across commits. Per `.claude/lessons/feedback_test_impact_verification_before_patching.md`, when a test fails, identify the impact before changing the test — patching a test to pass is a process breach.
+1. Capture the workflow_run id:
+   ```bash
+   gh run list --branch <your-branch> --limit 1 \
+     --json databaseId --jq '.[0].databaseId'
+   ```
+   Retry with exponential backoff up to ~2 min if the run hasn't
+   appeared yet (push-to-trigger lag is normal).
+
+2. Append a `validate-pending` entry to `.claude/decision-queue.json`:
+   ```json
+   {
+     "id": <next>,
+     "from": "impl",
+     "kind": "validate-pending",
+     "timestamp": "<ISO 8601 UTC>",
+     "workflow_run_id": <id>,
+     "branch": "<your-branch>",
+     "phase_task": <task-number>,
+     "answer": null,
+     "answered_by": null,
+     "resolved_at": null
+   }
+   ```
+
+3. Commit + push the DQ update.
+
+4. Exit with success.
+
+The impl-task slot frees as soon as the push lands. ci-watcher polls
+the workflow asynchronously and writes the result back into the DQ.
+The advisor reads `validate-result` (pass) or `validate-failed`
+(fail/timeout) on its next polling tick.
+
+**Pre-Shape-G plans (v1-JM-d and earlier).** Plans authored before
+v1-validate-agent shipped use inline cargo invocation in their §15
+DoD entries. If your plan is one of those (jm-d-impl-1.md, jm-d-impl-3
+through jm-d-impl-7, all v1-JM-a/b/c briefs, all v1-AD-* briefs), run
+the cargo commands the plan names — wrapper-aware
+(`./scripts/brehon/cargo-*.sh` Linux, `.bat` Windows). Do not run
+cargo locally for plans authored under Shape G (v1-JM-e onward). The
+single bounded retrofit at `jm-d-impl-2.md` §5 is Shape-G-compliant
+ahead of when its parked Task 2 work is queued.
+
+Per `.claude/lessons/feedback_pipes_mask_exit_codes.md`, never pipe
+cargo through tail/head/grep when you need to know if it succeeded —
+applies to local cargo (pre-Shape-G plans) and to any local diagnostic
+runs the advisor authorises. Per
+`.claude/lessons/feedback_no_cargo_output_paste.md`, never paste cargo
+output into commit messages or DQ entries.
+
+If a validation command fails (locally or out-of-band): fix the root
+cause and retry. Never accumulate broken state across commits. Per
+`.claude/lessons/feedback_test_impact_verification_before_patching.md`,
+when a test fails, identify the impact before changing the test —
+patching a test to pass is a process breach.
 
 ## Story-checkpoint awareness (read-only at task start)
 
@@ -136,3 +192,4 @@ On clean stop (DQ blocked or external constraint):
 - Never queue another Junior task from inside this subagent
 - Never write `answered_by: "advisor"` in `decision-queue.json`
 - Never invoke `Agent(...)` — subagents cannot nest
+- Never invoke cargo for build/lint/test on Shape-G plans — validation runs out-of-band on GH Actions per the validation gate above

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -2,6 +2,22 @@
   "pending": [],
   "resolved": [
     {
+      "id": 68,
+      "from": "impl",
+      "kind": "log",
+      "timestamp": "2026-04-27T21:20:00Z",
+      "question": "Plan §13 Task 1 references `bash scripts/brehon/migrate-roundtrip.sh` as an existing script (per JM-d §10.6 / scheduled-tasks pattern), but the script doesn't exist in the repo and JM-d's plan does not contain it either — phantom dependency.",
+      "options": [
+        "(a) ship a stub migrate-roundtrip.sh that exits 0 when no migrations/ change detected and exits non-zero (forcing replacement) when a real migration appears",
+        "(b) inline the migration round-trip logic in cargo-validate-migration.yml itself",
+        "(c) delete cargo-validate-migration.yml and defer to v1-JM-e"
+      ],
+      "context": "Foreground impl session checked `ls scripts/brehon/` and `grep -rn 'migrate-roundtrip' scripts/` — both empty. JM-d plan does not author the script either. The migration workflow would be triggered only on `migrations/**` push, and v1-validate-agent ships no migrations, so the stub is non-binding for this sub-phase — v1-JM-e (or whichever sub-phase ships the first post-Shape-G migration) replaces the stub.",
+      "answer": "(a) — shipped stub at scripts/brehon/migrate-roundtrip.sh in same Task 1 commit. Exits non-zero if a real migration is detected vs governance-v0 (forcing the next migration-authoring sub-phase to replace it). Documented as planning-side gap for retro §5 watch-items.",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-04-27T21:20:00Z"
+    },
+    {
       "id": 67,
       "from": "advisor",
       "kind": "clarify",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -2,6 +2,21 @@
   "pending": [],
   "resolved": [
     {
+      "id": 70,
+      "from": "impl",
+      "kind": "log",
+      "timestamp": "2026-04-27T22:00:00Z",
+      "question": "Empirical probe of `gh run watch <id> --exit-status` on gh CLI 2.89.0 against three real workflow-run scenarios revealed it returns exit 0 for ALL three: (a) already-completed-success run (25017407689), (b) already-completed-failure run (25017407659), (c) in-progress run watched live to completion-failure (25017554049). The flag's --help text says 'Exit with non-zero status if run fails' but observed behaviour is exit 0 in all cases.",
+      "options": [
+        "(a) ci-watcher must NEVER trust --exit-status; instead always run `gh run view <id> --json conclusion --jq '.conclusion'` post-watch and branch on the conclusion string (success | failure | cancelled | timed_out | etc)",
+        "(b) report upstream gh CLI bug + add a workaround comment in ci-watcher.md citing the gh version it was tested against"
+      ],
+      "context": "Three probes captured during v1-validate-agent Task 2 empirical-gating. The defensive fallback in plan §10.6 — 'post-watch gh run view to disambiguate' — was framed as defensive; empirical evidence makes it MANDATORY. ci-watcher's exit-code table is therefore: 'exit code from gh run watch is unreliable; always disambiguate via gh run view conclusion'. The plan §4 watchpoint #1's whole purpose was to discover this before authoring ci-watcher.md.",
+      "answer": "(a) — ci-watcher MUST always run `gh run view <id> --json conclusion --jq '.conclusion'` after `gh run watch <id> --exit-status` returns; classify on the conclusion string, never on the exit code. The exit code is captured but treated as advisory only. The empirical exit-code table in ci-watcher.md §5 records: gh CLI 2.89.0 returns exit 0 for success/failure/in-progress→failure (3 probes). Cancelled and queued-only probes deferred — not blocking ci-watcher authoring because the conclusion-string fallback covers all conclusion values (success | failure | cancelled | timed_out | action_required | neutral | skipped | stale).",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-04-27T22:00:00Z"
+    },
+    {
       "id": 69,
       "from": "impl",
       "kind": "log",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -2,6 +2,21 @@
   "pending": [],
   "resolved": [
     {
+      "id": 69,
+      "from": "impl",
+      "kind": "log",
+      "timestamp": "2026-04-27T21:35:00Z",
+      "question": "Plan §13 Task 1 prescribes `cargo check --workspace --features full --no-deps` for the validate-workspace workflow, but `cargo check` does NOT accept `--no-deps` (that's a `cargo clippy` flag). First push to phase-v1-validate-agent failed at workflow run 25017407659 with: error: unexpected argument '--no-deps' found.",
+      "options": [
+        "(a) drop --no-deps from cargo check step; keep it on the cargo clippy step (where it's valid)",
+        "(b) replace cargo check with cargo clippy --no-deps to deduplicate (clippy implies check)"
+      ],
+      "context": "First test push to phase-v1-validate-agent failed after ~30s with the above error. The plan inherited the --no-deps flag from earlier-phase clippy DoD wording in §13 (where it's valid for clippy and prevents linting transitive deps). For `cargo check`, no such flag exists; check by default does not lint transitive deps the way clippy does, so the flag is meaningless even if it parsed.",
+      "answer": "(a) — dropped --no-deps from the cargo check step in cargo-validate-workspace.yml; left --no-deps on the cargo clippy step (valid + intentional per feedback_features_full_p_crate_incompatible.md). Plan §13 Task 1 IMPLEMENT block was wrong on this one flag. Surfaced for retro §5 watch-items as a planner DoD-discipline miss (the plan's own §15 dry-run did not catch this because it dry-runs YAML parse, not cargo invocation — confirms why empirical first-push validation matters).",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-04-27T21:35:00Z"
+    },
+    {
       "id": 68,
       "from": "impl",
       "kind": "log",

--- a/.claude/lessons/feedback_dtolnay_rust_toolchain_components_with_toml.md
+++ b/.claude/lessons/feedback_dtolnay_rust_toolchain_components_with_toml.md
@@ -1,0 +1,68 @@
+---
+name: dtolnay/rust-toolchain ignores `components:` input when rust-toolchain.toml pins a channel
+description: When a repo has rust-toolchain.toml pinning a specific Rust channel, the `components:` input on dtolnay/rust-toolchain@master is silently ignored. Add an explicit `rustup component add` step.
+type: feedback
+---
+
+Empirical finding from v1-validate-agent Task 1 (2026-04-27): the `dtolnay/rust-toolchain@master` GitHub Action does NOT honour the `components:` action input when the repository has a `rust-toolchain.toml` file pinning the channel.
+
+## What fails
+
+Workflow YAML using the action's intended pattern:
+
+```yaml
+- uses: dtolnay/rust-toolchain@master
+  with:
+    components: clippy
+```
+
+When `rust-toolchain.toml` exists and contains:
+
+```toml
+[toolchain]
+channel = "1.95"
+```
+
+The action installs the pinned `1.95` toolchain (correct) but does NOT install `clippy` (incorrect). Subsequent `cargo clippy` steps fail with:
+
+```
+error: 'cargo-clippy' is not installed for the toolchain '1.95-x86_64-unknown-linux-gnu'.
+       To install, run `rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu`.
+```
+
+## Why it slips through
+
+The `components:` input is documented as the canonical way to add components to the installed toolchain. Standard cache + checkout shape from existing workflows (e.g. `cargo-test-e2e.yml`) doesn't reveal the bug if those workflows don't actually invoke clippy. v1-validate-agent's `cargo-validate-workspace.yml` was the first Brehon workflow to need clippy on the pinned `1.95` toolchain, and the bug surfaced on first push.
+
+## How to apply
+
+For any workflow YAML that invokes `cargo clippy` (or any other component beyond `rustc` + `cargo`) on a repo with `rust-toolchain.toml` pinning a channel:
+
+1. Use `dtolnay/rust-toolchain@master` for the channel install (it reads `rust-toolchain.toml` correctly).
+2. **Add an explicit `rustup component add` step** for each required component, citing the pinned channel + target:
+
+```yaml
+- uses: dtolnay/rust-toolchain@master
+  with:
+    components: clippy   # NB: silently ignored when rust-toolchain.toml exists; kept for documentation
+
+- name: Install clippy for pinned toolchain
+  run: rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu
+```
+
+The redundant `with: components:` line is a documentation marker for future readers; the `rustup component add` line is what actually installs.
+
+## Generalises to
+
+- `rustfmt` for `cargo fmt --check` workflows.
+- `rust-src` for cross-compiled or `-Z` flag work.
+- Any other `rustup` component the action can technically install but won't when a `rust-toolchain.toml` pin is present.
+- The same pattern likely affects competing actions (`actions-rs/toolchain`, `actions-rust-lang/setup-rust-toolchain`) when they read a toolchain file — verify on first use.
+
+## Symptom to recognise
+
+CI fails on the first cargo invocation that uses the missing component, with a clear `'cargo-X' is not installed for the toolchain` error. The `with: components:` line in the YAML appears correct on inspection. Searching for the bug in the action's repo issues will surface it (this is a known behaviour, not a regression).
+
+## Where this came from
+
+v1-validate-agent commit `000f86093` (Task 2 fix-up). Workflow run `25017554049` failed with the missing-clippy error after `cargo check` passed; the fix added the explicit `rustup component add` step. The plan's §13 Task 1 IMPLEMENT block did not anticipate this — surfaced for retro §5 watch-items as a planning-side miss.

--- a/.claude/lessons/feedback_dtolnay_rust_toolchain_components_with_toml.md
+++ b/.claude/lessons/feedback_dtolnay_rust_toolchain_components_with_toml.md
@@ -39,18 +39,22 @@ The `components:` input is documented as the canonical way to add components to 
 For any workflow YAML that invokes `cargo clippy` (or any other component beyond `rustc` + `cargo`) on a repo with `rust-toolchain.toml` pinning a channel:
 
 1. Use `dtolnay/rust-toolchain@master` for the channel install (it reads `rust-toolchain.toml` correctly).
-2. **Add an explicit `rustup component add` step** for each required component, citing the pinned channel + target:
+2. **Add an explicit `rustup component add` step** that derives the toolchain dynamically from `rustup show active-toolchain` — this tracks `rust-toolchain.toml` automatically across channel bumps and runner-target changes:
 
 ```yaml
 - uses: dtolnay/rust-toolchain@master
   with:
     components: clippy   # NB: silently ignored when rust-toolchain.toml exists; kept for documentation
 
-- name: Install clippy for pinned toolchain
-  run: rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu
+- name: Install clippy for active toolchain
+  run: |
+    toolchain="$(rustup show active-toolchain | awk '{print $1}')"
+    rustup component add clippy --toolchain "$toolchain"
 ```
 
 The redundant `with: components:` line is a documentation marker for future readers; the `rustup component add` line is what actually installs.
+
+**Anti-pattern to avoid:** hard-coding the toolchain version + triple in the `rustup component add` line (e.g. `rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu`). This breaks silently when `rust-toolchain.toml` is bumped to 1.96 (clippy installs into the wrong toolchain; the actual active one still has none) or when the runner target changes (e.g. `aarch64-unknown-linux-gnu` for arm64 runners). Always derive from `rustup show active-toolchain`. CR finding cr-4 on PR #104 caught the hard-coded form.
 
 ## Generalises to
 

--- a/.claude/lessons/feedback_gh_run_watch_exit_status_unreliable.md
+++ b/.claude/lessons/feedback_gh_run_watch_exit_status_unreliable.md
@@ -1,0 +1,48 @@
+---
+name: gh run watch --exit-status returns 0 in observed terminal scenarios on gh CLI 2.89.0
+description: Empirical probes show gh run watch --exit-status returns exit 0 for completed-success, completed-failure, and in-progress→failure-watched-live runs despite docs saying otherwise. Always disambiguate via gh run view --json conclusion.
+type: feedback
+---
+
+Empirical finding from v1-validate-agent Task 2 (2026-04-27): on gh CLI 2.89.0, `gh run watch <id> --exit-status` returns **exit 0** in all three observed terminal scenarios:
+
+1. Run already completed with `conclusion: success` (probe target: 25017407689) — exit 0.
+2. Run already completed with `conclusion: failure` (probe target: 25017407659) — exit 0.
+3. Run in-progress at start, watched live until completion with `conclusion: failure` (probe target: 25017554049) — exit 0.
+
+The flag's `--help` text says: "Exit with non-zero status if run fails." Observed behaviour contradicts that line.
+
+## Why this matters
+
+A polling agent that branches on `gh run watch --exit-status`'s exit code without disambiguation will classify every workflow run as success — false-green. v1-validate-agent's ci-watcher subagent depends on workflow-conclusion classification to write `validate-result` (pass) vs `validate-failed` (fail) DQ entries; getting this wrong means the advisor's polling loop reads pass for a failed cargo build and advances the §13-task pipeline against broken code.
+
+## How to apply
+
+Any subagent, script, or workflow that watches a GitHub Actions run via `gh run watch --exit-status`:
+
+1. Run `gh run watch <id> --exit-status` and capture the exit code (advisory only).
+2. **Always** follow with `gh run view <id> --json conclusion --jq '.conclusion'` and branch on the **conclusion string**, not the exit code.
+3. Conclusion values to expect: `success | failure | cancelled | timed_out | action_required | neutral | skipped | stale`.
+4. The exit code is informational; treat as advisory in case future gh CLI versions fix the bug.
+
+```bash
+gh run watch <id> --exit-status; status=$?
+conclusion=$(gh run view <id> --json conclusion --jq '.conclusion')
+case "$conclusion" in
+  success) ;;  # pass path
+  failure|cancelled|timed_out) ;;  # fail path
+  *) ;;  # classifier-miss → catch-fire
+esac
+```
+
+## Generalises to
+
+Any version-pinned `gh` CLI behaviour. Documented behaviour and `--help` text are insufficient signals. Empirically validate on the gh CLI version the agent runs against before authoring classifier logic. The same caution applies to other CLIs whose `--exit-status`-style flags are documented but rarely tested under real terminal-state matrices.
+
+## Symptom to recognise
+
+A polling agent silently classifies a known-failed workflow run as pass, and downstream consumers (advisor stage-shape, retro reports) read green for a red run. The agent's logs show "exit 0" but the GitHub UI shows the run failed. If you see this divergence, the exit code is lying — switch to conclusion-string disambiguation.
+
+## Where this came from
+
+DQ #70 (impl-self-resolved 2026-04-27, v1-validate-agent Task 2). Probes captured in `.claude/PRPs/debug/v1-validate-agent-task2-gh-run-watch-probes.log` (gitignored as `*.log`). The plan's §4 watchpoint #1 mandated empirical validation precisely because public docs were silent on success/timeout/cancelled exit semantics; the empirical pass found the bug before ci-watcher.md shipped, so the subagent's body now treats `gh run view` conclusion as authoritative and the watch exit code as informational.

--- a/.claude/lessons/feedback_planner_dod_dry_run_caught_partial.md
+++ b/.claude/lessons/feedback_planner_dod_dry_run_caught_partial.md
@@ -1,0 +1,68 @@
+---
+name: §15 dry-run catches YAML parse but misses invalid cargo flags inside YAML run: bodies
+description: Plan §15 dry-run discipline (yamllint / gh workflow view) catches YAML parse errors but cannot catch invalid cargo flags inside the YAML's `run:` body — first-push validation is the real gate.
+type: feedback
+---
+
+The plan-side §15 dry-run discipline (per `feedback_pre_phase_dod_smoke_test.md` + `feedback_plan_dod_dry_run_at_write.md`) catches YAML structural errors and missing files, but cannot catch invalid cargo flags embedded as shell strings inside a `run:` body. End-to-end validation requires a real first-push run on the GitHub-hosted runner.
+
+## Concrete failure
+
+v1-validate-agent plan §13 Task 1 IMPLEMENT block prescribed:
+
+```yaml
+- name: cargo check workspace + features full
+  run: cargo check --workspace --features full --no-deps
+```
+
+The plan's §15.1 dry-run shape was `gh workflow view --yaml ...` exit 0 OR `yamllint <path>` exit 0. Both pass — the YAML is well-formed, the file path is valid. But `cargo check` does NOT accept `--no-deps`; that flag is `cargo clippy`-only. The plan inherited `--no-deps` from clippy DoD wording in earlier phases where it was valid.
+
+First push to `phase-v1-validate-agent` failed at workflow run `25017407659` after ~30 seconds with:
+
+```
+error: unexpected argument '--no-deps' found
+```
+
+## Why this is a class of failure, not a one-off
+
+Plan §15 dry-run validates:
+- YAML syntactic structure (parse-able)
+- File existence at the path
+- Tool availability (`gh workflow view --help`, `yamllint --version`)
+
+Plan §15 dry-run does NOT validate:
+- The semantic correctness of any shell command nested inside a YAML `run:` body
+- Whether the cargo subcommand accepts the flags passed to it
+- Whether environment-dependent behaviour (toolchain components, cached dependencies, libpq discovery) actually works on the runner
+
+The semantic checks are runtime concerns — they only surface on a real workflow run.
+
+## How to apply
+
+For Shape G plans (workflow-driven validation):
+
+1. **Plan-side dry-run remains necessary** — yamllint / gh workflow view exit 0 catches the bulk of malformed-YAML errors before push.
+2. **The first push to the phase branch is the real gate.** Treat it as a probe: expect failure, capture the failure mode, fix-and-push.
+3. Plan-write should **explicitly call out** that DoD validity for cargo flag combinations is unverifiable until first push. Phrase §15 entries as "expected to pass on first push; if not, fix-up commit lands before the next task."
+4. Never hand-derive flag combinations from clippy DoD wording without verifying the flag exists for the subcommand. `cargo check`, `cargo clippy`, `cargo build`, `cargo test`, `cargo doc` all have distinct flag sets despite sharing many.
+
+## Generalises to
+
+Any DoD command that's a shell string nested inside a configuration file the planner doesn't actually execute at plan-write time:
+- GitHub Actions workflow `run:` bodies
+- Docker `RUN` lines in a Dockerfile
+- shell stanzas in CI YAMLs (CircleCI, GitLab CI, Buildkite)
+- npm `scripts:` entries the planner doesn't run via `npm run`
+- Makefile recipes referenced by name
+
+The dry-run validates the wrapper (the YAML / Dockerfile / Makefile parses) but cannot validate the wrapped command (the shell string is correct).
+
+## Symptom to recognise
+
+A plan ships, the phase branch is cut, the first impl-task push triggers the workflow, and the workflow fails ~30 seconds in with a flag-parsing error from cargo / docker / npm / make. The plan's §15 dry-run output was clean. The §16a Story 1 acceptance fails on first push but passes after a fix-up commit.
+
+This is not a planner-quality problem — it's an inherent limitation of plan-side dry-run for nested-shell DoD. The retro should treat first-push fix-ups as routine, not as planner failures, and capture the specific class of fix as a watch-item for the next sub-phase under the same shape.
+
+## Where this came from
+
+DQ #69 (impl-self-resolved 2026-04-27, v1-validate-agent). Fix-up commit `ed049970b` dropped `--no-deps` from the cargo check step. The `--no-deps` flag remained on the cargo clippy step where it's valid and intentional (per `feedback_features_full_p_crate_incompatible.md`).

--- a/.claude/rules/advisor-orchestrator.md
+++ b/.claude/rules/advisor-orchestrator.md
@@ -331,7 +331,7 @@ Stop the loop and surface to user immediately if:
 - A `bm-task` opens a PR into `main` instead of `governance-v0`.
 - The phase branch has uncommitted state when a Junior task reports complete (Junior's finalize push should have flushed it).
 - Rust-analyzer-lsp is missing on the EliteDesk daemon and a `planning` or `impl-task` task that depended on `LSP` returns failed.
-- A workflow run exceeds the 60-min ci-watcher cap → ci-watcher writes `kind: "validate-failed"` with `result: "timeout"`. Surface to user with the workflow run id and the elapsed wall-clock; do not auto-rerun.
+- A workflow run exceeds the 60-min ci-watcher cap → ci-watcher writes `kind: "validate-failed"` with `result: "timed_out"` (matches GitHub's conclusion enum spelling). Surface to user with the workflow run id and the elapsed wall-clock; do not auto-rerun.
 - ci-watcher's `gh run watch <id> --exit-status` returns an exit code not enumerated in the empirical exit-code table at `.claude/agents/ci-watcher.md` "Empirical exit-code table" — surface as classifier-miss with the observed exit code, the workflow run id, and the run's `gh run view <id> --json status,conclusion` snapshot. The exit-code table is grow-on-evidence; record the new pair (exit_code → conclusion) and update the table at retro time.
 
 For each, include the catch-fire reason and the rule it violated in the surfaced message.

--- a/.claude/rules/advisor-orchestrator.md
+++ b/.claude/rules/advisor-orchestrator.md
@@ -87,6 +87,8 @@ Before queueing any new `impl-task`, the advisor checks current UTC time. If in 
 
 This is mechanical, not heuristic — the advisor decides by reading the table above + `date -u`.
 
+**Shape G note:** under Shape G (v1-validate-agent onward), cargo no longer runs locally for impl-task throughput — the workflow YAMLs at `.github/workflows/cargo-validate-*.yml` run cargo on GitHub-hosted runners (off-box, ephemeral). Forbidden windows are non-binding for Shape-G impl-task dispatch. They remain binding for: (a) ad-hoc local cargo validation by the advisor pre-plan-approval (DoD smoke test), (b) pre-Shape-G plan dispatches (v1-JM-d and earlier impl-task briefs that still run cargo locally), (c) any local diagnostic cargo run authorised by the user during a CR fix-in-PR cycle.
+
 ### Subagent enforcement (defence in depth)
 
 The `impl-task` subagent's task-0 pre-flight check (per `.claude/agents/impl-task.md`) refuses to start work in a forbidden window and exits non-zero with `FORBIDDEN_WINDOW: <window>`. This catches the case where the advisor mistakenly queues during a forbidden window (e.g. cron table out of sync, daylight-saving edge case).
@@ -194,7 +196,9 @@ Per the c-inherited-dragon plan's "Stages of a sub-phase" map, the advisor knows
 - **Brief authored, no planning task yet** → run `/brehon-clarify .claude/PRPs/briefs/<phase>-planning-N.md` → resolve every clarify-DQ entry (advisor-mode for evident, user-relay for judgment-heavy) → only then queue the planning task. Skipping `/brehon-clarify` on a planning brief is a process breach the advisor must justify in the planning task's commit body.
 - **Planning complete** → run DoD smoke test → run watchpoint-specificity gate → surface to user → on user approval, queue `bm-cut` to make the phase branch
 - **bm-cut complete** → queue impl per **Cohort dispatch** (next section): if plan §13 Task 1 (or first non-pre-flight task) carries `[P]`, compute the cohort and queue all members simultaneously; otherwise queue Task 1 alone.
-- **Each impl-task complete** → check plan task list; **if cohort still has pending peers, wait** for all-complete before computing next cohort; otherwise compute next cohort starting from the next pending task. If all tasks done, queue `bm-cut` follow-up (`chore(lint):` if needed) then `bm-pr`.
+- **Each impl-task complete (under pre-Shape-G plans, v1-JM-d and earlier)** → check plan task list; **if cohort still has pending peers, wait** for all-complete before computing next cohort; otherwise compute next cohort starting from the next pending task. If all tasks done, queue `bm-cut` follow-up (`chore(lint):` if needed) then `bm-pr`.
+- **Each impl-task complete (under Shape G, v1-JM-e onward)** → impl-task already wrote a `kind: "validate-pending"` DQ entry post-push containing `workflow_run_id` + `branch` + `phase_task`; queue a `[role:ci-watcher]` Junior task with brief filled from the DQ entry's fields (template at `.claude/PRPs/templates/ci-watcher-brief.template.md`). The originating impl-task stays gated until ci-watcher resolves. ci-watcher runs ~10 sec model-time during the long-poll; the cargo work itself is GitHub-runner-side.
+- **ci-watcher complete** → read the resulting DQ entry. If `kind: "validate-result"` (`result: "pass"`), advance per the cohort/task pipeline (same logic as the pre-Shape-G "Each impl-task complete" rule above). If `kind: "validate-failed"`, run the §G4 classifier (see "§G4 classifier" sub-section below): allowlist match (≤3 file edits + clippy auto-fix or missing import or deprecated API) → queue narrow fix-impl-task brief; else → catch-fire to user with the `log_slice` + `failed_jobs`.
 - **All §16a stories `[done]`** (between last impl complete and bm-merge confirm) → run `/brehon-verify` → if any phantom, surface to user via catch-fire; otherwise advance to bm-pr stages below
 - **bm-pr complete** → wait for CodeRabbit (`bm-task` polls) → on CR posted, queue `bm-poll-cr`
 - **bm-poll-cr complete** → queue `bm-triage` (draft auto)
@@ -241,6 +245,65 @@ When a plan §13 task carries `[P]` and is the next pending task, the advisor co
 
 If a plan §13 has no `[P]` annotations (legacy plans pre-this-rule, or plans where the planner judged no parallelism was safe), every task is treated as non-`[P]` and dispatched serially. The cohort-dispatch logic does not broaden serial dispatch into accidental parallel — `[P]` must be explicit.
 
+### Cohort dispatch under Shape G (parallel validate-pending)
+
+Under Shape G (v1-JM-e onward), cohort members each enter
+`kind: "validate-pending"` simultaneously after their respective
+push — one workflow run per cohort task, fanned out on GitHub-hosted
+runners. The advisor dispatches one `[role:ci-watcher]` Junior task
+per `validate-pending` entry. Cohort advancement waits for **all**
+cohort members to reach `kind: "validate-result"` with `result:
+"pass"`. A single `kind: "validate-failed"` in the cohort blocks
+advancement and triggers the §G4 classifier per the validate-stage
+Stage-shape rule. If multiple cohort members fail simultaneously,
+classify each independently — auto-queue allowlist matches as
+parallel fix-impl-tasks (each forming its own [P]-marker degenerate
+cohort), surface non-allowlist failures to user as a single
+catch-fire bundle.
+
+## §G4 classifier
+
+Per `.claude/PRPs/plans/v1-validate-agent.plan.md` §4 watchpoint #7
++ §10.9. When a `kind: "validate-failed"` DQ entry surfaces, the
+advisor reads its `result`, `log_slice`, and `failed_jobs`, then
+applies the classifier:
+
+**Allowlist (auto-queue narrow fix-impl-task, ≤3 file edits):**
+
+| Failure signature | Auto-fix | Source lesson |
+|---|---|---|
+| `clippy::doc_lazy_continuation` warning | reword + mid-paragraph "and" | `feedback_clippy_doc_lazy_continuation_in_doc_comments.md` |
+| `error[E0432]: unresolved import` | add the missing `use` per the suggestion | n/a (mechanical) |
+| `warning: use of deprecated <api>` | replace with the suggested replacement | n/a (mechanical) |
+
+For an allowlist match, the advisor authors a narrow fix-impl-task
+brief at `.claude/PRPs/briefs/<phase>-fix-impl-<n>.md` containing:
+the failed-job log slice (≤200 lines), the specific file:line cited
+by the lint, the auto-fix recipe from the source lesson (or
+mechanical replacement), and a hard cap "≤3 file edits". The brief
+is dispatched as a normal `[role:impl-task]` Junior task; the
+resulting commit lands on the phase branch and re-triggers the
+workflow.
+
+**Non-allowlist (catch-fire to user):**
+
+- compile errors (any `error[E*]` other than `E0432`)
+- test failures (panics, assertion fails, e2e flakes, testcontainers
+  issues)
+- timeout / OOM / runner death
+- any failure whose log slice doesn't match a row in the allowlist
+
+Surface as: "validate-failed on `<branch>` (workflow run `<id>`):
+non-allowlist failure. Failed jobs: `<failed_jobs>`. Log slice
+attached. Surfaced to user — no auto-fix attempted."
+
+The allowlist is **conservative by design** (per
+`feedback_principles_not_rules.md` — guidance over rigid rules).
+Grow it only on retro evidence: if a CR-triage cycle classifies a
+non-allowlist failure as "this could have been auto-fixed", record
+it in the retro §5 watch-items and add to the allowlist on the next
+sub-phase's plan if the pattern reproduces.
+
 ## Verify gate (post-impl, pre-merge)
 
 Per `.claude/commands/brehon-verify.md` (spec-kit pattern adoption — `feedback_brehon_verify_pre_merge.md`):
@@ -268,6 +331,8 @@ Stop the loop and surface to user immediately if:
 - A `bm-task` opens a PR into `main` instead of `governance-v0`.
 - The phase branch has uncommitted state when a Junior task reports complete (Junior's finalize push should have flushed it).
 - Rust-analyzer-lsp is missing on the EliteDesk daemon and a `planning` or `impl-task` task that depended on `LSP` returns failed.
+- A workflow run exceeds the 60-min ci-watcher cap → ci-watcher writes `kind: "validate-failed"` with `result: "timeout"`. Surface to user with the workflow run id and the elapsed wall-clock; do not auto-rerun.
+- ci-watcher's `gh run watch <id> --exit-status` returns an exit code not enumerated in the empirical exit-code table at `.claude/agents/ci-watcher.md` "Empirical exit-code table" — surface as classifier-miss with the observed exit code, the workflow run id, and the run's `gh run view <id> --json status,conclusion` snapshot. The exit-code table is grow-on-evidence; record the new pair (exit_code → conclusion) and update the table at retro time.
 
 For each, include the catch-fire reason and the rule it violated in the surfaced message.
 

--- a/.claude/rules/decision-queue.md
+++ b/.claude/rules/decision-queue.md
@@ -184,21 +184,33 @@ polling loop applies different routing per kind.
   reads this entry and dispatches a `[role:ci-watcher]` Junior task
   to poll the workflow run. The originating impl-task is gated until
   ci-watcher resolves. Writer: **impl-task only**.
-- **`kind: "validate-result"`** — the ci-watcher subagent observed
-  workflow conclusion `success` via `gh run watch <id> --exit-status`.
-  Goes **directly to `resolved`** with `from: "ci-watcher"`,
-  `answered_by: "ci-watcher-self-resolved"`, `result: "pass"`. The
-  advisor reads this entry and advances the §13-task pipeline (cohort
-  check). Writer: **ci-watcher only**.
-- **`kind: "validate-failed"`** — the ci-watcher subagent observed
-  workflow conclusion `failure | cancelled | timeout` (or hit its own
-  60-min wall-clock cap). Goes to `pending` with `from: "ci-watcher"`,
-  `answered_by: null`, `result: "fail" | "cancelled" | "timeout" |
-  "gh_unauth"`. Required fields when `result: "fail"`: `log_slice`
-  (last ~200 lines per failed job), `failed_jobs` (array of job
-  names). The advisor reads this entry, runs the §G4 classifier
-  (auto-queue fix-impl-task for allowlist matches ≤3 file edits, else
-  catch-fire). Writer: **ci-watcher only**.
+- **`kind: "validate-result"`** — the ci-watcher subagent classified
+  the workflow after reading `conclusion: "success"` from
+  `gh run view <id> --json conclusion` (do NOT rely on
+  `gh run watch <id> --exit-status` for final classification — per
+  `feedback_gh_run_watch_exit_status_unreliable.md`, the exit code is
+  unreliable on gh CLI 2.89.0). Goes **directly to `resolved`** with
+  `from: "ci-watcher"`, `answered_by: "ci-watcher-self-resolved"`,
+  `result: "pass"`. The advisor reads this entry and advances the
+  §13-task pipeline (cohort check). Writer: **ci-watcher only**.
+- **`kind: "validate-failed"`** — the ci-watcher subagent classified
+  the workflow after reading `conclusion: "failure" | "cancelled" |
+  "timed_out"` from `gh run view <id> --json conclusion` (or hit its
+  own 60-min wall-clock cap, or the run was unreachable). Goes to
+  `pending` with `from: "ci-watcher"`, `answered_by: null`,
+  `result: "fail" | "cancelled" | "timed_out" | "gh_unauth" | "run_not_found"`.
+  Required fields when `result: "fail"`: `log_slice` (last ~200 lines
+  per failed job), `failed_jobs` (array of job names). The advisor
+  reads this entry, runs the §G4 classifier (auto-queue fix-impl-task
+  for allowlist matches ≤3 file edits, else catch-fire). Writer:
+  **ci-watcher only**.
+
+> **Note on enum values:** GitHub's workflow `conclusion` API returns
+> `timed_out` (with underscore) for timeout state — the `result` enum
+> mirrors GitHub's exact spelling. `run_not_found` covers the case
+> where `gh run view <id>` fails with run-not-found (e.g. wrong
+> branch, run garbage-collected, GitHub-side eviction); ci-watcher's
+> pre-flight run-existence check writes this result and exits 0.
 
 Use `kind: "log"` instead of writing a `LESSON:` commit-trailer when
 the finding is gated to a specific question/decision pattern. Use a
@@ -382,7 +394,7 @@ These are the recurring failure modes the audit and Phase-6 #37 incident produce
 4. **NEVER skip the mid-task commit + push** for a Junior worktree write. Without the push, the entry is trapped on the worktree until Junior's finalize step. The advisor cannot see it. (See "Mid-task visibility" below for the full mechanism.)
 5. **NEVER ask open-ended questions.** Always provide at least two concrete `options`. "What should I do?" is not a question; "should I take option-A (use feature X) or option-B (use feature Y) given <evidence>" is.
 6. **NEVER write `kind: "clarify"` from a non-advisor session.** That kind is advisor-only — produced by `/brehon-clarify` at the pre-planning gate. A Junior subagent that writes `kind: "clarify"` has misunderstood the workflow (impl-task ambiguity → `kind: "blocker"` from `from: "impl"`; brief ambiguity at planning time is the advisor's responsibility, not the planner's).
-7. **NEVER write `kind: "validate-result" | "validate-failed"` from a non-ci-watcher session.** Those kinds are ci-watcher-only — produced by polling a workflow run via `gh run watch <id> --exit-status`. impl-task writes `kind: "validate-pending"` (with `from: "impl"`); ci-watcher writes the result/failed sibling entries (with `from: "ci-watcher"`). Cross-role authoring is a process breach.
+7. **NEVER write `kind: "validate-result" | "validate-failed"` from a non-ci-watcher session.** Those kinds are ci-watcher-only — produced by ci-watcher reading `conclusion` via `gh run view <id> --json conclusion` after a `gh run watch <id> --exit-status` long-poll (the watch is for blocking, not for classification — see `feedback_gh_run_watch_exit_status_unreliable.md`). impl-task writes `kind: "validate-pending"` (with `from: "impl"`); ci-watcher writes the result/failed sibling entries (with `from: "ci-watcher"`). Cross-role authoring is a process breach.
 
 ## After writing a question
 
@@ -533,7 +545,7 @@ identity determines which `from` value is valid:
   `kind: "validate-result"` (always to `resolved` with
   `answered_by: "ci-watcher-self-resolved"`, `result: "pass"`) or
   `kind: "validate-failed"` (to `pending` with `answered_by: null`,
-  `result: "fail" | "cancelled" | "timeout" | "gh_unauth"`,
+  `result: "fail" | "cancelled" | "timed_out" | "gh_unauth" | "run_not_found"`,
   `log_slice`, `failed_jobs`). Pinned to Haiku 4.5, narrow-tools
   (Read, Edit, Write, Bash). Never invokes cargo, never edits code
   in `crates/` / `migrations/` / `tests/` / `docs/` / `.github/

--- a/.claude/rules/decision-queue.md
+++ b/.claude/rules/decision-queue.md
@@ -144,7 +144,7 @@ Keep `question` under 50 words. Put evidence in `context`, not in the
 question. Always provide at least two concrete `options` — never ask
 open-ended questions.
 
-## kind: "blocker" vs "log" vs "clarify"
+## kind: "blocker" vs "log" vs "clarify" vs "validate-pending" vs "validate-result" vs "validate-failed"
 
 The `kind` field separates entries by what they gate and who writes
 them. All go in `decision-queue.json` so they're committed/pushed
@@ -174,6 +174,31 @@ polling loop applies different routing per kind.
   **advisor only** — never impl, bm, or planner. Produced by
   `/brehon-clarify` (per `.claude/commands/brehon-clarify.md` and
   `feedback_clarify_before_plan.md`).
+- **`kind: "validate-pending"`** — the impl-task subagent committed
+  + pushed and is awaiting out-of-band cargo validation on GitHub
+  Actions (Shape G, per `v1-validate-agent.plan.md` §4 + §10.7). Goes
+  to `pending` with `from: "impl"`, `answered_by: null`. Required
+  fields: `workflow_run_id` (integer, captured via `gh run list
+  --branch <branch> --limit 1 --json databaseId`), `branch`,
+  `phase_task` (the §13 task number). The advisor's polling loop
+  reads this entry and dispatches a `[role:ci-watcher]` Junior task
+  to poll the workflow run. The originating impl-task is gated until
+  ci-watcher resolves. Writer: **impl-task only**.
+- **`kind: "validate-result"`** — the ci-watcher subagent observed
+  workflow conclusion `success` via `gh run watch <id> --exit-status`.
+  Goes **directly to `resolved`** with `from: "ci-watcher"`,
+  `answered_by: "ci-watcher-self-resolved"`, `result: "pass"`. The
+  advisor reads this entry and advances the §13-task pipeline (cohort
+  check). Writer: **ci-watcher only**.
+- **`kind: "validate-failed"`** — the ci-watcher subagent observed
+  workflow conclusion `failure | cancelled | timeout` (or hit its own
+  60-min wall-clock cap). Goes to `pending` with `from: "ci-watcher"`,
+  `answered_by: null`, `result: "fail" | "cancelled" | "timeout" |
+  "gh_unauth"`. Required fields when `result: "fail"`: `log_slice`
+  (last ~200 lines per failed job), `failed_jobs` (array of job
+  names). The advisor reads this entry, runs the §G4 classifier
+  (auto-queue fix-impl-task for allowlist matches ≤3 file edits, else
+  catch-fire). Writer: **ci-watcher only**.
 
 Use `kind: "log"` instead of writing a `LESSON:` commit-trailer when
 the finding is gated to a specific question/decision pattern. Use a
@@ -206,6 +231,29 @@ The advisor's polling loop reads `decision-queue.json` and routes by
   planning task is gated until every clarify-pending on the brief is
   resolved.
 - `(clarify, resolved)` — historical record. No action.
+- `(validate-pending, pending)` — advisor dispatches a
+  `[role:ci-watcher]` Junior task with brief filled from the entry's
+  `workflow_run_id` + `branch` + `phase_task`. The originating
+  impl-task stays gated until ci-watcher resolves. Per
+  `advisor-orchestrator.md` Stage-shape "Each impl-task complete
+  (under Shape G)".
+- `(validate-pending, resolved)` — historical record only (the
+  validate-pending entry was superseded by a sibling `validate-result`
+  or `validate-failed` entry; the resolved transition is bookkeeping).
+- `(validate-result, resolved)` — advisor reads `result: "pass"` and
+  advances the §13-task pipeline (cohort check). No mid-loop user
+  surfacing.
+- `(validate-result, pending)` — **schema breach** (validate-result
+  entries are always self-resolved by ci-watcher). Surface as
+  catch-fire.
+- `(validate-failed, pending)` — advisor runs the §G4 classifier:
+  if the failure matches the allowlist (≤3 file edits + clippy
+  auto-fix or missing import or deprecated API), auto-queue a narrow
+  fix-impl-task; else surface to user as catch-fire with the
+  `log_slice` + `failed_jobs`. Per `advisor-orchestrator.md`
+  "§G4 classifier" sub-section.
+- `(validate-failed, resolved)` — historical record only (the failure
+  was triaged + addressed in a follow-up commit/cohort).
 
 ## Recipes (copy-pasteable)
 
@@ -334,6 +382,7 @@ These are the recurring failure modes the audit and Phase-6 #37 incident produce
 4. **NEVER skip the mid-task commit + push** for a Junior worktree write. Without the push, the entry is trapped on the worktree until Junior's finalize step. The advisor cannot see it. (See "Mid-task visibility" below for the full mechanism.)
 5. **NEVER ask open-ended questions.** Always provide at least two concrete `options`. "What should I do?" is not a question; "should I take option-A (use feature X) or option-B (use feature Y) given <evidence>" is.
 6. **NEVER write `kind: "clarify"` from a non-advisor session.** That kind is advisor-only — produced by `/brehon-clarify` at the pre-planning gate. A Junior subagent that writes `kind: "clarify"` has misunderstood the workflow (impl-task ambiguity → `kind: "blocker"` from `from: "impl"`; brief ambiguity at planning time is the advisor's responsibility, not the planner's).
+7. **NEVER write `kind: "validate-result" | "validate-failed"` from a non-ci-watcher session.** Those kinds are ci-watcher-only — produced by polling a workflow run via `gh run watch <id> --exit-status`. impl-task writes `kind: "validate-pending"` (with `from: "impl"`); ci-watcher writes the result/failed sibling entries (with `from: "ci-watcher"`). Cross-role authoring is a process breach.
 
 ## After writing a question
 
@@ -462,8 +511,8 @@ restoring visibility.
 ## Subagents and attribution
 
 Junior dispatches tasks to subagents named in the dispatch line
-(`[role:planning|impl-task|bm-task]`). The subagent's identity
-determines which `from` value is valid:
+(`[role:planning|impl-task|bm-task|ci-watcher]`). The subagent's
+identity determines which `from` value is valid:
 
 - `planning` subagent → `from: "planner"`. May pre-seed `pending` or
   `resolved` entries with `answered_by: "planner"` (forward-looking
@@ -471,11 +520,25 @@ determines which `from` value is valid:
   or `kind: "log"`.
 - `impl-task` subagent → `from: "impl"`. Pending entries only —
   `answered_by: null`. Self-resolve only with
-  `answered_by: "impl-self-resolved"`. Writes `kind: "blocker"` or
-  `kind: "log"`.
+  `answered_by: "impl-self-resolved"`. Writes `kind: "blocker"`,
+  `kind: "log"`, or `kind: "validate-pending"` (the last one
+  introduced by Shape G in v1-validate-agent — the post-push
+  validation handoff). impl-task continues writing as `from: "impl"`
+  even when the entry carries `kind: "validate-pending"` (per DQ
+  #63); the new `from: "ci-watcher"` is ci-watcher's only.
 - `bm-task` subagent → `from: "bm"`. Pending entries with
   `answered_by: null`, or self-resolve as `"bm-self-resolved"`. Writes
   `kind: "blocker"` or `kind: "log"`.
+- `ci-watcher` subagent → `from: "ci-watcher"`. Writes
+  `kind: "validate-result"` (always to `resolved` with
+  `answered_by: "ci-watcher-self-resolved"`, `result: "pass"`) or
+  `kind: "validate-failed"` (to `pending` with `answered_by: null`,
+  `result: "fail" | "cancelled" | "timeout" | "gh_unauth"`,
+  `log_slice`, `failed_jobs`). Pinned to Haiku 4.5, narrow-tools
+  (Read, Edit, Write, Bash). Never invokes cargo, never edits code
+  in `crates/` / `migrations/` / `tests/` / `docs/` / `.github/
+  workflows/`, never applies clippy auto-fixes (those are advisor
+  §G4 classifier work). Per `.claude/agents/ci-watcher.md`.
 - **Advisor session** (homeserver, persistent, never on Junior worktree)
   → `from: "advisor"`. Writes the full triage spectrum: answers to
   pending blockers (`answered_by: "advisor"` on resolved entries from
@@ -490,5 +553,6 @@ by the persistent advisor session (label: `advisor`) or for entries
 where the advisor relayed a user reply in-channel (label: `user`).
 None of the Junior subagents may write `kind: "clarify"` — that kind
 is advisor-only by design (clarify gates planning before any Junior
-task runs). This rule applies to both foreground and Junior-dispatched
-invocations.
+task runs). Only ci-watcher may write `kind: "validate-result" |
+"validate-failed"`; only impl-task may write `kind: "validate-pending"`.
+This rule applies to both foreground and Junior-dispatched invocations.

--- a/.github/workflows/cargo-validate-migration.yml
+++ b/.github/workflows/cargo-validate-migration.yml
@@ -1,0 +1,59 @@
+name: cargo-validate-migration
+
+# Out-of-band migration round-trip validation for Brehon phase
+# branches. Runs only when migrations/** changes in a push to a
+# `phase-v1-*` or `junior/*` branch. Companion to
+# cargo-validate-workspace.yml — see
+# .claude/PRPs/plans/v1-validate-agent.plan.md §10.4.
+
+on:
+  push:
+    branches:
+      - 'phase-v1-*'
+      - 'junior/*'
+    paths:
+      - 'migrations/**'
+      - '.github/workflows/cargo-validate-migration.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cargo-validate-migration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-migration:
+    name: validate migration round-trip
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install libpq + Postgres client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev pkg-config postgresql-client
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-validate-migration-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-validate-migration-${{ runner.os }}-
+
+      - name: Migration round-trip
+        run: bash scripts/brehon/migrate-roundtrip.sh

--- a/.github/workflows/cargo-validate-migration.yml
+++ b/.github/workflows/cargo-validate-migration.yml
@@ -44,10 +44,17 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install libpq + Postgres client
+      - name: Install libpq
         run: |
+          # libpq-dev + pkg-config compile pq-sys against libpq (needed
+          # for any cargo step that touches diesel/pq-sys). postgresql-
+          # client (the psql CLI) is intentionally NOT installed yet —
+          # the migrate-roundtrip stub doesn't use it. The first
+          # sub-phase that ships real round-trip logic (likely
+          # testcontainers Postgres + a SELECT probe) re-adds
+          # postgresql-client to this step at that time.
           sudo apt-get update
-          sudo apt-get install -y libpq-dev pkg-config postgresql-client
+          sudo apt-get install -y libpq-dev pkg-config
 
       - name: Cache cargo registry + target
         uses: actions/cache@v4

--- a/.github/workflows/cargo-validate-migration.yml
+++ b/.github/workflows/cargo-validate-migration.yml
@@ -31,7 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # fetch-depth: 0 is required because migrate-roundtrip.sh
+          # diffs migrations/ vs origin/governance-v0 — a shallow
+          # checkout (default fetch-depth: 1) does not include that
+          # ref and the diff would silently exit 0, defeating the
+          # guard. Full history is cheap on this runner.
+          fetch-depth: 0
           submodules: recursive
 
       - name: Install Rust toolchain

--- a/.github/workflows/cargo-validate-workspace.yml
+++ b/.github/workflows/cargo-validate-workspace.yml
@@ -1,0 +1,80 @@
+name: cargo-validate-workspace
+
+# Out-of-band cargo validation for Brehon phase branches. Runs
+# `cargo check + clippy + test --no-run` on every push to a
+# `phase-v1-*` or `junior/*` branch, freeing the EliteDesk Junior
+# worker slot from in-band cargo work (Shape G — see
+# .claude/PRPs/plans/v1-validate-agent.plan.md).
+#
+# Trigger pattern is push-only per DQ #66. PR-side status checks
+# come via branch protection rules, configured out-of-band.
+
+on:
+  push:
+    branches:
+      - 'phase-v1-*'
+      - 'junior/*'
+    paths:
+      - 'crates/**'
+      - 'migrations/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/cargo-validate-workspace.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Use github.ref so concurrent pushes to the same branch cancel-in-progress;
+  # different branches run independently. Differs from cargo-test-e2e.yml
+  # which uses pull_request.number.
+  group: cargo-validate-workspace-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-workspace:
+    name: validate workspace
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # crates/email/translations/ is a submodule pointing to
+          # LemmyNet/lemmy-translations; lemmy_email/build.rs reads it
+          # at compile time, so we must initialise it.
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          # Pinned in rust-toolchain.toml; the action reads that file.
+          toolchain: stable
+          components: clippy
+
+      - name: Install libpq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev pkg-config
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-validate-workspace-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-validate-workspace-${{ runner.os }}-
+
+      - name: cargo check workspace + features full
+        run: cargo check --workspace --features full --no-deps
+
+      - name: cargo clippy workspace + features full
+        run: cargo clippy --workspace --features full --no-deps -- -D warnings
+
+      - name: cargo test compile (no-run)
+        run: cargo test --no-run -p lemmy_server --test e2e

--- a/.github/workflows/cargo-validate-workspace.yml
+++ b/.github/workflows/cargo-validate-workspace.yml
@@ -53,13 +53,16 @@ jobs:
           # Pinned in rust-toolchain.toml; the action reads that file.
           toolchain: stable
 
-      - name: Install clippy for pinned toolchain
+      - name: Install clippy for active toolchain
         run: |
-          # rust-toolchain.toml pins channel = "1.95", which dtolnay's
-          # action installs without clippy by default. cargo-validate-
-          # workspace runs clippy, so install it explicitly against the
-          # pinned channel.
-          rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu
+          # rust-toolchain.toml pins the channel, which dtolnay's action
+          # installs without clippy by default. cargo-validate-workspace
+          # runs clippy, so install it explicitly for the active toolchain
+          # rustup actually selected — this tracks rust-toolchain.toml
+          # automatically (channel bumps, target changes), unlike the
+          # earlier hard-coded "1.95-x86_64-unknown-linux-gnu" form.
+          toolchain="$(rustup show active-toolchain | awk '{print $1}')"
+          rustup component add clippy --toolchain "$toolchain"
 
       - name: Install libpq
         run: |

--- a/.github/workflows/cargo-validate-workspace.yml
+++ b/.github/workflows/cargo-validate-workspace.yml
@@ -52,7 +52,14 @@ jobs:
         with:
           # Pinned in rust-toolchain.toml; the action reads that file.
           toolchain: stable
-          components: clippy
+
+      - name: Install clippy for pinned toolchain
+        run: |
+          # rust-toolchain.toml pins channel = "1.95", which dtolnay's
+          # action installs without clippy by default. cargo-validate-
+          # workspace runs clippy, so install it explicitly against the
+          # pinned channel.
+          rustup component add clippy --toolchain 1.95-x86_64-unknown-linux-gnu
 
       - name: Install libpq
         run: |

--- a/.github/workflows/cargo-validate-workspace.yml
+++ b/.github/workflows/cargo-validate-workspace.yml
@@ -71,7 +71,7 @@ jobs:
             cargo-validate-workspace-${{ runner.os }}-
 
       - name: cargo check workspace + features full
-        run: cargo check --workspace --features full --no-deps
+        run: cargo check --workspace --features full
 
       - name: cargo clippy workspace + features full
         run: cargo clippy --workspace --features full --no-deps -- -D warnings

--- a/scripts/brehon/migrate-roundtrip.sh
+++ b/scripts/brehon/migrate-roundtrip.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# migrate-roundtrip.sh — placeholder for migration round-trip validation
+#
+# Invoked by .github/workflows/cargo-validate-migration.yml on pushes
+# to phase-v1-* / junior/* branches that touch migrations/**.
+#
+# v1-validate-agent (this commit) ships the workflow YAML + this stub.
+# The first sub-phase that authors a real migration after Shape G ships
+# (likely v1-JM-e or v1-JM-d Task 2 once it's queued via DQ #61) MUST
+# replace this body with real round-trip logic:
+#
+#   1. Diff migrations/ vs governance-v0 to identify the new migration id.
+#   2. Spin up a throwaway Postgres (testcontainers-style or apt-installed).
+#   3. Apply the new migration via cargo run -p lemmy_diesel_utils
+#      --features full -- run.
+#   4. Run a representative SELECT against the changed schema to confirm
+#      the migration applied cleanly.
+#   5. Apply the down migration via cargo run -p lemmy_diesel_utils
+#      --features full -- redo (or equivalent).
+#   6. Re-apply forward; confirm idempotent.
+#
+# Until that lands, this stub exits 0 on push events that don't actually
+# touch migrations/ (the workflow's `paths:` filter prevents most invocations);
+# if it IS triggered by a real migrations/ change, it exits non-zero so the
+# author of that migration is forced to replace the stub.
+#
+# See .claude/PRPs/plans/v1-validate-agent.plan.md §13 Task 1 GOTCHA + §19
+# (Notes) for the planning-side gap that produced this stub.
+
+set -euo pipefail
+
+# If the working tree contains a real new migration vs governance-v0, fail loud.
+# Otherwise this is a no-op (the workflow's path filter shouldn't trigger us
+# without a migrations/ change, but defence in depth).
+if git diff --name-only origin/governance-v0...HEAD -- migrations/ 2>/dev/null | grep -q '\.sql$'; then
+    echo "ERROR: migrate-roundtrip.sh is a stub. A real migration was detected" >&2
+    echo "  in the diff vs governance-v0 — replace this stub with real round-trip" >&2
+    echo "  logic before merging. See script header for the v1-JM-e checklist." >&2
+    exit 1
+fi
+
+echo "migrate-roundtrip.sh: no migrations/ change detected vs governance-v0; stub exiting 0."
+exit 0

--- a/scripts/brehon/migrate-roundtrip.sh
+++ b/scripts/brehon/migrate-roundtrip.sh
@@ -29,10 +29,21 @@
 
 set -euo pipefail
 
+# Verify the diff base ref is fetched. CI uses fetch-depth: 0 so this
+# should always pass, but fail loud if it doesn't — a missing ref would
+# silently exit 0 and defeat the guard (the original cr-1 finding on
+# PR #104).
+if ! git rev-parse --verify origin/governance-v0 >/dev/null 2>&1; then
+    echo "ERROR: migrate-roundtrip.sh requires origin/governance-v0 to be" >&2
+    echo "  fetched. The CI checkout step must use fetch-depth: 0 (or" >&2
+    echo "  explicitly fetch governance-v0). Aborting." >&2
+    exit 2
+fi
+
 # If the working tree contains a real new migration vs governance-v0, fail loud.
 # Otherwise this is a no-op (the workflow's path filter shouldn't trigger us
 # without a migrations/ change, but defence in depth).
-if git diff --name-only origin/governance-v0...HEAD -- migrations/ 2>/dev/null | grep -q '\.sql$'; then
+if git diff --name-only origin/governance-v0...HEAD -- migrations/ | grep -q '\.sql$'; then
     echo "ERROR: migrate-roundtrip.sh is a stub. A real migration was detected" >&2
     echo "  in the diff vs governance-v0 — replace this stub with real round-trip" >&2
     echo "  logic before merging. See script header for the v1-JM-e checklist." >&2


### PR DESCRIPTION
<!--
  v1-validate-agent — Out-of-Junior cargo validation via GH Actions (Shape G).
  This PR uses the Brehon governance-v0 PR template per
  .github/pull_request_template.md, adapted for an infra-only sub-phase
  (no Rust code authored — workflow YAMLs + agent specs + schema-additive
  rule edits + one bounded brief retrofit).
-->

## Phase

- [x] Other (tooling / docs / CI / upstream rebase) — post-v0 infrastructure sub-phase. NOT a v0 endpoint phase. Validate-agent is the Shape G plumbing that makes v1-JM-e and onward run cargo on GitHub Actions instead of the EliteDesk Junior worker.

## Summary

Post-v0 infrastructure sub-phase that **moves cargo validation off the EliteDesk Junior worker and onto GitHub-hosted Actions runners**. Ships:

- Two new workflow YAMLs: `cargo-validate-workspace.yml` (check + clippy + test --no-run) and `cargo-validate-migration.yml` (migration round-trip stub) on push to `phase-v1-*` / `junior/*`.
- Fifth Junior subagent role `[role:ci-watcher]` (Haiku 4.5, low effort, narrow tools) that polls workflow runs via `gh run watch` (long-poll) + `gh run view --json conclusion` (authoritative classification — the watch exit code is unreliable on gh CLI 2.89.0).
- Schema-additive extension to `decision-queue.md`: three new `kind` values (`validate-pending`, `validate-result`, `validate-failed`) + one new `from` value (`ci-watcher`). Atomic with `impl-task.md` and `advisor-orchestrator.md`.
- impl-task push-and-exit contract (Layer G2): commit, push, write a `validate-pending` DQ entry, exit; cargo no longer runs locally on Junior.
- Plan-template §15.6 forward-only "DoD per workflow" shape for v1-JM-e onward.
- Single bounded retrofit: `jm-d-impl-2.md` §5 from inline cargo to push-and-exit per DQ #61.

Plan: `.claude/PRPs/plans/v1-validate-agent.plan.md` (confidence 7/10; retro confidence 8/10 after empirical-evidence boost from the gh CLI bug catch).

Story 1 acceptance confirmed: `cargo-validate-workspace.yml` ran green on `phase-v1-validate-agent` at workflow run [25018404875](https://github.com/barrie-cork/lemmy/actions/runs/25018404875): cargo check ✓, cargo clippy ✓, cargo test --no-run ✓ (cold-cache wall-clock ~28 min).

## Definition of Done

This is an **infra-only** sub-phase — no Rust code authored. Most cargo gates are NA (the new gates ARE the cargo gates). Substituting validate-agent's own §16a Stories block for the v0 numbered DoD:

- [x] Tasks in this PR match plan §13 Tasks 0-6 (audit + 5 deliverables + retro)
- [x] No `crates/` / `migrations/` / `tests/` edits (verified via `git diff --name-only governance-v0..HEAD`)
- [x] No `Cargo.toml` / `Cargo.lock` / `rust-toolchain.toml` edits (NA — infra-only)
- [x] Cold-build cargo check / clippy / test --no-run all green on workflow run 25018404875 (Story 1)
- [x] §16a Story 1 (workflow triggers + green): ✓ confirmed
- [x] §16a Story 2 (ci-watcher reads validate-pending, polls): designed, not exercised end-to-end (foreground impl session, not four-role)
- [x] §16a Story 3 (success → validate-result: pass): same — design-only
- [ ] §16a Story 4 (failure → validate-failed with log_slice): **[deferred-to-retro]** — no real failure-allowlist scenario surfaced
- [ ] §16a Story 5 (advisor §G4 classifier auto-queues fix-impl-task): **[deferred-to-retro]** — same gating as Story 4
- [ ] §16a Story 6 (validate-agent bm-merge unblocks JM-d Task 2): only verifiable post-merge

## ADR impact matrix

| ADR | Touched? | Notes |
|---|---|---|
| ADR-008 append-only `governance_log` / hash chain | no | No `crates/` / `migrations/` edits |
| ADR-013 `CaseStatus::EmergencyRemove` exhaustive match | no | No Rust code authored |
| ADR-015 pseudonymised actor IDs / `scrub()` on public strings | no | No log content authored |
| ADR-010 v0 scope — adds an endpoint or dependency? | no | Post-v0 infra sub-phase; no endpoint added |
| ADR-006 inbound federation signals advisory-only | no | No federation code touched |
| New ADR added or existing ADR superseded? | no | No new ADR; no ADR superseded |

## Validation commands run locally

Local cargo: NOT run (this PR is the Shape G transition itself; running cargo locally would be self-contradictory). Validation runs on GitHub-hosted runners per the new workflows:

```
gh workflow view --yaml cargo-validate-workspace.yml   exit: 0
gh workflow view --yaml cargo-validate-migration.yml   exit: 0
yamllint .github/workflows/cargo-validate-*.yml        n/a (yamllint not on laptop; gh workflow view is primary path per DQ #67)
cargo-validate-workspace.yml run on phase branch       conclusion: success (run 25018404875)
cargo-validate-migration.yml run on phase branch       not triggered (no migrations/** in this sub-phase — expected per §15.3)
```

The 4 fix-in-pr commits (cr-* findings) added 1 more workflow run; latest run will be re-confirmed before merge.

## Risk / rollback

- Migration reversible via `diesel migration redo`? **n/a** (no migrations authored)
- If merged and wrong, rollback is:
  1. Revert the merge commit on `governance-v0` (`git revert -m 1 <merge-sha>`).
  2. The two new workflows stop firing on `phase-v1-*` pushes (no consumers harmed — they trigger on push only, not on existing phase branches' future merges).
  3. The schema-additive `kind` values become orphaned — `decision-queue.md` enumerates them but no consumer writes/reads them. Forward-only-immune, so harmless.
  4. The ci-watcher subagent file is removed; advisor stage-shape transitions referencing ci-watcher become dead code. Cosmetic.
- **No data migration**, **no schema change**, **no API contract change**. Rollback is clean.

## AI review acknowledgement

- [x] CodeRabbit walkthrough read; 7 findings triaged into 4 fix-in-pr commits (4b1d9a01c, a17c1d0a4, a1e9a20d9, 24c701562). Triage matrix at `.claude/PRPs/reviews/pr-104-findings.yaml`.
- [ ] `governance-ai-review` workflow comment read — workflow run 25019032296 failed with "workflow file issue" on the retro-commit push event; this is **pre-existing CI noise unrelated to v1-validate-agent's diff** (the workflow's `paths:` filter doesn't include any v1-validate-agent files). Carry-forward, NOT a finding on this PR.
- [ ] `adr-compliance` workflow — NA (no Rust code; ADR matrix above shows zero touches).

## Notes for reviewer

- This sub-phase ran as **foreground impl session, NOT four-role Junior orchestration**. The four-role pieces (ci-watcher subagent, push-and-exit impl-task, validate-stage in advisor-orchestrator) are designed and shipped but not yet exercised end-to-end. v1-JM-e will be the first sub-phase under full Shape G.
- Three planning-side surprises self-resolved as `kind: log` DQ entries during execution (#68 phantom dependency, #69 flag drift, #70 gh CLI bug). Each captured a finding the next planning task would have wanted; all three promoted to lessons in `.claude/lessons/` (in commit `da7e01358`).
- Per `.claude/rules/phase-branch.md`: do **NOT** squash at merge — the task-per-commit history is load-bearing for retros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous push-and-exit validation with GitHub Actions and a CI watcher to track workflow conclusions.

* **Documentation**
  * New lessons, templates and playbooks capturing CI validation behaviour, pitfalls and updated validation rules and decision-queue kinds.
  * Retro and verification reports summarising validation findings and next steps.

* **Infrastructure**
  * Added automated workspace and migration validation workflows and a migration round‑trip validation script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->