### PR TITLE
refactor(e2e): v1-quality-r3 — EnvVarGuard C4 sweep (23 raw set_var sites)

### DIFF
--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,6 +1,32 @@
 {
   "schema_version": 3,
-  "pending": [],
+  "pending": [
+    {
+      "id": "65b95cc574c8-002",
+      "from": "impl",
+      "kind": "validate-pending-laptop-e2e",
+      "timestamp": "2026-05-30T22:48:42Z",
+      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "T2 wrapped all test-body INIT/GOV sites (10 fns, Edits A-J); T1 documented 2 bootstrap exceptions. Phase tip at cca087156e2bf18b2032c2d1807bc9a0452e537e. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class).",
+      "branch": "junior/role-impl-task-v1-quality-r3-task-2-envvarguard-wrap-test-body-setter-sites-see-claude-prps-briefs-v1-quality-r3-im-532",
+      "phase_task": "2",
+      "commands": [
+        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
+      ],
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null
+    }
+  ],
   "resolved": [
     {
       "from": "planner",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -4905,6 +4905,23 @@
       "approved_by": null,
       "approved_at": null,
       "id": "630fc36b795c-002"
+    },
+    {
+      "id": "65b95cc574c8-001",
+      "from": "impl",
+      "kind": "log",
+      "timestamp": "2026-05-30T22:47:32Z",
+      "question": "brief audit window (400 chars) too small for T1's 7-line SAFETY comment blocks; modified 800-char window passes cleanly",
+      "options": [
+        "widen-audit-window-to-800-in-future-briefs",
+        "no-action-impl-is-correct"
+      ],
+      "context": "v1-quality-r3 T2: cargo-check=exit0, clippy=exit0. Python audit with 400-char has_safety() window fails for lines 840/841 and 6122/6123 (bootstrap exceptions) because T1's SAFETY justification block is ~573 chars above the set_var calls. Modified audit with 800-char window: all 4 sites have SAFETY, count=2 INIT+2 GOV (correct). All 10 test-body sites wrapped. Implementation is correct. Audit window miscalibrated in the brief, not in the impl. Self-resolving as log — would-advisor-agree test: yes, 800-char evidence is unambiguous.",
+      "answer": "impl-self-resolved: 800-char audit passes (0 unsafe-without-SAFETY sites); count 2+2 correct; implementation is sound. Recommend: future briefs use 800+ char window for has_safety() when SAFETY comment blocks are multi-line. Proceeding with commit.",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-05-30T22:47:32Z",
+      "approved_by": null,
+      "approved_at": null
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,32 +1,6 @@
 {
   "schema_version": 3,
-  "pending": [
-    {
-      "id": "4b129a8b08f1-001",
-      "from": "impl",
-      "kind": "validate-pending-laptop-e2e",
-      "timestamp": "2026-05-30T23:01:26Z",
-      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "T2 wrapped all 10 test-body INIT/GOV sites with EnvVarGuard; T1 documented 2 bootstrap exceptions with SAFETY comments. Phase tip at bf3f7201d. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class.md).",
-      "branch": "phase-v1-quality-r3",
-      "phase_task": "2",
-      "commands": [
-        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
-      ],
-      "result": null,
-      "log_slice": null,
-      "failed_commands": null,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null
-    }
-  ],
+  "pending": [],
   "resolved": [
     {
       "from": "planner",
@@ -4971,6 +4945,31 @@
       "answer": "Duplicate of 4b129a8b08f1-001 (two job runs for the same T2 task). Advisor resolved as duplicate; 4b129a8b08f1-001 is the live e2e gate entry.",
       "answered_by": "advisor",
       "resolved_at": "2026-05-30T23:21:47Z",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "4b129a8b08f1-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-e2e",
+      "timestamp": "2026-05-30T23:01:26Z",
+      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "T2 wrapped all 10 test-body INIT/GOV sites with EnvVarGuard; T1 documented 2 bootstrap exceptions with SAFETY comments. Phase tip at bf3f7201d. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class.md).",
+      "branch": "phase-v1-quality-r3",
+      "phase_task": "2",
+      "commands": [
+        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
+      ],
+      "result": "pass",
+      "log_slice": "126 passed; 0 failed; 5 ignored; finished in 2716.29s",
+      "failed_commands": null,
+      "answer": "e2e gate passed: 126/0/5, E2E_EXIT_0, 2716s. Advisor-laptop run 2026-05-31.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-05-31T00:23:46Z",
       "approved_by": null,
       "approved_at": null
     }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,6 +1,32 @@
 {
   "schema_version": 3,
-  "pending": [],
+  "pending": [
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-e2e",
+      "timestamp": "2026-05-30T23:01:26Z",
+      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "T2 wrapped all 10 test-body INIT/GOV sites with EnvVarGuard; T1 documented 2 bootstrap exceptions with SAFETY comments. Phase tip at bf3f7201d. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class.md).",
+      "branch": "phase-v1-quality-r3",
+      "phase_task": "2",
+      "commands": [
+        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
+      ],
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "id": "4b129a8b08f1-001"
+    }
+  ],
   "resolved": [
     {
       "from": "planner",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -25,31 +25,6 @@
       "resolved_at": null,
       "approved_by": null,
       "approved_at": null
-    },
-    {
-      "id": "65b95cc574c8-002",
-      "from": "impl",
-      "kind": "validate-pending-laptop-e2e",
-      "timestamp": "2026-05-30T22:48:42Z",
-      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "T2 wrapped all test-body INIT/GOV sites (10 fns, Edits A-J); T1 documented 2 bootstrap exceptions. Phase tip at cca087156e2bf18b2032c2d1807bc9a0452e537e. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class).",
-      "branch": "junior/role-impl-task-v1-quality-r3-task-2-envvarguard-wrap-test-body-setter-sites-see-claude-prps-briefs-v1-quality-r3-im-532",
-      "phase_task": "2",
-      "commands": [
-        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
-      ],
-      "result": null,
-      "log_slice": null,
-      "failed_commands": null,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null
     }
   ],
   "resolved": [
@@ -4971,6 +4946,31 @@
       "answer": "impl-self-resolved: 800-char audit passes (0 unsafe-without-SAFETY sites); count 2+2 correct; implementation is sound. Recommend: future briefs use 800+ char window for has_safety() when SAFETY comment blocks are multi-line. Proceeding with commit.",
       "answered_by": "impl-self-resolved",
       "resolved_at": "2026-05-30T22:47:32Z",
+      "approved_by": null,
+      "approved_at": null
+    },
+    {
+      "id": "65b95cc574c8-002",
+      "from": "impl",
+      "kind": "validate-pending-laptop-e2e",
+      "timestamp": "2026-05-30T22:48:42Z",
+      "question": "Run full e2e gate (R12) for v1-quality-r3 at phase tip — env-var-management refactor class mandatory",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "T2 wrapped all test-body INIT/GOV sites (10 fns, Edits A-J); T1 documented 2 bootstrap exceptions. Phase tip at cca087156e2bf18b2032c2d1807bc9a0452e537e. Full e2e mandatory per gate4 rule (feedback_gate4_full_e2e_env_refactor_class).",
+      "branch": "junior/role-impl-task-v1-quality-r3-task-2-envvarguard-wrap-test-body-setter-sites-see-claude-prps-briefs-v1-quality-r3-im-532",
+      "phase_task": "2",
+      "commands": [
+        "cmd //c \"scripts\\\\brehon\\\\cargo-test.bat --workspace --test e2e --features full > .claude/PRPs/debug/v1-quality-r3-e2e.log 2>&1 && echo E2E_EXIT_0 >> .claude/PRPs/debug/v1-quality-r3-e2e.log || echo E2E_EXIT_NONZERO >> .claude/PRPs/debug/v1-quality-r3-e2e.log\""
+      ],
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "answer": "Duplicate of 4b129a8b08f1-001 (two job runs for the same T2 task). Advisor resolved as duplicate; 4b129a8b08f1-001 is the live e2e gate entry.",
+      "answered_by": "advisor",
+      "resolved_at": "2026-05-30T23:21:47Z",
       "approved_by": null,
       "approved_at": null
     }

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -2568,13 +2568,8 @@ async fn report_to_modlog_golden_path() -> lemmy_utils::error::LemmyResult<()> {
   // -- 1. Set env vars BEFORE any Lemmy code touches `SETTINGS`. --------
   // Deterministic 32-byte ed25519 seed: 31 zero bytes + 0x01.
   const SIGNING_SEED_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000001";
-  // SAFETY: tests run with --test-threads=1 so no concurrent env mutation;
-  // these vars are read by SETTINGS (LazyLock) and the governance log
-  // signer at first call.
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
 
   // -- 2. Spin up Postgres and apply the full schema. -------------------
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
@@ -3349,11 +3344,8 @@ async fn sponsor_liability_with_founder_multiplier() -> lemmy_utils::error::Lemm
   use reqwest_middleware::ClientBuilder;
 
   const SIGNING_SEED_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000001";
-  // SAFETY: tests run with --test-threads=1; no concurrent env mutation.
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -4117,13 +4109,8 @@ async fn all_mvp_endpoints_return_non_404() -> lemmy_utils::error::LemmyResult<(
   use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
   use reqwest_middleware::ClientBuilder;
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var(
-      "GOVERNANCE_LOG_SIGNING_KEY",
-      "0000000000000000000000000000000000000000000000000000000000000001",
-    );
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -4462,13 +4449,8 @@ async fn ineligible_user_cannot_be_picked_for_jury() -> lemmy_utils::error::Lemm
   use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
   use reqwest_middleware::ClientBuilder;
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var(
-      "GOVERNANCE_LOG_SIGNING_KEY",
-      "0000000000000000000000000000000000000000000000000000000000000001",
-    );
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -4791,13 +4773,8 @@ async fn governance_events_notify_fires() -> lemmy_utils::error::LemmyResult<()>
   use tokio::sync::mpsc;
   use tokio_postgres::{AsyncMessage, NoTls, Notification};
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var(
-      "GOVERNANCE_LOG_SIGNING_KEY",
-      "0000000000000000000000000000000000000000000000000000000000000001",
-    );
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -4926,9 +4903,7 @@ async fn underscore_prefix_usernames_still_register() -> lemmy_utils::error::Lem
   };
   use reqwest_middleware::ClientBuilder;
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -5049,11 +5024,8 @@ async fn sanction_notice_round_trip() -> lemmy_utils::error::LemmyResult<()> {
   // config-file load. Both DBs share the same signing key — fine for v0
   // since the test only reads each chain locally.
   const SIGNING_SEED_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000001";
-  // SAFETY: tests run with --test-threads=1 so no concurrent env mutation.
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
 
   // -- 1. Boot container A + apply schema. ------------------------------
   let (_container_a, port_a) = governance_fixtures::start_postgres().await?;
@@ -5678,13 +5650,8 @@ async fn appeal_inside_window_succeeds_expired_rejects() -> lemmy_utils::error::
   use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
   use reqwest_middleware::ClientBuilder;
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var(
-      "GOVERNANCE_LOG_SIGNING_KEY",
-      "0000000000000000000000000000000000000000000000000000000000000001",
-    );
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -5879,13 +5846,8 @@ async fn declining_juror_not_picked_as_own_replacement() -> lemmy_utils::error::
   use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
   use reqwest_middleware::ClientBuilder;
 
-  unsafe {
-    std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-    std::env::set_var(
-      "GOVERNANCE_LOG_SIGNING_KEY",
-      "0000000000000000000000000000000000000000000000000000000000000001",
-    );
-  }
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
 
   let (_container, host_port) = governance_fixtures::start_postgres().await?;
   let db_url = governance_fixtures::db_url(host_port);
@@ -16832,11 +16794,8 @@ mod v1_ship_3_fixtures {
   async fn two_sponsors_lose_endorsement_strength_on_sanction() -> LemmyResult<()> {
     const SIGNING_SEED_HEX: &str =
       "0000000000000000000000000000000000000000000000000000000000000001";
-    // SAFETY: tests run with --test-threads=1; no concurrent env mutation.
-    unsafe {
-      std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
-      std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
-    }
+    let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+    let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
 
     let (_container, host_port) = governance_fixtures::start_postgres().await?;
     let db_url = governance_fixtures::db_url(host_port);

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -829,6 +829,13 @@ mod governance_fixtures {
     Data<LemmyContext>,
     String,
   )> {
+    // SAFETY: tests run with --test-threads=1; no concurrent env mutation.
+    // These two env vars are intentionally process-scoped (NOT EnvVarGuard-wrapped):
+    // both are constant-valued ("1" / fixed signing seed) and bootstrap() has many
+    // callers across this test module — wrapping here would drop the guard at
+    // bootstrap() return, unsetting the var before the test body runs (see
+    // feedback_envvarguard_fixture_lifetime_footgun.md). LEMMY_DATABASE_URL IS
+    // guarded (per-call value) at the _g_db_url binding below.
     unsafe {
       std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
       std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);
@@ -6142,6 +6149,13 @@ mod admin_config_fixtures {
   )> {
     const SIGNING_SEED_HEX: &str =
       "0000000000000000000000000000000000000000000000000000000000000001";
+    // SAFETY: tests run with --test-threads=1; no concurrent env mutation.
+    // These two env vars are intentionally process-scoped (NOT EnvVarGuard-wrapped):
+    // both are constant-valued ("1" / fixed signing seed) and bootstrap() has many
+    // callers across this test module — wrapping here would drop the guard at
+    // bootstrap() return, unsetting the var before the test body runs (see
+    // feedback_envvarguard_fixture_lifetime_footgun.md). LEMMY_DATABASE_URL IS
+    // guarded (per-call value) at the _g_db_url binding below.
     unsafe {
       std::env::set_var("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
       std::env::set_var("GOVERNANCE_LOG_SIGNING_KEY", SIGNING_SEED_HEX);


### PR DESCRIPTION
## Summary

Wraps all remaining raw `unsafe { std::env::set_var(...) }` calls in `crates/server/tests/e2e.rs` with `EnvVarGuard` RAII guards, completing the C4 EnvVarGuard retrofit started in v1-quality-r2.

- **Task 1** — SAFETY-justification comments above 2 `bootstrap()` fixture sites (`governance_fixtures::bootstrap` ~line 832, `admin_config_fixtures::bootstrap` ~line 6145). These stay raw (option-b) because wrapping at bootstrap() return drops the guard before the test body runs (see `feedback_envvarguard_fixture_lifetime_footgun.md`).
- **Task 2** — 10 test-body sites replaced with `let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1")` / `let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", <value>)` RAII bindings. 19 insertions, 60 deletions.

## Phase

- [x] v1-quality (quality / hardening sub-phase)

## Definition of Done

- [x] `cargo check --workspace --features full`: ✓ exit 0
- [x] `cargo clippy --workspace --features full --no-deps -- -D warnings`: ✓ exit 0
- [x] `cargo test --workspace --test e2e --features full`: ✓ **126 passed, 0 failed, 5 ignored** (E2E_EXIT_0; 2716s, advisor-laptop gate)

## ADR impact matrix

| ADR | Impact |
|-----|--------|
| ADR-011 (AGPLv3) | None — test-only change |
| ADR-012 (Extism plugin host) | None |
| ADR-013 (EmergencyRemove) | None — no change to case status handling |
| ADR-014 (Federation) | None |
| ADR-015 (Pseudonymisation) | None — no schema changes |

## Rollback strategy

Revert the EnvVarGuard bindings to raw `unsafe { std::env::set_var(...) }` calls. Risk: low — changes are test-infrastructure only and do not affect production code paths. The raw calls are still semantically valid; the RAII guards add cleanup on test exit without changing test behaviour.

## Plan reference

`.claude/PRPs/plans/v1-quality-r3.plan.md`