### PR TITLE
chore(migrations): pin valid_from literals on v0 + v1-AD-a seed migrations (audit 3.D.6)

### DIFF
--- a/.claude/PRPs/briefs/refactor-valid-from-bm-pr.md
+++ b/.claude/PRPs/briefs/refactor-valid-from-bm-pr.md
@@ -1,0 +1,91 @@
+---
+phase: chore/refactor-valid-from
+role: bm-task
+task: bm-pr
+brief_n: 2
+authored: 2026-05-15
+audit_source: .claude/PRPs/reports/v1-code-quality-audit-2026-05-14.md
+audit_findings: 3.D.6 (rank 6 — PR-4)
+---
+
+# [role:bm-task] bm-pr chore/refactor-valid-from — see .claude/PRPs/briefs/refactor-valid-from-bm-pr.md
+
+## §1 Role + dispatch
+
+`[role:bm-task] bm-pr chore/refactor-valid-from — open PR into governance-v0`
+
+## §2 Scope
+
+Open a PR from `chore/refactor-valid-from` into `governance-v0` per
+`.claude/commands/bm/bm-pr.md`. Execute Phase 1 → Phase 7 of that
+script. Auto, no prompt (per branch-manager.md autonomy table — open
+PR into governance-v0 is Auto).
+
+**Branch state (already prepared by advisor — do NOT re-cut or
+re-push):**
+
+- `chore/refactor-valid-from` is at `af055f0fa` (pushed to origin):
+  - `a2aa023ed` — `chore(migrations): pin valid_from literals on v0 + v1-AD-a seed migrations (audit §3.D.6)` (the refactor; 3 SQL files)
+  - `af055f0fa` — `chore(decision-queue): advisor-laptop backfill DQ #215 #216 — PR-4 valid-from validate-pending pass`
+- Working tree is clean; branch is pushed; remote == local.
+- This is a **chore branch** — no `.plan.md` exists. bm-pr script's
+  retro gate + Phase 1c e2e gate both correctly skip for chore
+  branches (script is plan-aware). Phase 1b historical-fail sweep is
+  a no-op (pending=0, no failed validate-pending entries).
+
+**Title** (chore branch → `chore(<scope>): <prose>` from first
+commit subject): `chore(migrations): pin valid_from literals on v0 + v1-AD-a seed migrations (audit 3.D.6)`
+
+**PR body** — assemble per bm-pr Phase 3. No completion report, no
+plan file. Use commit log + this context. Body MUST include:
+
+- `## Summary` — Retrofits `valid_from` literal pinning on 2 seed
+  migrations (`2026-04-18-...add_governance_config`,
+  `2026-04-22-...seed_v1_config_keys`) + down.sql parity. Without the
+  literal, `valid_from` defaults to `now()` and each migration rerun
+  inserts a duplicate active row under the `(scope, key, valid_from)`
+  unique index. Mirrors the JM-a cr-10 pattern from
+  `2026-04-23-...seed_v1_jm_config_keys/up.sql`.
+- `## Plan reference` — `Ad-hoc — no plan file (chore branch; one of
+  the audit-driven refactor-tier PRs per
+  .claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md)`
+- `## Closes` — `Closes audit finding 3.D.6 (v1-code-quality-audit-2026-05-14.md, rank 6)`
+- `## Validation` — Workspace check: local `cargo-check.sh
+  --workspace --features full` PASS (DQ #215, advisor-laptop fallback
+  after GH cargo-validate-workspace stuck-runner x2). Migration check:
+  GH `cargo-validate-migration` run 25891289464 PASS (DQ #216).
+  Reference the advisor-laptop backfill rationale (Junior #263
+  omitted Recipe-1 DQ writes; recovery per advisor-orchestrator.md
+  §5.2 validate-pending-laptop handler).
+
+## §3 Required reading
+
+- `.claude/commands/bm/bm-pr.md` (the operational script — follow Phase 1→7)
+- `.claude/rules/branch-manager.md` (file-ownership; autonomy table)
+- `.claude/rules/phase-branch.md` (PR into governance-v0, not main; not draft)
+- `.claude/rules/gh-pr-fork-target.md` (`--repo barrie-cork/lemmy` mandatory on every `gh pr` call)
+- `.claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md` (PR-4 of 5; sequential lane; strict-gate context)
+
+## §4 Constraints
+
+- **NEVER** touch `crates/**`, `migrations/**`, `tests/**`,
+  `docs/brehon-law-inspired-network/**` (BM file-ownership boundary).
+- **NEVER** open PR into `main` — base is `governance-v0`.
+- **NEVER** open as draft (CR skips drafts per phase-branch.md).
+- **NEVER** re-cut or force-push the branch — it is already prepared.
+- `--repo barrie-cork/lemmy` on EVERY `gh pr` subcommand.
+- Do NOT post a PR comment or submit a review (those are Manual/ask
+  per autonomy table — bm-pr only opens the PR).
+- Do NOT run `/bm-poll-cr` or `/bm-triage` — advisor dispatches those
+  separately after CR posts.
+- Append to runlog `.claude/runlog/chore-refactor-valid-from.md`
+  (Phase 6) — create if absent (bm-cut created it).
+- Return the PR number + URL in the final summary so the advisor can
+  track it.
+
+## §5 Concurrency note
+
+Lane-dedicated worktree on the daemon side. PR-5 (`diesel-errors`) +
+PR-6 (`seed-tests`) are NOT yet dispatched (advisor holds them
+sequentially until this PR-4 PR is open + CR-triaged). No cross-lane
+file overlap (this PR is the only one touching `migrations/`).

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -3514,6 +3514,48 @@
       "result": "pass",
       "log_slice": null,
       "failed_jobs": null
+    },
+    {
+      "id": 215,
+      "from": "advisor",
+      "kind": "validate-pending",
+      "timestamp": "2026-05-15T08:48:00Z",
+      "question": "PR-4 (valid-from) workspace check — backfilled by advisor-laptop after Junior #263 omitted Recipe-1 DQ write and GH cargo-validate-workspace stuck-runner x2",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Junior #263 succeeded + pushed worker commit (3 SQL files) but did NOT raise the brief-mandated validate-pending entries. GH cargo-validate-workspace run 25891289465 froze >100min twice (frozen-updatedAt). Advisor-laptop fallback per advisor-orchestrator.md §5.2: cargo-check.sh --workspace --features full on worker tip detached HEAD = CHECK_EXIT_0, 'Finished dev profile in 7m 23s', zero errors. Log: C:/Users/barri/.claude/logs/validate-laptop-pr4-workspace.log",
+      "workflow_run_id": null,
+      "branch": "chore/refactor-valid-from",
+      "phase_task": 1,
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": "PASS — local cargo-check --workspace --features full exited 0 (7m23s, zero errors) on worker tip 2a14893d5 (rebased to a2aa023ed onto chore/refactor-valid-from; only unrelated .claude/briefs prose differs between bases, SQL identical). GH-side workspace check abandoned after 2x stuck-runner. Equivalent validation per §5.2 validate-pending-laptop handler.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-05-15T08:48:00Z"
+    },
+    {
+      "id": 216,
+      "from": "advisor",
+      "kind": "validate-pending",
+      "timestamp": "2026-05-15T08:48:00Z",
+      "question": "PR-4 (valid-from) migration check — backfilled by advisor-laptop (GH cargo-validate-migration run 25891289464 already passed; Junior #263 omitted Recipe-1 DQ write)",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "cargo-validate-migration run 25891289464 on worker push (same push as the stuck workspace run) completed with conclusion=success at 2026-05-14T23:21Z. Junior #263 did not raise the paired validate-pending DQ entry; advisor-laptop backfills the already-green result.",
+      "workflow_run_id": 25891289464,
+      "branch": "chore/refactor-valid-from",
+      "phase_task": 1,
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": "PASS — GH cargo-validate-migration run 25891289464 conclusion=success (23:21Z, same push as the stuck workspace run). Migration round-trip green on GH-hosted runner; only the workspace job stuck. Backfilled to preserve Shape-G two-phase audit trail.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-05-15T08:48:00Z"
     }
   ],
   "schema_version": 2

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -3532,7 +3532,7 @@
       "result": "pass",
       "log_slice": null,
       "failed_jobs": null,
