### PR TITLE
test(seed_founders): unit tests for parse_founder_spec validation (audit 3.E.20)

### DIFF
--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -3577,6 +3577,27 @@
       "answer": "PASS — local cargo-check --workspace --features full exited 0 (2m02s warm, zero errors) on worker tip e19ad8e4d (rebased to c1b3978c0 onto chore/refactor-diesel-errors; clean — admin_audit_stream.rs untouched between merge-base and chore tip, PR-4 migration commit auto-dropped as already-upstream via #128 squash). The merged code uses a `match` on the .optional() Result with `continue` on the Err arm (NOT a .map_err(...).ok().flatten() chain — the bm-pr brief's anticipated variant; the worker chose a cleaner idiomatic match). GH-side workspace check abandoned after 3rd stuck-runner instance (confirmed persistent GH cargo-validate-workspace runner problem; cargo-validate-migration on prior pushes ran fine). Equivalent validation per §5.2 validate-pending-laptop handler. USER-APPROVAL (per-instance, PR-5): user explicitly authorised option (c) advisor-laptop fallback validation on 2026-05-15 ('Go with C', responding to the PR-4 workspace stuck-runner catch-fire) AND granted overnight autonomous operation ('guide this overnight autonomously', 2026-05-15) AND confirmed sequential lane processing ('I prefer to do seqnetially', 2026-05-15) — the authorisation explicitly covers reuse of the §5.2 advisor-laptop fallback mechanism for each refactor lane including this PR-5 instance. Approval evidence: this entry's own timestamp + answered_by:advisor-laptop, cross-referenced to the 2026-05-15 transcript authorisations above (per-instance pointer per CR #129 cr-1). §5.2 validate-pending-laptop is a mechanical validation runner (not an ADR/scope/visible-impact decision per gate-2).",
       "answered_by": "advisor-laptop",
       "resolved_at": "2026-05-15T09:25:08Z"
+    },
+    {
+      "id": 218,
+      "from": "advisor",
+      "kind": "validate-pending",
+      "timestamp": "2026-05-15T12:57:21Z",
+      "question": "PR-6 seed_founders parse_founder_spec unit tests — workspace check + 5-test local run",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Shape-G cargo-validate-workspace run 25917190542 was the 4th persistent stuck-runner (PR-4 x2 + PR-5 x1 + PR-6 x1) — frozen updatedAt since creation, zero job progress; cancelled per advisor-orchestrator.md §5.2 (advisor-laptop fallback, user-authorised 'Go with C' 2026-05-15). cargo-check attempt-1 failed on an uninitialized lemmy_email translations git submodule (crates/email/translations, lemmy-translations.git) in the re-pointed worktree — a worktree-bootstrap defect fixed via `git submodule update --init crates/email/translations`, NOT a code defect. cargo-test attempt-1 failed on a wrong -p selector (impl brief §2.5/§4 said `-p seed_founders` but the crate name is `brehon_seed_founders` — directory name ≠ crate name), corrected to `-p brehon_seed_founders`. Junior worker #266 raised a colliding DQ #214 off a stale daemon governance-v0 base (branched f0c2b75af carrying already-merged PR-4/PR-5 commits) — that entry was DISCARDED; this is the correctly re-authored entry. The cargo-test wrapper applies --workspace (overriding -p), so it executed the full workspace test suite, not only the seed_founders binary.",
+      "answer": "pass — PR-6 is validated. Local cargo-check.bat --workspace --features full → CHECK_EXIT_0 (attempt 2, 6m21s, post submodule-init; full workspace incl brehon_seed_founders compiles clean). The 5 new parse_founder_spec tests ALL PASS: seed_founders test binary reported 'test result: ok. 5 passed; 0 failed; 0 ignored' (parse_founder_spec_valid / _exceeds_max / _negative_delta / _non_numeric / _wrong_segment_count all ... ok). HONEST validation caveat: because the wrapper forces --workspace, the run also executed lemmy_api's lib tests, of which 8 FAILED with 'LazyLock instance has previously been poisoned' originating at crates/utils/src/settings/mod.rs:27 (the SETTINGS LazyLock cannot initialize without Postgres on the laptop; one init failure poisons the process-wide lock and cascades to 7 more). These 8 failures are PRE-EXISTING, DB-environment-dependent tests in a DIFFERENT crate (lemmy_api --lib), entirely UNTOUCHED by PR-6 — PR-6 only appends a #[cfg(test)] mod tests block to crates/tools/seed_founders/src/main.rs, with zero production-code change and no Cargo.toml change. This is the identical laptop-has-no-DB limitation that made PR-4 (#128) and PR-5 (#129) use compile-only (cargo-check) as the Shape-G fallback gate; they shipped on that basis. User reviewed this exact split and confirmed 'Validated — proceed' (2026-05-15). User also authorised the advisor-laptop fallback ('Go with C', 2026-05-15) + overnight autonomy + sequential lane processing — these cover PR-6, the LAST refactor lane (PR-6 of 5; PR-3 dropped via DQ #214).",
+      "answered_by": "advisor-laptop",
+      "branch": "chore/refactor-seed-tests",
+      "phase_task": "PR-6",
+      "workflow_run_id": null,
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "resolved_at": "2026-05-15T12:57:21Z"
     }
   ],
   "schema_version": 2

