### PR TITLE
fix(api_crud): wrap create_report SELECT-then-write in run_transaction (audit 3.B.1 CRIT)

### DIFF
--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -3598,6 +3598,27 @@
       "log_slice": null,
       "failed_jobs": null,
       "resolved_at": "2026-05-15T12:57:21Z"
+    },
+    {
+      "id": 219,
+      "from": "advisor",
+      "kind": "validate-pending",
+      "timestamp": "2026-05-15T15:42:13Z",
+      "question": "PR-2 create_report.rs run_transaction TOCTOU fix (audit 3.B.1 CRIT) — workspace check + test-target compile",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Shape-G cargo-validate-workspace triggers on junior/* pushes ONLY (not chore/*). Worker #267's junior/* push triggered run 25924783575, which was the 5TH PERSISTENT stuck-runner (PR-4 x2 + PR-5 x1 + PR-6 x1 + PR-2 x1) — status=in_progress, updatedAt frozen at 14:58:58Z since creation 14:58:52Z (~70min stale, job 'validate workspace' zero progress); CANCELLED per advisor-orchestrator.md §5.2 (advisor-laptop fallback, user-authorised 'Go with C' 2026-05-15 + overnight autonomy + sequential lane processing — covers PR-2). L1 daemon-base ROOT FIX was applied PRE-DISPATCH: the daemon /srv/brehon-fork governance-v0 was STALE at ac52534e3d (not on the merged lineage — exact root cause of PR-6 #266's colliding DQ #214); reset to origin/governance-v0 09db10847, so worker #267 branched from the correct base and raised its own DQ #219 (from:impl) CLEANLY off that base with no id collision (the L1 fix worked — 'raised-clean' mode, contrast PR-6 #266 stale-collision). The advisor cherry-picked ONLY the code commit 511640ae9 (-> e57c20e9e on chore) onto chore/refactor-toctou, NOT the worker's GH-Shape-G-referencing DQ commit; this advisor-laptop entry is the authoritative validation record (id 219 is free on the chore branch since the worker DQ commit was not cherry-picked). L6 submodule fix applied pre-emptively (crates/email/translations init'd) so no lemmy_email build.rs read_dir failure recurred. The cargo-test wrapper applies --workspace; --no-run means it COMPILES all test targets (incl e2e.rs) but executes nothing — pure compile-gate, correct for a structural refactor.",
+      "answer": "pass — PR-2 is validated. Local cargo-check.bat --workspace --features full -> CHECK_EXIT_0 (Finished dev profile in 12m14s; full workspace incl lemmy_api_crud — the crate containing create_report.rs — compiled clean, zero error[/could-not-compile/unused-import). Local cargo-test.bat --workspace --features full --no-run -> TESTCOMPILE_EXIT_0 (all test targets incl tests/e2e.rs + test_errors_used.rs compiled clean). The refactor (extract process_report helper mirroring create_endorsement::process_endorsement; wrap SELECT-then-UPDATE/INSERT block in conn.run_transaction; hoist pseudonym fetch pre-tx per ADR-015; rewire governance_log::append from pre-tx pool_ref to in-tx &mut (&mut *conn).into() so log appends are atomic with the case write) compiles with zero behavior change. Logs: C:/Users/barri/.claude/logs/pr2-check.log + C:/Users/barri/.claude/logs/pr2-testcompile.log. NOTE: no concurrency test added (out of scope per impl brief §5); pre-tx reason_code validation intentionally left pre-tx per audit §3.B.6 positive exemplar. This is the same compile-only Shape-G fallback gate PR-4 (#128) + PR-5 (#129) + PR-6 (#130) shipped on (laptop has no Postgres so DB-dependent tests can't execute); user reviewed + confirmed this validation model and authorised §5.2 advisor-laptop fallback + overnight autonomy + sequential lane (2026-05-15) — covers PR-2 (refactor-tier PR-2 of 5; PR-3 dropped via DQ #214; PR-1 is the LAST and is user-gated explicitly before dispatch).",
+      "answered_by": "advisor-laptop",
+      "branch": "chore/refactor-toctou",
+      "phase_task": "PR-2",
+      "workflow_run_id": null,
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "resolved_at": "2026-05-15T15:42:13Z"
     }
   ],
   "schema_version": 2

--- a/.claude/runlog/chore-refactor-toctou.md
+++ b/.claude/runlog/chore-refactor-toctou.md
@@ -92,3 +92,26 @@ sequential.
   user gate 3 → user gate 5 → merge → strict-gate 4/5 → surface PR-1
   for explicit user go-ahead (do NOT auto-start the highest-risk
   e2e.rs lane).
+
+## bm: PR opened — 2026-05-15
+
+- **bm-pr run INLINE by advisor** (L3/L15 — Junior bm-task
+  `base_branch=chore/*` fails on daemon worktree-ref resolution;
+  proven PR-4 #264 + PR-5 #265 + PR-6 #130). Brief read from canonical
+  governance-v0 `.claude/PRPs/briefs/refactor-toctou-bm-pr.md` (L5 —
+  NOT cherry-picked onto this branch).
+- **PR #131 opened**: `fix(api_crud): wrap create_report
+  SELECT-then-write in run_transaction (audit 3.B.1 CRIT)` →
+  base `governance-v0`, head `chore/refactor-toctou`, NOT draft,
+  `--repo barrie-cork/lemmy`.
+  URL: https://github.com/barrie-cork/lemmy/pull/131
+- Commits in PR (base `09db10847`): `653174f03` + `be0d1eda5` (lane
+  runlog prep + dispatch), `e57c20e9e` (`fix(api_crud)` code commit
+  cherry-picked from worker #267 `511640ae9`), `c8449d340` (DQ #219
+  advisor-laptop validate-pending pass + runlog).
+- No PR comment posted, no review submitted (Manual/ask per autonomy
+  table — triage digest is the separate user-gate-3 step).
+- Awaiting CodeRabbit final review → findings YAML → user gate 3
+  (CR triage) → user gate 5 (merge confirm) → squash-merge →
+  strict-gate 4/5 → surface PR-1 (LAST, highest-risk) for explicit
+  user go-ahead.

--- a/.claude/runlog/chore-refactor-toctou.md
+++ b/.claude/runlog/chore-refactor-toctou.md
@@ -43,3 +43,52 @@ sequential.
   0 active / 0 queued). Awaiting worker completion → Shape-G validate
   (or §5.2 advisor-laptop fallback if stuck-runner recurs per L2) →
   bm-pr inline (L3) → CR → user gate 3 → user gate 5 → merge.
+
+## advisor: validated — 2026-05-15
+
+- **Junior #267 done** (run #1 succeeded, 14:42→15:00Z ~17min). Worker
+  raised DQ #219 (`from:impl`) CLEANLY off the L1-fixed base — NO id
+  collision (contrast PR-6 #266 stale-base collision DQ #214). **The
+  proactive L1 daemon-base root fix worked** — empirically confirmed
+  the retro diagnosis. Worker code commit `511640ae9`:
+  - touches ONLY `crates/api/api_crud/src/governance/create_report.rs`
+    (+65/-11); subject `fix(api_crud): wrap create_report
+    SELECT-then-write in run_transaction (audit 3.B.1 CRIT)`.
+  - extracts `process_report` helper mirroring
+    `create_endorsement::process_endorsement`
+    (`#[allow(clippy::too_many_arguments)]`, returns
+    `LemmyResult<CreateGovernanceReportResponse>`).
+  - wraps the SELECT-then-UPDATE/INSERT block in
+    `conn.run_transaction(|conn| async move {…}.scope_boxed())` —
+    CRITICAL TOCTOU race closed.
+  - hoists pseudonym fetch PRE-tx (mirrors `create_endorsement.rs` per
+    ADR-015); rewires `governance_log::append` from pre-tx `pool_ref`
+    to in-tx `&mut (&mut *conn).into()` (substantive: log appends now
+    atomic with the case write). Zero behavior change.
+- Cherry-picked ONLY `511640ae9` → `e57c20e9e` on chore (NOT the
+  worker's GH-Shape-G-referencing DQ commit). `git diff --stat
+  origin/governance-v0...HEAD` = ONLY `create_report.rs` + this runlog
+  + DQ — no scope creep.
+- Pushed `chore/refactor-toctou` (`be0d1eda5..e57c20e9e`).
+  `cargo-validate-workspace.yml` triggers on `junior/*` ONLY (not
+  `chore/*`); worker #267 `junior/*` push triggered run `25924783575`
+  = **5th persistent stuck-runner** (PR-4 ×2 + PR-5 ×1 + PR-6 ×1 +
+  PR-2 ×1 — frozen `in_progress`, zero job progress). Cancelled per
+  advisor-orchestrator.md §5.2 (advisor-laptop fallback,
+  user-authorised "Go with C" + overnight autonomy + sequential lane).
+- **§5.2 advisor-laptop validation — PASS:** local
+  `cargo-check.bat --workspace --features full` → `CHECK_EXIT_0`
+  (12m14s, `lemmy_api_crud` clean); local `cargo-test.bat --workspace
+  --features full --no-run` → `TESTCOMPILE_EXIT_0` (all test targets
+  incl `e2e.rs` compiled clean). Logs at
+  `C:/Users/barri/.claude/logs/pr2-check.log` +
+  `pr2-testcompile.log`. Authoritative entry: **DQ #219**
+  (`from:advisor`, `kind:validate-pending`, `result:pass`,
+  `answered_by:advisor-laptop`). L6 submodule was init'd pre-emptively
+  — no `lemmy_email build.rs` failure recurred.
+- Next: bm-pr INLINE (L3/L15) per
+  `.claude/PRPs/briefs/refactor-toctou-bm-pr.md` (authored on
+  governance-v0 `a998ecc03` — L5: NOT cherry-picked here) → CR →
+  user gate 3 → user gate 5 → merge → strict-gate 4/5 → surface PR-1
+  for explicit user go-ahead (do NOT auto-start the highest-risk
+  e2e.rs lane).

--- a/.claude/runlog/chore-refactor-toctou.md
+++ b/.claude/runlog/chore-refactor-toctou.md
@@ -1,0 +1,41 @@
+# Runlog — chore/refactor-toctou (PR-2, refactor-tier serial lane — FIRST of 2 remaining)
+
+Audit-driven refactor-tier PR-2 of 5. Audit finding **3.B.1**
+(rank 3, severity **CRITICAL**): wrap the SELECT-then-UPDATE/INSERT
+block in `crates/api/api_crud/src/governance/create_report.rs` in
+`run_transaction` (TOCTOU race; sibling `create_endorsement.rs` /
+`revoke_endorsement.rs` already use the pattern — internal
+inconsistency).
+
+Sequencing: PR-4 #128 + PR-5 #129 + PR-6 #130 (the Step-2c parallel
+cohort) shipped 2026-05-15. PR-2 + PR-1 are the Step-2a/2b serial
+dedicated lanes. User chose **PR-2 first, then PR-1** (low-risk
+isolated 1-file fix before the high-risk e2e.rs reshape). Strictly
+sequential.
+
+---
+
+## advisor: lane prepared — 2026-05-15
+
+- **L1 ROOT FIX applied first (tonight's retro lesson):** the daemon
+  `/srv/brehon-fork` `governance-v0` was STALE at `ac52534e3d` (not
+  even on the merged lineage — exactly the root cause of PR-6 #266's
+  colliding DQ #214). Ran `ssh homeserver: cd /srv/brehon-fork &&
+  git fetch origin && git reset --hard origin/governance-v0` →
+  daemon now at `09db10847` (current tip incl. PR-4/5/6 + retro).
+  PR-2 worker will branch from the correct base.
+- bm-cut run **INLINE by advisor** (L3/L15 — Junior bm-task
+  `base_branch=chore/*` fails on daemon worktree-ref resolution;
+  proven PR-4 #264 + PR-5 #265).
+- Trunk verified clean + synced (`09db10847` == origin/governance-v0).
+- Cut `chore/refactor-toctou` off `governance-v0` @ `09db10847`
+  (local-only, no push — per bm-cut brief Phase 3).
+- Added lane-dedicated worktree
+  `C:/Users/barri/Developer/brehon-fork-refactor-toctou`.
+- **L6 FIX applied proactively (tonight's lesson):**
+  `git submodule update --init crates/email/translations` in the new
+  worktree (checked out `a3f9e466`) — re-pointed worktrees don't
+  auto-init submodules; this prevents the PR-6 cargo-check
+  `lemmy_email build.rs read_dir` failure before it can happen.
+- Next: dispatch impl-task Junior with `base_branch=governance-v0`
+  (NOT `chore/*` — L3) per `.claude/PRPs/briefs/refactor-toctou-impl.md`.

--- a/.claude/runlog/chore-refactor-toctou.md
+++ b/.claude/runlog/chore-refactor-toctou.md
@@ -37,5 +37,9 @@ sequential.
   worktree (checked out `a3f9e466`) — re-pointed worktrees don't
   auto-init submodules; this prevents the PR-6 cargo-check
   `lemmy_email build.rs read_dir` failure before it can happen.
-- Next: dispatch impl-task Junior with `base_branch=governance-v0`
+- Dispatched impl-task **Junior #267** with `base_branch=governance-v0`
   (NOT `chore/*` — L3) per `.claude/PRPs/briefs/refactor-toctou-impl.md`.
+  Daemon health confirmed pre-dispatch (PID 258450, uptime 195h,
+  0 active / 0 queued). Awaiting worker completion → Shape-G validate
+  (or §5.2 advisor-laptop fallback if stuck-runner recurs per L2) →
+  bm-pr inline (L3) → CR → user gate 3 → user gate 5 → merge.

--- a/crates/api/api_crud/src/governance/create_report.rs
+++ b/crates/api/api_crud/src/governance/create_report.rs
@@ -34,7 +34,7 @@ use diesel::{
   insert_into,
   update,
 };
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
 use lemmy_api::governance::{
   actor_pseudonym_helper,
   case_open_snapshot,
@@ -89,8 +89,12 @@ pub async fn create_report(
     target_remote_url,
   } = resolve_target(&context, data.target_type, data.target_id).await?;
 
-  let pool_ref = &mut context.pool();
-  let conn = &mut get_conn(pool_ref).await?;
+  // PRE-TX: fetch pseudonym before acquiring the transaction connection
+  // (mirrors create_endorsement.rs pattern per ADR-015).
+  let pseudonym = actor_pseudonym_helper::get_or_create(&mut context.pool(), reporter_id).await?;
+
+  let pool = &mut context.pool();
+  let conn = &mut get_conn(pool).await?;
 
   // Phase 5b task 58: compute the OQ-006 weight from config + reporter
   // snapshot. ConfigCache lives for the whole handler invocation.
@@ -127,6 +131,57 @@ pub async fn create_report(
   let recency_factor = (-hours_old / half_life_hours).exp();
   let weight_micros = compute_weight_micros(base_weight, reporter_reputation, recency_factor);
 
+  let data_for_tx = data;
+  let pseudonym_for_tx = pseudonym;
+
+  let outcome = conn
+    .run_transaction(|conn| {
+      async move {
+        process_report(
+          conn,
+          reporter_id,
+          pseudonym_for_tx,
+          data_for_tx,
+          weight_micros,
+          threshold_micros,
+          reporter_reputation,
+          target_post_id,
+          target_comment_id,
+          target_person_id,
+          target_community_id,
+          target_remote_url,
+          reason_code,
+          cache,
+        )
+        .await
+      }
+      .scope_boxed()
+    })
+    .await?;
+
+  Ok(Json(outcome))
+}
+
+/// Body of the `run_transaction` closure. Named helper so the outer
+/// future stays under the workspace `large_futures` lint threshold
+/// (mirror of `create_endorsement::process_endorsement`).
+#[allow(clippy::too_many_arguments)]
+async fn process_report(
+  conn: &mut AsyncPgConnection,
+  reporter_id: PersonId,
+  pseudonym: String,
+  data: CreateGovernanceReport,
+  weight_micros: i64,
+  threshold_micros: i64,
+  reporter_reputation: f64,
+  target_post_id: Option<PostId>,
+  target_comment_id: Option<CommentId>,
+  target_person_id: Option<PersonId>,
+  target_community_id: Option<CommunityId>,
+  target_remote_url: Option<String>,
+  reason_code: String,
+  mut cache: ConfigCache,
+) -> LemmyResult<CreateGovernanceReportResponse> {
   let existing: Option<(ModerationCaseId, i64, CaseStatus)> = moderation_case::table
     .filter(moderation_case::target_type.eq(data.target_type))
     .filter(
@@ -189,10 +244,11 @@ pub async fn create_report(
         None => Scope::Instance,
       };
       let applied_config_snapshot =
-        case_open_snapshot::build_applied_config_snapshot(&mut conn.into(), case_scope).await?;
+        case_open_snapshot::build_applied_config_snapshot(&mut (&mut *conn).into(), case_scope)
+          .await?;
       let active_version_i64 = config::get_int_opt(
         &mut cache,
-        &mut conn.into(),
+        &mut (&mut *conn).into(),
         case_scope,
         "rule_set.active_version_id",
       )
@@ -231,10 +287,8 @@ pub async fn create_report(
     }
   };
 
-  let pseudonym = actor_pseudonym_helper::get_or_create(pool_ref, reporter_id).await?;
-
   governance_log::append(
-    pool_ref,
+    &mut (&mut *conn).into(),
     "report_created",
     json!({
       "case_id": case_id.0,
@@ -249,7 +303,7 @@ pub async fn create_report(
 
   if just_met_threshold {
     governance_log::append(
-      pool_ref,
+      &mut (&mut *conn).into(),
       "threshold_met",
       json!({
         "case_id": case_id.0,
@@ -260,10 +314,10 @@ pub async fn create_report(
     .await?;
   }
 
-  Ok(Json(CreateGovernanceReportResponse {
+  Ok(CreateGovernanceReportResponse {
     case_id: Some(case_id),
     threshold_met: just_met_threshold,
-  }))
+  })
 }
 
 /// Pure OQ-006 weight computation in micros.


### PR DESCRIPTION
## Summary

Wraps the SELECT-then-UPDATE/INSERT block in `crates/api/api_crud/src/governance/create_report.rs` in `conn.run_transaction(...)`, closing a **CRITICAL TOCTOU race** (audit §3.B.1, rank 3, severity CRITICAL): two concurrent `create_report` calls for the same target could both read "no existing case" then both INSERT, or interleave the case-version UPDATE with another writer.

- Extracts a `process_report` helper holding the transaction-closure body, mirroring `create_endorsement::process_endorsement` (named helper keeps the outer future under the workspace `large_futures` lint threshold; `#[allow(clippy::too_many_arguments)]`).
- Pseudonym fetch is hoisted **pre-transaction** (mirrors `create_endorsement.rs` per ADR-015).
- `governance_log::append` rewired from the pre-tx `pool_ref` to the in-tx connection (`&mut (&mut *conn).into()`) so log appends are now **atomic with the case write** (substantive correctness improvement — previously appends ran outside the case-write boundary).
- Pre-tx validation (reason_code checks) intentionally left at pre-tx position per audit §3.B.6 positive exemplar.
- **ZERO behavior change** on the success path; no concurrency test added (out of scope per impl brief §5).

Sibling `create_endorsement.rs` / `revoke_endorsement.rs` already use this pattern — this restores internal consistency across the governance write handlers.

## Plan reference

Ad-hoc — no plan file (chore branch; audit-driven refactor-tier **PR-2 of 5** — serial dedicated lane Step-2b — per `.claude/PRPs/handovers/refactor-execution-plan-2026-05-14.md`; PR-3 was dropped via DQ #214 so the gate is 5 PRs not 6; user-chosen sequencing PR-2 first then PR-1).

## Closes

Closes audit finding **3.B.1** (`v1-code-quality-audit-2026-05-14.md`, rank 3, severity CRITICAL).

## Validation

Shape-G `cargo-validate-workspace` triggers on `junior/*` pushes only (NOT `chore/*`). Worker #267's `junior/*` push triggered run `25924783575`, which was the **5th persistent stuck-runner** (PR-4 ×2 + PR-5 ×1 + PR-6 ×1 + PR-2 ×1 — `in_progress` frozen since creation, zero job progress). Cancelled per `advisor-orchestrator.md` §5.2 (advisor-laptop fallback, user-authorised "Go with C" 2026-05-15 + overnight autonomy + sequential lane).

**advisor-laptop §5.2 validation — PASS** (DQ #219, `from:advisor`, `kind:validate-pending`, `result:pass`, `answered_by:advisor-laptop`):

- `cargo-check.bat --workspace --features full` → `CHECK_EXIT_0` (Finished dev profile in 12m14s; full workspace incl `lemmy_api_crud` — the crate containing `create_report.rs` — compiled clean, zero `error[`/`could-not-compile`/unused-import).
- `cargo-test.bat --workspace --features full --no-run` → `TESTCOMPILE_EXIT_0` (all test targets incl `tests/e2e.rs` + `test_errors_used.rs` compiled clean).

This is the same compile-only Shape-G fallback gate PR-4 (#128) + PR-5 (#129) + PR-6 (#130) shipped on (laptop has no Postgres so DB-dependent tests can't execute; user reviewed + confirmed this validation model). The L1 daemon-base root fix was applied pre-dispatch (daemon `governance-v0` was stale `ac52534e3d`; reset to `origin/governance-v0` `09db10847`) so worker #267 branched from the correct base and raised its own DQ #219 cleanly with no id collision. L6 submodule (`crates/email/translations`) init'd pre-emptively — no `lemmy_email build.rs` failure recurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Resolved a time-of-check-time-of-use race condition in the report creation process that could result in inconsistent database state during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/barrie-cork/lemmy/pull/131)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->