### PR TITLE
fix: clippy::map_err_ignore on accept_jury_assignment (JM-e carry-forward)

### DIFF
--- a/crates/api/api/src/governance/accept_jury_assignment.rs
+++ b/crates/api/api/src/governance/accept_jury_assignment.rs
@@ -89,7 +89,7 @@ async fn process_accept(
     .select(jury_assignment::role)
     .first(conn)
     .await
-    .map_err(|_| LemmyErrorType::NotFound)?;
+    .map_err(|_e| LemmyErrorType::NotFound)?;
 
   // 2. Load case for conflict checks.
   let case: ModerationCase = moderation_case::table


### PR DESCRIPTION
## Summary

One-line lint fix carried forward from JM-e Task 2 fix-impl (`360c24cb9`).

`.map_err(|_| LemmyErrorType::NotFound)?;` at `crates/api/api/src/governance/accept_jury_assignment.rs:92` violates the workspace-deny `clippy::map_err_ignore` rule (`Cargo.toml:99`). Minimal-diff fix uses `|_e|` (ignored-named) per the lint's recommended remediation — the diesel error is intentionally lossy here because `LemmyErrorType::NotFound` doesn't carry a source.

## Why this slipped past JM-e DoD

Discovered while measuring local validation cycle timing in the `tooling-local-validation` worktree experiment (separate WIP). Main-worktree warm clippy hit this lint at 162s before failure; tooling-worktree's older branch did not (it predates `360c24cb9`).

Junior's JM-e Task 2 §15 DoD clippy step did not catch it. Investigation pending on whether the DoD command was scope-limited or features-flag-limited — carry-forward item for the v1-JM-e retro.

## Verification

`cargo-clippy.bat --workspace --features full --no-deps -- -D warnings` now exits 0 in 58.9s warm on `governance-v0` post-fix.

## Test plan

- [x] Workspace clippy passes locally (warm, 58.9s)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code quality through minor adjustments to error handling logic. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->