-      "answer": "PASS — local cargo-check --workspace --features full exited 0 (7m23s, zero errors) on worker tip 2a14893d5 (rebased to a2aa023ed onto chore/refactor-valid-from; only unrelated .claude/briefs prose differs between bases, SQL identical). GH-side workspace check abandoned after 2x stuck-runner. Equivalent validation per §5.2 validate-pending-laptop handler.",
+      "answer": "PASS — local cargo-check --workspace --features full exited 0 (7m23s, zero errors) on worker tip 2a14893d5 (rebased to a2aa023ed onto chore/refactor-valid-from; only unrelated .claude/briefs prose differs between bases, SQL identical). GH-side workspace check abandoned after 2x stuck-runner. Equivalent validation per §5.2 validate-pending-laptop handler. USER-APPROVAL: user explicitly authorised option (c) advisor-laptop fallback validation on 2026-05-15 ('Go with C', in response to the workspace-check stuck-runner x2 catch-fire). §5.2 validate-pending-laptop is a mechanical validation runner (not an ADR/scope/visible-impact decision per gate-2); this reference is added for audit self-containment per CR finding cr-1 on PR #128.",
       "answered_by": "advisor-laptop",
       "resolved_at": "2026-05-15T08:48:00Z"
     },
@@ -3553,7 +3553,7 @@
       "result": "pass",
       "log_slice": null,
       "failed_jobs": null,