--- a/.claude/runlog/chore-refactor-seed-tests.md
+++ b/.claude/runlog/chore-refactor-seed-tests.md
@@ -1,0 +1,78 @@
+# Runlog — chore/refactor-seed-tests (PR-6, refactor-tier LAST lane)
+
+Audit-driven refactor-tier PR-6 of 5 (PR-3 dropped via DQ #214).
+Audit finding 3.E.20 (rank 17, severity MED): add unit tests for
+`parse_founder_spec` in `crates/tools/seed_founders/src/main.rs`.
+
+---
+
+## advisor: lane prepared — 2026-05-15
+
+- Cut `chore/refactor-seed-tests` off `governance-v0` tip post-PR-4
+  (#128) + PR-5 (#129) merge. Dispatched impl-task Junior #266 with
+  `base_branch=governance-v0` (NOT `chore/*` — daemon cannot resolve
+  chore refs, per PR-4 #264 + PR-5 #265).
+- **Worker stale-base / DQ-collision (#266):** the daemon's
+  `/srv/brehon-fork` `governance-v0` was stale at task-create time, so
+  worker #266 branched off `f0c2b75af` (carrying already-merged
+  PR-4/PR-5 commits) and raised a colliding **DQ #214** (its stale view
+  maxed at 214; the real max was 217). Recovered by cherry-picking
+  ONLY the real PR-6 code commit (`2e5c301ff` → `58e16fa9d`) onto the
+  current `chore/refactor-seed-tests`; the worker's bad DQ commit was
+  DISCARDED. Re-authored the validate-pending DQ fresh as **#218**.
+- **Worktree-bootstrap submodule defect:** the re-pointed worktree
+  lacked the `crates/email/translations` git submodule
+  (`lemmy-translations.git`); `lemmy_email` `build.rs`
+  `read_dir("translations/backend/")` failed (OS path not found) on
+  cargo-check attempt-1. Fixed via
+  `git submodule update --init crates/email/translations` (checked out
+  `a3f9e466`). NOT a code defect — a worktree-bootstrap miss
+  (`feedback_worktree_submodules_not_auto_init`).
+- **Wrong package selector:** impl brief §2.5/§4 specified
+  `-p seed_founders`, but the crate name is `brehon_seed_founders`
+  (directory name ≠ crate name; confirmed via
+  `grep '^name' crates/tools/seed_founders/Cargo.toml`). cargo-test
+  attempt-1 failed "package not found"; corrected to
+  `-p brehon_seed_founders`.
+- **Shape-G stuck-runner (4th):** `cargo-validate-workspace` run
+  `25917190542` was the 4th persistent stuck-runner (PR-4 ×2 +
+  PR-5 ×1 + PR-6 ×1 — frozen `updatedAt` since creation, zero job
+  progress). Cancelled per `advisor-orchestrator.md` §5.2; advisor-
+  laptop fallback (user-authorised "Go with C" 2026-05-15).
+- **Validation (advisor-laptop §5.2):**
+  `cargo-check.bat --workspace --features full` → `CHECK_EXIT_0`
+  (6m21s, attempt-2 post submodule-init). The 5 `parse_founder_spec_*`
+  tests ALL PASS (`seed_founders` test binary:
+  `test result: ok. 5 passed; 0 failed; 0 ignored`). 8 unrelated
+  `lemmy_api` lib tests failed on the laptop's lack of Postgres
+  (`LazyLock` poison from `crates/utils/src/settings/mod.rs:27`) —
+  pre-existing, DB-env, NOT PR-6 (different crate; identical
+  limitation to PR-4/PR-5 which shipped compile-only). User reviewed
+  the split and confirmed "Validated — proceed" (2026-05-15).
+- **POSITIVE four-role signal:** impl #266 improved on the planning
+  brief — deviated from brief §2.3's clippy-unsafe `.expect()` /
+  `.unwrap_err()` example to `LemmyResult<()>` + `?` with a private
+  `assert_unknown_err` helper (workspace clippy denies unwrap/expect
+  even in tests, per `feedback_clippy_test_style`).
+- Backfilled DQ **#218** to `resolved[]` (result: pass,
+  `answered_by: advisor-laptop`); committed `bbae3e2fa`, pushed
+  `origin chore/refactor-seed-tests`.
+
+## bm: PR opened — 2026-05-15
+
+- bm-pr run **INLINE by advisor** (L3/L15 — Junior bm-task
+  `base_branch=chore/*` fails on daemon worktree-ref resolution; see
+  PR-4 #264 + PR-5 #265).
+- Lane tip verified: `bbae3e2fa` (DQ #218) → `58e16fa9d` (PR-6 code)
+  → `6cdbe5926` (merged PR-5). Diff vs `governance-v0` = exactly 2
+  files: `crates/tools/seed_founders/src/main.rs` (+75) +
+  `.claude/decision-queue.json` (+21). Zero production-code change,
+  no `Cargo.toml`, zero cross-lane file overlap.
+- **PR #130** opened:
+  https://github.com/barrie-cork/lemmy/pull/130 —
+  `chore/refactor-seed-tests` → `governance-v0`, not draft,
+  `--repo barrie-cork/lemmy`. Title:
+  `test(seed_founders): unit tests for parse_founder_spec validation
+  (audit 3.E.20)`.
+- Awaiting CodeRabbit auto-review. No PR comment / review submitted
+  (Manual per autonomy table).

--- a/crates/tools/seed_founders/src/main.rs
+++ b/crates/tools/seed_founders/src/main.rs
@@ -315,3 +315,78 @@ async fn main() -> LemmyResult<()> {
   let args = Args::parse();
   run(args).await
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn assert_unknown_err(result: LemmyResult<FounderSpec>, substr: &str) -> LemmyResult<()> {
+    match result {
+      Ok(_) => Err(LemmyErrorType::Unknown(format!("expected Err containing '{substr}'")).into()),
+      Err(e) => match &e.error_type {
+        LemmyErrorType::Unknown(msg) => {
+          assert!(msg.contains(substr), "error missing '{substr}'; got: {msg}");
+          Ok(())
+        }
+        _ => Err(
+          LemmyErrorType::Unknown(format!("unexpected error variant: {}", e.error_type)).into(),
+        ),
+      },
+    }
+  }
+
+  #[test]
+  fn parse_founder_spec_valid() -> LemmyResult<()> {
+    let spec = parse_founder_spec("42:5:10:15", 100)?;
+    assert_eq!(spec.person_id.0, 42);
+    assert_eq!(spec.jury_reliability, 5);
+    assert_eq!(spec.reporting_accuracy, 10);
+    assert_eq!(spec.endorsement_strength, 15);
+    Ok(())
+  }
+
+  #[test]
+  fn parse_founder_spec_negative_delta() -> LemmyResult<()> {
+    assert_unknown_err(parse_founder_spec("1:0:5:5", 100), "jury_reliability must be > 0")?;
+    assert_unknown_err(
+      parse_founder_spec("1:5:-3:5", 100),
+      "reporting_accuracy must be > 0",
+    )?;
+    Ok(())
+  }
+
+  #[test]
+  fn parse_founder_spec_exceeds_max() -> LemmyResult<()> {
+    assert_unknown_err(
+      parse_founder_spec("1:101:5:5", 100),
+      "jury_reliability=101 exceeds founder.max_seed_delta=100",
+    )?;
+    Ok(())
+  }
+
+  #[test]
+  fn parse_founder_spec_wrong_segment_count() -> LemmyResult<()> {
+    assert_unknown_err(
+      parse_founder_spec("1:5:5", 100),
+      "must be PERSON_ID:JUR:RPT:END",
+    )?;
+    assert_unknown_err(
+      parse_founder_spec("1:5:5:5:5", 100),
+      "must be PERSON_ID:JUR:RPT:END",
+    )?;
+    Ok(())
+  }
+
+  #[test]
+  fn parse_founder_spec_non_numeric() -> LemmyResult<()> {
+    assert_unknown_err(
+      parse_founder_spec("not_a_num:5:5:5", 100),
+      "person-id not a valid i32",
+    )?;
+    assert_unknown_err(
+      parse_founder_spec("1:abc:5:5", 100),
+      "jury_reliability not a valid i32",
+    )?;
+    Ok(())
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `#[cfg(test)] mod tests` block at the end of `crates/tools/seed_founders/src/main.rs` with exactly **5 sync `#[test]` cases** covering `parse_founder_spec` validation:

- `parse_founder_spec_valid` — happy path (well-formed `PERSON_ID:JUR:RPT:END`, all values in range)
- `parse_founder_spec_negative_delta` — zero / negative reputation dimensions reject (each must be > 0)
- `parse_founder_spec_exceeds_max` — values > `max_seed_delta` reject
- `parse_founder_spec_wrong_segment_count` — ≠4 colon-separated segments reject
- `parse_founder_spec_non_numeric` — non-i32 segments reject with parse-error message

`parse_founder_spec` is the CLI entry-point parser for the founder-seeding tool; before this change it had zero edge-case coverage (audit §3.E.20, rank 17, severity MED). **PURE additive** — no production code touched, no `Cargo.toml` change (`LemmyErrorType` already imported). Tests are sync (`#[test]`, not `#[tokio::test]`) — no DB / testcontainers; run in <1s.

**Note — impl improved on the planning brief:** the impl brief §2.3 example used `.expect()` / `.unwrap_err()`, which the workspace clippy config denies even in test code (per `feedback_clippy_test_style`). Junior #266 correctly deviated, using `LemmyResult<()>` + `?` with a private `assert_unknown_err` helper instead — idiomatic and clippy-clean. Good four-role signal (impl caught a planning-brief defect).

## Plan reference

Ad-hoc — no plan file (chore branch; audit-driven refactor-tier **PR-6 of 5 — LAST lane** — per `.claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md`; PR-3 was dropped via DQ #214 so the gate is 5 PRs, not 6).

## Closes

Closes audit finding **3.E.20** (`v1-code-quality-audit-2026-05-14.md`, rank 17, severity MED).

## Validation

Shape-G `cargo-validate-workspace` run `25917190542` was the **4th persistent stuck-runner** (PR-4 ×2 + PR-5 ×1 + PR-6 ×1 — frozen `updatedAt` since creation, zero job progress); cancelled per `advisor-orchestrator.md` §5.2 (advisor-laptop fallback, user-authorised "Go with C" 2026-05-15). Tracked as **DQ #218** (result: pass).

Advisor-laptop §5.2 validation:

- `cargo-check.bat --workspace --features full` → **CHECK_EXIT_0** (6m21s; full workspace incl. `brehon_seed_founders` compiles clean; attempt-2 post submodule-init — a re-pointed-worktree bootstrap defect, `crates/email/translations` uninitialized, fixed via `git submodule update --init`, not a code defect).
- `cargo-test.bat --workspace --features full -p brehon_seed_founders --tests` → the **5 `parse_founder_spec_*` tests ALL PASS**: `seed_founders` test binary reported `test result: ok. 5 passed; 0 failed; 0 ignored`.

**Honest validation caveat:** the cargo-test wrapper forces `--workspace` (overriding `-p`), so the run also executed `lemmy_api`'s lib tests, of which 8 failed with `LazyLock instance has previously been poisoned` originating at `crates/utils/src/settings/mod.rs:27` (the `SETTINGS` `LazyLock` cannot initialize without Postgres on the laptop; one init failure poisons the process-wide lock and cascades to 7 more). These 8 are **pre-existing, DB-environment-dependent tests in a DIFFERENT crate** (`lemmy_api --lib`), entirely **untouched by PR-6** (PR-6 only appends a test module to `crates/tools/seed_founders/src/main.rs`). This is the identical laptop-has-no-DB limitation that made PR-4 (#128) and PR-5 (#129) use compile-only as the Shape-G fallback gate; they shipped on that basis. User reviewed this exact split and confirmed "Validated — proceed" (2026-05-15).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for founder specification validation, covering valid parsing, error handling for invalid delimiters, numeric validation, and boundary checks.

* **Chores**
  * Updated internal documentation and workflow validation records to improve development process tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/barrie-cork/lemmy/pull/130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->