### PR TITLE
fix(api_crud): enable reqwest-middleware form feature (GH #83)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3119,7 +3119,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6555,7 +6555,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6643,7 +6643,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7447,7 +7447,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8999,7 +8999,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ reqwest = { version = "0.13.2", default-features = false, features = [
   "rustls-no-provider",
   "stream",
 ] }
-reqwest-middleware = "0.5.1"
+reqwest-middleware = { version = "0.5.1", features = ["form"] }
 reqwest-tracing = "0.7.0"
 clokwerk = "0.4.0"
 doku = { version = "0.21.1", features = ["url-2"] }


### PR DESCRIPTION
## What

Enable the `form` feature on `reqwest-middleware` in `Cargo.toml`:
```toml
reqwest-middleware = { version = "0.5.1", features = ["form"] }
```

## Why

Without the `form` feature, reqwest-middleware 0.5.1 gates the `.form()` extension method behind a feature flag. The OAuth token exchange in `create.rs:638` calls `.form()` on `ClientWithMiddleware` — which is a `reqwest::Client` wrapped by middleware. This compiled in dev mode but broke under `cargo check -p lemmy_api_crud --features full`.

## Validation

```bash
cargo check -p lemmy_api_crud --features full  # exits 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workspace dependency to enable additional form handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->