-      "answer": "PASS — GH cargo-validate-migration run 25891289464 conclusion=success (23:21Z, same push as the stuck workspace run). Migration round-trip green on GH-hosted runner; only the workspace job stuck. Backfilled to preserve Shape-G two-phase audit trail.",
+      "answer": "PASS — GH cargo-validate-migration run 25891289464 conclusion=success (23:21Z, same push as the stuck workspace run). Migration round-trip green on GH-hosted runner; only the workspace job stuck. Backfilled to preserve Shape-G two-phase audit trail. USER-APPROVAL: user explicitly authorised option (c) advisor-laptop fallback validation on 2026-05-15 ('Go with C', in response to the workspace-check stuck-runner x2 catch-fire). §5.2 validate-pending-laptop is a mechanical validation runner (not an ADR/scope/visible-impact decision per gate-2); this reference is added for audit self-containment per CR finding cr-1 on PR #128.",
       "answered_by": "advisor-laptop",
       "resolved_at": "2026-05-15T08:48:00Z"
     }

--- a/.claude/runlog/chore-refactor-valid-from.md
+++ b/.claude/runlog/chore-refactor-valid-from.md
@@ -1,0 +1,21 @@
+# Runlog — chore/refactor-valid-from (PR-4, audit 3.D.6)
+
+Refactor-tier lane per `.claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md`.
+Pin `valid_from` literals on v0 + v1-AD-a seed migrations.
+
+## advisor: lane prepared — 2026-05-15T08:50Z
+
+- Branch `chore/refactor-valid-from` cut off `governance-v0` (canonical session, no Junior bm-cut task — direct dispatch path).
+- Junior #263 (`impl-task`) produced `a2aa023ed` (migration refactor, 3 SQL files) but **omitted Recipe-1 validate-pending DQ writes** (process miss; retro L1 candidate).
+- GH `cargo-validate-workspace` run 25891289465 stuck-runner ×2 (>100 min frozen each). `cargo-validate-migration` run 25891289464 PASS.
+- Advisor-laptop recovery per advisor-orchestrator.md §5.2: local `cargo-check.sh --workspace --features full` = CHECK_EXIT_0 (7m23s, zero errors). Worker commit rebased onto chore tip (`.claude/briefs` prose only between bases — SQL identical).
+- DQ #215 (workspace pass) + #216 (migration pass) backfilled, `answered_by: advisor-laptop`.
+
+## bm: PR opened — 2026-05-15T08:55Z
+
+- **PR:** #128 — chore(migrations): pin valid_from literals on v0 + v1-AD-a seed migrations (audit 3.D.6)
+- **URL:** https://github.com/barrie-cork/lemmy/pull/128
+- **Base ← Head:** governance-v0 ← chore/refactor-valid-from
+- **Body source:** commits + bm-pr brief (no completion report, no plan — chore branch)
+- **Opened by:** advisor session inline (L15 precedent — bm-task Junior #264 failed: daemon `git worktree add ... chore/refactor-valid-from` → `fatal: invalid reference` because `/srv/brehon-fork` had no local chore ref).
+- **Next:** wait ~5–10 min for CodeRabbit; then bm-poll-cr 128.

--- a/migrations/2026-04-18-000000-0000_add_governance_config/up.sql
+++ b/migrations/2026-04-18-000000-0000_add_governance_config/up.sql
@@ -73,41 +73,46 @@ CREATE UNIQUE INDEX reputation_snapshot_person_null_community
 -- Seed 34 instance-scoped config rows. ON CONFLICT DO NOTHING on
 -- (scope, key, valid_from) makes this idempotent — reruns after manual
 -- admin edits preserve the admin edits (the unique index on
--- (scope, key, valid_from) distinguishes valid_from=now() from the seed's
--- valid_from=seed-time).
-INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text) VALUES
-    ('instance', 'thresholds.jury_reliability',           'int',  50,         NULL,    NULL, NULL),
-    ('instance', 'thresholds.reporting_accuracy',         'int',  50,         NULL,    NULL, NULL),
-    ('instance', 'thresholds.endorsement_strength',       'int',  25,         NULL,    NULL, NULL),
-    ('instance', 'jury.panel_size',                       'int',  5,          NULL,    NULL, NULL),
-    ('instance', 'jury.quorum',                           'int',  3,          NULL,    NULL, NULL),
-    ('instance', 'jury.age_requirement_days',             'int',  60,         NULL,    NULL, NULL),
-    ('instance', 'jury.max_concurrent_assignments',       'int',  3,          NULL,    NULL, NULL),
-    ('instance', 'jury.fallback_on_small_pool',           'bool', NULL,       NULL,    true, NULL),
-    ('instance', 'deltas.juror_aligned',                  'int',  10,         NULL,    NULL, NULL),
-    ('instance', 'deltas.juror_outlier',                  'int',  -5,         NULL,    NULL, NULL),
-    ('instance', 'deltas.reporter_upheld',                'int',  10,         NULL,    NULL, NULL),
-    ('instance', 'deltas.reporter_dismissed',             'int',  -5,         NULL,    NULL, NULL),
-    ('instance', 'deltas.endorsement_created_sponsor',    'int',  5,          NULL,    NULL, NULL),
-    ('instance', 'deltas.endorsement_created_sponsee',    'int',  5,          NULL,    NULL, NULL),
-    ('instance', 'deltas.sponsor_liability_minor',        'int',  -10,        NULL,    NULL, NULL),
-    ('instance', 'deltas.sponsor_liability_moderate',     'int',  -50,        NULL,    NULL, NULL),
-    ('instance', 'deltas.sponsor_liability_severe',       'int',  -200,       NULL,    NULL, NULL),
-    ('instance', 'liability.founder_multiplier',          'float', NULL,      2.0,     NULL, NULL),
-    ('instance', 'liability.regular_multiplier',          'float', NULL,      1.0,     NULL, NULL),
-    ('instance', 'liability.sponsor_liability_floor',     'int',  0,          NULL,    NULL, NULL),
-    ('instance', 'report.base_weight',                    'float', NULL,      1.0,     NULL, NULL),
-    ('instance', 'report.clamp_min',                      'float', NULL,      0.1,     NULL, NULL),
-    ('instance', 'report.clamp_max',                      'float', NULL,      2.0,     NULL, NULL),
-    ('instance', 'report.recency_half_life_hours',        'float', NULL,      168.0,   NULL, NULL),
-    ('instance', 'report.case_threshold_micros',          'int',  3000000,    NULL,    NULL, NULL),
-    ('instance', 'decay.positive_half_life_days',         'int',  90,         NULL,    NULL, NULL),
-    ('instance', 'onboarding.default_membership_state',   'text', NULL,       NULL,    NULL, 'member'),
-    ('instance', 'onboarding.sponsor_gate_strategy',      'text', NULL,       NULL,    NULL, 'age'),
-    ('instance', 'onboarding.sponsor_min_account_age_days','int', 30,         NULL,    NULL, NULL),
-    ('instance', 'founder.max_founders_active',           'int',  20,         NULL,    NULL, NULL),
-    ('instance', 'founder.max_expires_days',              'int',  365,        NULL,    NULL, NULL),
-    ('instance', 'founder.max_seed_delta',                'int',  200,        NULL,    NULL, NULL),
-    ('instance', 'job.snapshot_interval_seconds',         'int',  900,        NULL,    NULL, NULL),
-    ('instance', 'job.snapshot_batch_chunk_size',         'int',  500,        NULL,    NULL, NULL)
+-- (scope, key, valid_from) distinguishes the seed's pinned literal from
+-- admin edits at valid_from = now()). Every row pins valid_from to the
+-- stable literal '2026-04-18T00:00:00Z' so reruns hit the same row under
+-- the unique index and ON CONFLICT DO NOTHING is a true no-op. Without
+-- the literal, valid_from defaults to now() and each rerun inserts a
+-- duplicate active row (same class as JM-a cr-10, fixed here retroactively
+-- per audit §3.D.6).
+INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text, valid_from) VALUES
+    ('instance', 'thresholds.jury_reliability',           'int',  50,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'thresholds.reporting_accuracy',         'int',  50,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'thresholds.endorsement_strength',       'int',  25,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'jury.panel_size',                       'int',  5,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'jury.quorum',                           'int',  3,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'jury.age_requirement_days',             'int',  60,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'jury.max_concurrent_assignments',       'int',  3,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'jury.fallback_on_small_pool',           'bool', NULL,       NULL,    true, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.juror_aligned',                  'int',  10,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.juror_outlier',                  'int',  -5,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.reporter_upheld',                'int',  10,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.reporter_dismissed',             'int',  -5,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.endorsement_created_sponsor',    'int',  5,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.endorsement_created_sponsee',    'int',  5,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.sponsor_liability_minor',        'int',  -10,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.sponsor_liability_moderate',     'int',  -50,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'deltas.sponsor_liability_severe',       'int',  -200,       NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'liability.founder_multiplier',          'float', NULL,      2.0,     NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'liability.regular_multiplier',          'float', NULL,      1.0,     NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'liability.sponsor_liability_floor',     'int',  0,          NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'report.base_weight',                    'float', NULL,      1.0,     NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'report.clamp_min',                      'float', NULL,      0.1,     NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'report.clamp_max',                      'float', NULL,      2.0,     NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'report.recency_half_life_hours',        'float', NULL,      168.0,   NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'report.case_threshold_micros',          'int',  3000000,    NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'decay.positive_half_life_days',         'int',  90,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'onboarding.default_membership_state',   'text', NULL,       NULL,    NULL, 'member',  '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'onboarding.sponsor_gate_strategy',      'text', NULL,       NULL,    NULL, 'age',     '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'onboarding.sponsor_min_account_age_days','int', 30,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'founder.max_founders_active',           'int',  20,         NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'founder.max_expires_days',              'int',  365,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'founder.max_seed_delta',                'int',  200,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'job.snapshot_interval_seconds',         'int',  900,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz),
+    ('instance', 'job.snapshot_batch_chunk_size',         'int',  500,        NULL,    NULL, NULL,      '2026-04-18T00:00:00Z'::timestamptz)
 ON CONFLICT (scope, key, valid_from) DO NOTHING;

