### PR TITLE
chore(local-tooling): rust-lld linker + profile.dev tweaks (PR #107 follow-up)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,23 @@
+# Local-only build configuration for brehon-fork.
+# Companion to scripts/brehon/cargo-*.bat / *.sh — those wrappers set
+# the vcvars + libpq env that this file's linker selection depends on.
+#
+# Per Perplexity research 2026-05-02: rust-lld is the Rust-vendored
+# LLD (NOT lld-link.exe from system LLVM, which has a mixed 2024
+# track record on Windows). rust-lld:
+#   - Ships with rustup; no separate install needed
+#   - Tuned for Rust's exact LLVM version
+#   - Saves ~10-30s on test binary linking
+#   - Irrelevant for cargo check/clippy (codegen skipped)
+#
+# Background:
+#   - LLD became default on Linux x86_64 in Rust 1.90 (Sept 2025)
+#   - Windows MSVC has issue #71520 still open; manual opt-in here
+#   - Modrinth Labrinth (similar Rust/Actix/Diesel stack) adopted
+#     this in 2025: github.com/modrinth/code commit c899d955
+#
+# Rollback: comment the [target...] block; cargo silently falls
+# back to link.exe.
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ codegen-units = 1 # Reduce parallel code generation.
 # out temporarily, but make sure to leave this in the main branch.
 [profile.dev]
 debug = 0
+incremental = true
+# `split-debuginfo = "packed"` is the only stable value on Windows MSVC
+# (see cargo PR #11347). Setting it explicitly keeps incremental rebuilds
+# fast and prevents future toolchain bumps from silently changing
+# defaults. No-op on Linux/macOS where defaults already match.
+split-debuginfo = "packed"
 
 # Optimize procedural macros
 [profile.dev.build-override]


### PR DESCRIPTION
## Summary

Follow-up to PR #107 — completes the two top-tier perf items from the
local-validation tooling cycle that didn't land in that PR:

1. `.cargo/config.toml` selecting `rust-lld` for `x86_64-pc-windows-msvc`
2. `[profile.dev]` additions: `incremental = true` + `split-debuginfo = "packed"`

## Why this slipped from PR #107

PR #107 shipped:
- `scripts/brehon/cargo-nextest.{bat,sh}`
- `BREHON_USE_NEXTEST=1` dispatch in `scripts/brehon/cargo-test.{bat,sh}`
- `.config/nextest.toml` (threads-required = 4, slow-timeout)
- `bacon.toml` (clippy default job, smoke + full e2e variants)
- `scripts/brehon/Dockerfile.test-pg` + `apply-migrations-to-image.sh` (pre-bake scaffolding, deferred)
- `.claude/lessons/feedback_local_validation_cycle_2026_05_02.md`

But did NOT ship `.cargo/config.toml` or the `Cargo.toml [profile.dev]` additions — those got dropped during the JM-e merge cycle.

## What this adds

### `.cargo/config.toml` (new, 24 lines)

```toml
[target.x86_64-pc-windows-msvc]
linker = "rust-lld"
```

- `rust-lld` is the Rust-vendored LLD; ships with rustup. Tuned to Rust's exact LLVM version.
- LLD is default on Linux x86_64 since Rust 1.90 (Sept 2025); manual opt-in on Windows MSVC pending issue #71520.
- Saves ~10-30s on test-binary linking. Irrelevant for `cargo check`/`clippy` (codegen skipped).
- Rollback: comment the block; cargo silently falls back to `link.exe`.

### `Cargo.toml [profile.dev]` (additive, +4 lines)

```toml
[profile.dev]
debug = 0
incremental = true            # was implicit-default; now explicit
split-debuginfo = "packed"    # only stable Windows MSVC value (cargo PR #11347)
```

No-op on Linux/macOS where defaults already match. Setting both explicitly prevents future toolchain bumps from silently changing defaults.

## Verification

On `chore/local-tooling-rust-lld`:

```
scripts/brehon/cargo-nextest.bat run --workspace --features full \
  --test e2e -E "test(postgres_container_boots)"
```

Result:
```
        PASS [   4.459s] (1/1) lemmy_server::e2e postgres_container_boots
     Summary [   4.460s] 1 test run: 1 passed, 68 skipped
    Finished `test` profile [unoptimized] target(s) in 22m 08s
```

Total cycle: 22m 08s cold-compile + 4.5s test + nextest overhead = 22.3 min wall-clock. Captured at `.claude/build-fresh-nextest-smoke.log`.

## Source

Per Perplexity research 2026-05-02 + Modrinth Labrinth's adoption (github.com/modrinth/code commit c899d955) — known-good pattern for Rust/Actix/Diesel stacks on Windows.

## Test plan

- [x] Workspace nextest smoke passes (postgres_container_boots)
- [ ] CodeRabbit review
- [ ] Linker fallback verified (commenting the `[target...]` block re-runs with link.exe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development build profile configuration with incremental compilation support, reducing build times during iterative development and improving developer productivity.
  * Refined Windows platform build environment setup with optimised linker configuration for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->