--- a/migrations/2026-04-22-000300-0000_seed_v1_config_keys/down.sql
+++ b/migrations/2026-04-22-000300-0000_seed_v1_config_keys/down.sql
@@ -1,14 +1,16 @@
 -- Reverse of 2026-04-22-000300-0000_seed_v1_config_keys up.sql.
--- Deletes the 27 admin-dashboard-owned rows seeded by up.sql. Does NOT
--- drop the governance_config table (that belongs to the v0 Phase 5a
--- migration `2026-04-18-000000-0000_add_governance_config`).
---
--- Idempotent by construction: DELETE ... WHERE key IN (...) against an
--- empty table is a no-op; rerunning down after up+down leaves the table
--- unchanged.
+-- Deletes exactly the 27 v1-AD-a seed rows identified by the stable
+-- valid_from = '2026-04-22T00:03:00Z' literal the up.sql pins (per
+-- audit §3.D.6 retrofit). Targeting the seed literal preserves any admin
+-- edits at valid_from = now() that landed since seed-time — those are
+-- community-authored config history and must survive revert+reapply.
+-- Does NOT drop the governance_config table (that belongs to the v0
+-- Phase 5a migration `2026-04-18-000000-0000_add_governance_config`).
 
 DELETE FROM governance_config
-WHERE scope = 'instance' AND key IN (
+WHERE scope = 'instance'
+  AND valid_from = '2026-04-22T00:03:00Z'::timestamptz
+  AND key IN (
     'jury.severity_thresholds.minor',
     'jury.severity_thresholds.moderate',
     'jury.severity_thresholds.severe',

--- a/migrations/2026-04-22-000300-0000_seed_v1_config_keys/up.sql
+++ b/migrations/2026-04-22-000300-0000_seed_v1_config_keys/up.sql
@@ -16,38 +16,42 @@
 -- test `every_seeded_key_has_const_fallback` + the e2e
 -- `config_parity_round_trip` walk this list and fail closed on drift.
 --
--- ON CONFLICT (scope, key, valid_from) DO NOTHING keeps this migration
--- idempotent across reruns; the per-statement now() resolves once so the
--- 27 rows share a valid_from within a single run.
+-- Idempotency: every row pins valid_from to the STABLE LITERAL
+-- '2026-04-22T00:03:00Z' so reruns hit the same row under the unique index
+-- on (scope, key, valid_from) and ON CONFLICT DO NOTHING is a true no-op.
+-- Without the literal, valid_from defaults to now() and each rerun inserts
+-- a duplicate active row (same class as JM-a cr-10, fixed here retroactively
+-- per audit §3.D.6). Pre-existing admin edits at valid_from = now() survive
+-- reapply because the unique index treats them as distinct rows.
 
-INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text) VALUES
-    ('instance', 'jury.severity_thresholds.minor',                     'text', NULL,  NULL, NULL,  'majority'),
-    ('instance', 'jury.severity_thresholds.moderate',                  'text', NULL,  NULL, NULL,  '60%'),
-    ('instance', 'jury.severity_thresholds.severe',                    'text', NULL,  NULL, NULL,  '75%'),
-    ('instance', 'jury.diversity_constraints_enabled',                 'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'jury.appeal_panel_size_increase',                    'int',  2,     NULL, NULL,  NULL),
-    ('instance', 'jury.deadline_window_hours',                         'int',  72,    NULL, NULL,  NULL),
-    ('instance', 'decay.negative_half_life_days',                      'int',  180,   NULL, NULL,  NULL),
-    ('instance', 'decay.endorsement_strength_half_life_days',          'int',  90,    NULL, NULL,  NULL),
-    ('instance', 'decay.jury_reliability_half_life_days',              'int',  90,    NULL, NULL,  NULL),
-    ('instance', 'onboarding.sponsor_min_endorsement_strength',        'int',  25,    NULL, NULL,  NULL),
-    ('instance', 'onboarding.sponsor_allowlist_table_name',            'text', NULL,  NULL, NULL,  'sponsor_allowlist'),
-    ('instance', 'onboarding.provisional_membership_cooldown_days',    'int',  14,    NULL, NULL,  NULL),
-    ('instance', 'founder.founder_seal_visible_in_profile',            'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'deltas.participation_weekly_active',                 'int',  1,     NULL, NULL,  NULL),
-    ('instance', 'participation.dormancy_window_days',                 'int',  30,    NULL, NULL,  NULL),
-    ('instance', 'deltas.participation_dormant',                       'int',  -2,    NULL, NULL,  NULL),
-    ('instance', 'participation.attestation_enabled',                  'bool', NULL,  NULL, false, NULL),
-    ('instance', 'federation.inbound_advisory_only',                   'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'federation.peer_attestation_ttl_days',               'int',  30,    NULL, NULL,  NULL),
-    ('instance', 'federation.signature_required',                      'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'federation.quarantine_recommendation_severity_floor','text', NULL,  NULL, NULL,  'moderate'),
-    ('instance', 'federation.outbound_publish_enabled',                'bool', NULL,  NULL, true,  NULL),
+INSERT INTO governance_config (scope, key, value_type, value_int, value_float, value_bool, value_text, valid_from) VALUES
+    ('instance', 'jury.severity_thresholds.minor',                     'text', NULL,  NULL, NULL,  'majority',  '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'jury.severity_thresholds.moderate',                  'text', NULL,  NULL, NULL,  '60%',       '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'jury.severity_thresholds.severe',                    'text', NULL,  NULL, NULL,  '75%',       '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'jury.diversity_constraints_enabled',                 'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'jury.appeal_panel_size_increase',                    'int',  2,     NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'jury.deadline_window_hours',                         'int',  72,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'decay.negative_half_life_days',                      'int',  180,   NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'decay.endorsement_strength_half_life_days',          'int',  90,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'decay.jury_reliability_half_life_days',              'int',  90,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'onboarding.sponsor_min_endorsement_strength',        'int',  25,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'onboarding.sponsor_allowlist_table_name',            'text', NULL,  NULL, NULL,  'sponsor_allowlist', '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'onboarding.provisional_membership_cooldown_days',    'int',  14,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'founder.founder_seal_visible_in_profile',            'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'deltas.participation_weekly_active',                 'int',  1,     NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'participation.dormancy_window_days',                 'int',  30,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'deltas.participation_dormant',                       'int',  -2,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'participation.attestation_enabled',                  'bool', NULL,  NULL, false, NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'federation.inbound_advisory_only',                   'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'federation.peer_attestation_ttl_days',               'int',  30,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'federation.signature_required',                      'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'federation.quarantine_recommendation_severity_floor','text', NULL,  NULL, NULL,  'moderate',  '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'federation.outbound_publish_enabled',                'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
     -- rule_set.active_version_id deliberately NOT seeded — absence-of-row
     -- IS the "no active version" signal. See plan §4.1 + task 6 GOTCHA.
-    ('instance', 'rule_set.auto_carry_in_flight_cases',                'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'rule_set.text_max_bytes',                            'int',  65536, NULL, NULL,  NULL),
-    ('instance', 'rule_set.version_propagation_delay_hours',           'int',  24,    NULL, NULL,  NULL),
-    ('instance', 'governance.dashboard.html_pages_enabled',            'bool', NULL,  NULL, true,  NULL),
-    ('instance', 'governance.dashboard.step_up_enforced',              'bool', NULL,  NULL, false, NULL)
+    ('instance', 'rule_set.auto_carry_in_flight_cases',                'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'rule_set.text_max_bytes',                            'int',  65536, NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'rule_set.version_propagation_delay_hours',           'int',  24,    NULL, NULL,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'governance.dashboard.html_pages_enabled',            'bool', NULL,  NULL, true,  NULL,        '2026-04-22T00:03:00Z'::timestamptz),
+    ('instance', 'governance.dashboard.step_up_enforced',              'bool', NULL,  NULL, false, NULL,        '2026-04-22T00:03:00Z'::timestamptz)
 ON CONFLICT (scope, key, valid_from) DO NOTHING;


### PR DESCRIPTION
## Summary

Retrofits `valid_from` literal pinning on two seed migrations that defaulted to `now()`, plus down.sql parity:

- `migrations/2026-04-18-000000-0000_add_governance_config/up.sql` (Phase 5a / v0, 34 rows) → pinned to `'2026-04-18T00:00:00Z'::timestamptz`
- `migrations/2026-04-22-000300-0000_seed_v1_config_keys/up.sql` (v1-AD-a, 27 rows) → pinned to `'2026-04-22T00:03:00Z'::timestamptz`

Without an explicit literal, `valid_from` defaults to `now()`, so each migration rerun inserts a duplicate active row under the `(scope, key, valid_from)` unique index — `ON CONFLICT DO NOTHING` becomes a no-op only by accident. Mirrors the pattern JM-a cr-10 established in `migrations/2026-04-23-000200-0000_seed_v1_jm_config_keys/up.sql`.

## Plan reference

Ad-hoc — no plan file (chore branch; one of the audit-driven refactor-tier PRs per `.claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md`, PR-4 of 5).

## Closes

Closes audit finding **3.D.6** (`.claude/PRPs/reports/v1-code-quality-audit-2026-05-14.md`, rank 6, severity MED).

## Validation

Shape-G two-phase validation (recorded as DQ #215 + #216 on this branch):

- **Workspace check** — DQ #215, `result: pass`. GH `cargo-validate-workspace` run 25891289465 hit a stuck-runner twice (>100 min frozen-updatedAt each). Fell back to local `scripts/brehon/cargo-check.sh --workspace --features full` per advisor-orchestrator.md §5.2 validate-pending-laptop handler → `CHECK_EXIT_0`, `Finished dev profile in 7m 23s`, zero errors.
- **Migration check** — DQ #216, `result: pass`. GH `cargo-validate-migration` run 25891289464 `conclusion=success` (same push as the stuck workspace run; only the workspace job stuck).

Note: Junior #263 produced the correct migration commit but omitted the brief-mandated Recipe-1 validate-pending DQ writes; the advisor backfilled #215/#216 (`answered_by: advisor-laptop`) as the canonical §5.2 recovery. The worker commit was rebased onto the `chore/refactor-valid-from` tip (intervening commits were `.claude/briefs` prose only — SQL identical, local validation remains valid).

---

*PR opened by advisor session inline (L15 precedent — deterministic BM gate work; bm-task Junior #264 failed on a daemon worktree-ref resolution error). CodeRabbit review will follow automatically (not draft per phase-branch.md).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PR-brief describing phased execution, validation notes and operational constraints.
  * Added runlog and appended decision‑queue entries documenting validation backfills and workflow events.

* **Chores**
  * Updated governance configuration seeds and migration scripts to pin explicit timestamps for deterministic, idempotent seeding and precise rollback behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/barrie-cork/lemmy/pull/128)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->