### PR TITLE
fix(governance): post/comment authors are first-class defendants (BUG-1, ADR-017)

### DIFF
--- a/crates/api/api/src/governance/admin_emergency_remove.rs
+++ b/crates/api/api/src/governance/admin_emergency_remove.rs
@@ -145,13 +145,35 @@ async fn process_emergency_remove(
     EmergencyRemoveTarget::Comment(id) => (None, Some(id), None),
     EmergencyRemoveTarget::Community(id) => (None, None, Some(id)),
   };
+  // ADR-017: post/comment authors are first-class defendants. Resolve the
+  // content author so the emergency-removed author has a Defendant path
+  // (appeal/sanction/reputation/liability). Read via the in-transaction
+  // `conn` (not `context.pool()`) to avoid pool re-entrancy inside the tx;
+  // the rows were just flagged `removed = true` above but `find` is by PK.
+  let target_person_id: Option<PersonId> = match target {
+    EmergencyRemoveTarget::Post(id) => Some(
+      post::table
+        .find(id)
+        .select(post::creator_id)
+        .first(conn)
+        .await?,
+    ),
+    EmergencyRemoveTarget::Comment(id) => Some(
+      comment::table
+        .find(id)
+        .select(comment::creator_id)
+        .first(conn)
+        .await?,
+    ),
+    EmergencyRemoveTarget::Community(_) => None,
+  };
   let form = ModerationCaseInsertForm {
     community_id,
     creator_id: Some(admin_id),
     target_type: target.case_target_type(),
     target_post_id,
     target_comment_id,
-    target_person_id: None,
+    target_person_id,
     target_community_id,
     target_remote_url: None,
     reason_code: "emergency_remove".to_string(),

--- a/crates/api/api/src/governance/submit_jury_vote.rs
+++ b/crates/api/api/src/governance/submit_jury_vote.rs
@@ -458,8 +458,12 @@ async fn process_vote(
     .await?;
 
     // 8.5. Sponsor-liability path-kind branch (v1-SL-d).
-    // Only Person-target cases can have active sureties; Post/Comment-target
-    // cases have `target_person_id = None` (GOTCHA-56h) and skip silently.
+    // Fires for any case whose `target_person_id` resolves to a defendant.
+    // Per ADR-017, post/comment-targeted cases now carry the content author
+    // in `target_person_id`, so an author's sureties bear liability when the
+    // author's content is sanctioned (the GOTCHA-56h "skip silently" carve-out
+    // no longer applies). Community-targeted cases still have no single
+    // defendant and skip via the `None` arm.
     if let Some(target_id) = case_row.target_person_id {
       let deltas = sponsor_liability::compute_sponsor_liability(
         conn,

--- a/crates/api/api_crud/src/governance/create_report.rs
+++ b/crates/api/api_crud/src/governance/create_report.rs
@@ -394,22 +394,26 @@ async fn resolve_target(
   match target_type {
     CaseTargetType::Post => {
       let post_id = PostId(target_id);
-      Post::read(&mut context.pool(), post_id).await?;
+      // ADR-017: the post author is a first-class defendant. Populate
+      // `target_person_id` with the content author's `creator_id` so the
+      // author has a Defendant path for appeal/sanction/reputation/liability.
+      let post = Post::read(&mut context.pool(), post_id).await?;
       Ok(TargetRefs {
         target_post_id: Some(post_id),
         target_comment_id: None,
-        target_person_id: None,
+        target_person_id: Some(post.creator_id),
         target_community_id: None,
         target_remote_url: None,
       })
     }
     CaseTargetType::Comment => {
       let comment_id = CommentId(target_id);
-      Comment::read(&mut context.pool(), comment_id).await?;
+      // ADR-017: the comment author is a first-class defendant (see Post arm).
+      let comment = Comment::read(&mut context.pool(), comment_id).await?;
       Ok(TargetRefs {
         target_post_id: None,
         target_comment_id: Some(comment_id),
-        target_person_id: None,
+        target_person_id: Some(comment.creator_id),
         target_community_id: None,
         target_remote_url: None,
       })

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -9739,6 +9739,77 @@ async fn admin_emergency_remove_case_has_severity_tier_severe()
   Ok(())
 }
 
+/// ADR-017 — `emergency_remove_open_case` resolves the post author into
+/// `target_person_id`, so an emergency-removed author is a first-class
+/// defendant. Exercises the new in-transaction `post::table.find(id)
+/// .select(post::creator_id)` block (the existing emergency-remove tests
+/// use a Community target, which hits the `None` arm and never runs it).
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_emergency_remove_post_sets_author_defendant()
+-> lemmy_utils::error::LemmyResult<()> {
+  use diesel::{ExpressionMethods, QueryDsl};
+  use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+  use lemmy_api::governance::admin_emergency_remove::{
+    EmergencyRemoveTarget, emergency_remove_open_case,
+  };
+  use lemmy_db_schema::source::{
+    instance::Instance,
+    post::{Post, PostInsertForm},
+  };
+  use lemmy_db_schema_file::{
+    PersonId,
+    enums::{CaseStatus, CaseTargetType},
+    schema::moderation_case,
+  };
+  use lemmy_diesel_utils::traits::Crud;
+
+  let (_container, context, db_url) = governance_fixtures::bootstrap().await?;
+  let instance = Instance::read_or_create(&mut context.pool(), "test.invalid").await?;
+  let community = governance_fixtures::seed_community(&context, instance.id).await?;
+  let (admin_id, _) =
+    governance_fixtures::seed_user(&context, instance.id, "admin_er_post", true).await?;
+  let (author_id, _) =
+    governance_fixtures::seed_user(&context, instance.id, "er_post_author", false).await?;
+
+  let post = Post::create(
+    &mut context.pool(),
+    &PostInsertForm::new("adr017 er post".into(), author_id, community.id),
+  )
+  .await?;
+
+  let case_id = emergency_remove_open_case(
+    &mut context.pool(),
+    admin_id,
+    EmergencyRemoveTarget::Post(post.id),
+    Some(community.id),
+    "ADR-017 emergency-remove author-defendant test".to_string(),
+  )
+  .await?;
+
+  let mut conn = AsyncPgConnection::establish(&db_url).await?;
+  let row: (CaseTargetType, Option<PersonId>, CaseStatus) = moderation_case::table
+    .filter(moderation_case::id.eq(case_id))
+    .select((
+      moderation_case::target_type,
+      moderation_case::target_person_id,
+      moderation_case::status,
+    ))
+    .first(&mut conn)
+    .await?;
+  assert_eq!(row.0, CaseTargetType::Post, "emergency-remove case targets the post");
+  assert_eq!(
+    row.1,
+    Some(author_id),
+    "ADR-017: emergency_remove_open_case resolves target_person_id to the post author (creator_id)",
+  );
+  assert_eq!(
+    row.2,
+    CaseStatus::EmergencyRemove,
+    "emergency_remove opens case with status = EmergencyRemove (ADR-013)",
+  );
+  Ok(())
+}
+
 /// PR #95 cr-3 + cr-4 — emergency-remove with a seedable juror pool seats
 /// the full Severe-tier panel, persists `selected_under_constraints` per
 /// juror, and emits both `severity_tier_frozen` and the extended

--- a/crates/server/tests/e2e.rs
+++ b/crates/server/tests/e2e.rs
@@ -1123,6 +1123,11 @@ async fn governance_log_hash_chain_holds() -> lemmy_utils::error::LemmyResult<()
 /// round-trip tests are `#[ignore]`d pending GH issue #43; the pre-flight
 /// assertion will enforce list⇄disk parity once they are un-ignored.
 const MIGRATIONS_TO_REVERT_PHASE_1: &[&str] = &[
+  // ADR-017 author-as-defendant backfill (1 migration, bump 19 → 20).
+  // Data-only backfill of moderation_case.target_person_id; reverting it
+  // (down.sql nulls the backfilled rows) is a no-op on empty governance
+  // tables, so it slots cleanly into the newest-first revert window.
+  "2026-06-01-000000-0000_backfill_author_defendant",
   // v1-federation-inbound-a (1 migration, bump 18 → 19)
   "2026-05-17-000000-0000_add_federation_inbound_v1",
   // v1-RT-r1 (4 migrations, bump 14 → 18)
@@ -5802,6 +5807,386 @@ async fn appeal_inside_window_succeeds_expired_rejects() -> lemmy_utils::error::
   assert!(
     resp_b.is_err(),
     "GH #34: appeal with appeal_window_expires_at in past must fail (window expired)",
+  );
+
+  Ok(())
+}
+
+// ============================================================================
+// ADR-017 — post/comment authors are first-class governance defendants
+// ============================================================================
+//
+// Smoke-test BUG-1: a post (or comment) author could not appeal a case
+// against their own content. `request_appeal` resolves the Defendant via
+// `case.target_person_id == Some(caller_id)`, but post/comment-targeted
+// cases left `target_person_id` NULL through v0, so the author had no
+// defendant path and `POST /governance/appeal` returned NotFound.
+//
+// Per ADR-017, `create_report.rs::resolve_target` now populates
+// `target_person_id` with the content author's `creator_id` for post and
+// comment cases. This test seeds a Decided post-targeted case and a Decided
+// comment-targeted case (both with `target_person_id = content author`),
+// asserts the author can appeal each, and asserts a non-author is still
+// denied (NotFound) — preserving the §12.4 spoofing-protection invariant.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_comment_author_appeal_succeeds_nonauthor_denied()
+-> lemmy_utils::error::LemmyResult<()> {
+  use actix_web::web::{Data, Json};
+  use chrono::{Duration, Utc};
+  use diesel::{Connection as _, ExpressionMethods, PgConnection, QueryDsl};
+  use diesel_async::{AsyncConnection as _, AsyncPgConnection, RunQueryDsl};
+  use lemmy_api_common::governance::RequestAppeal;
+  use lemmy_api_crud::governance::request_appeal::request_appeal;
+  use lemmy_api_utils::{context::LemmyContext, request::client_builder};
+  use lemmy_db_schema::source::{
+    comment::{Comment, CommentInsertForm},
+    governance::moderation_case::ModerationCaseInsertForm,
+    instance::Instance,
+    post::{Post, PostInsertForm},
+    secret::Secret,
+  };
+  use lemmy_db_schema_file::{
+    enums::{CaseSeverity, CaseStatus, CaseTargetType},
+    schema::moderation_case,
+  };
+  use lemmy_diesel_utils::{
+    connection::{ActualDbPool, build_db_pool_for_tests},
+    traits::Crud,
+  };
+  use lemmy_utils::{error::LemmyErrorType, rate_limit::RateLimit, settings::SETTINGS};
+  use reqwest_middleware::ClientBuilder;
+
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
+
+  let (_container, host_port) = governance_fixtures::start_postgres().await?;
+  let db_url = governance_fixtures::db_url(host_port);
+  let _g_db_url = EnvVarGuard::set("LEMMY_DATABASE_URL", &db_url);
+
+  {
+    let mut sync_conn = PgConnection::establish(&db_url)?;
+    governance_fixtures::apply_all_schema(&mut sync_conn)?;
+  }
+
+  let pool: ActualDbPool = build_db_pool_for_tests();
+  let client = client_builder(&SETTINGS).build()?;
+  let middleware_client = ClientBuilder::new(client).build();
+  let secret = Secret {
+    id: 0,
+    jwt_secret: String::new().into(),
+  };
+  let rate_limit = RateLimit::with_debug_config();
+  let context = Data::new(LemmyContext::create(
+    pool,
+    middleware_client.clone(),
+    middleware_client,
+    secret,
+    rate_limit,
+  ));
+
+  let instance = Instance::read_or_create(&mut context.pool(), "test.invalid").await?;
+
+  // Author of the post, author of the comment, and an unrelated third party.
+  let (post_author, post_author_view) =
+    governance_fixtures::seed_user(&context, instance.id, "adr017_post_author", false).await?;
+  let (comment_author, comment_author_view) =
+    governance_fixtures::seed_user(&context, instance.id, "adr017_comment_author", false).await?;
+  let (_nonauthor, nonauthor_view) =
+    governance_fixtures::seed_user(&context, instance.id, "adr017_nonauthor", false).await?;
+
+  let community = governance_fixtures::seed_community(&context, instance.id).await?;
+
+  // Real content rows so target_post_id / target_comment_id satisfy their FKs.
+  let post = Post::create(
+    &mut context.pool(),
+    &PostInsertForm::new("adr017 post".into(), post_author, community.id),
+  )
+  .await?;
+  let comment = Comment::create(
+    &mut context.pool(),
+    &CommentInsertForm::new(comment_author, post.id, community.id, "adr017 comment".into()),
+    None,
+  )
+  .await?;
+  assert_eq!(post.creator_id, post_author, "sanity: post author");
+  assert_eq!(comment.creator_id, comment_author, "sanity: comment author");
+
+  let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+
+  // Decided post-targeted case: target_person_id = the post's author (ADR-017).
+  let post_case_form = ModerationCaseInsertForm {
+    community_id: None,
+    creator_id: None,
+    target_type: CaseTargetType::Post,
+    target_post_id: Some(post.id),
+    target_comment_id: None,
+    target_person_id: Some(post_author),
+    target_community_id: None,
+    target_remote_url: None,
+    reason_code: "adr017_post".to_string(),
+    severity: CaseSeverity::Low,
+    status: CaseStatus::Decided,
+    threshold_score: 1,
+    ..Default::default()
+  };
+  let post_case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&post_case_form)
+      .get_result(&mut async_conn)
+      .await?;
+
+  // Decided comment-targeted case: target_person_id = the comment's author.
+  let comment_case_form = ModerationCaseInsertForm {
+    target_type: CaseTargetType::Comment,
+    target_post_id: None,
+    target_comment_id: Some(comment.id),
+    target_person_id: Some(comment_author),
+    reason_code: "adr017_comment".to_string(),
+    ..post_case_form.clone()
+  };
+  let comment_case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&comment_case_form)
+      .get_result(&mut async_conn)
+      .await?;
+
+  // Both cases need a future appeal window + a panel_size_snapshot (the same
+  // post-insert stamp the appeal_inside_window test uses; the direct insert
+  // path bypasses admin_assign_jury which would otherwise stamp these).
+  let future = Utc::now() + Duration::days(1);
+  for case_id in [post_case.id, comment_case.id] {
+    diesel::update(moderation_case::table.filter(moderation_case::id.eq(case_id)))
+      .set((
+        moderation_case::appeal_window_expires_at.eq(Some(future)),
+        moderation_case::panel_size_snapshot.eq(Some(5_i32)),
+      ))
+      .execute(&mut async_conn)
+      .await?;
+  }
+
+  // Post author appeals their own post case → succeeds.
+  let post_resp = request_appeal(
+    Json(RequestAppeal {
+      case_id: post_case.id,
+      reason: "i am the post author".to_string(),
+    }),
+    context.clone(),
+    post_author_view,
+  )
+  .await?
+  .into_inner();
+  assert!(
+    post_resp.appeal_id.0 > 0,
+    "ADR-017: post author must be able to appeal a case against their own post",
+  );
+
+  // Comment author appeals their own comment case → succeeds.
+  let comment_resp = request_appeal(
+    Json(RequestAppeal {
+      case_id: comment_case.id,
+      reason: "i am the comment author".to_string(),
+    }),
+    context.clone(),
+    comment_author_view,
+  )
+  .await?
+  .into_inner();
+  assert!(
+    comment_resp.appeal_id.0 > 0,
+    "ADR-017: comment author must be able to appeal a case against their own comment",
+  );
+
+  // A non-author appealing a post case is still denied with NotFound
+  // (§12.4 spoofing protection — caller is neither defendant nor reporter).
+  // The first post case already flipped Decided → Appealed when its author
+  // appealed above, so assert against a fresh Decided post case here.
+  let spoof_case_form = ModerationCaseInsertForm {
+    reason_code: "adr017_spoof".to_string(),
+    ..post_case_form
+  };
+  let spoof_case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&spoof_case_form)
+      .get_result(&mut async_conn)
+      .await?;
+  diesel::update(moderation_case::table.filter(moderation_case::id.eq(spoof_case.id)))
+    .set((
+      moderation_case::appeal_window_expires_at.eq(Some(future)),
+      moderation_case::panel_size_snapshot.eq(Some(5_i32)),
+    ))
+    .execute(&mut async_conn)
+    .await?;
+
+  let err = request_appeal(
+    Json(RequestAppeal {
+      case_id: spoof_case.id,
+      reason: "i am not the author".to_string(),
+    }),
+    context.clone(),
+    nonauthor_view,
+  )
+  .await
+  .expect_err("ADR-017: a non-author must not be able to appeal another's post case");
+  assert!(
+    matches!(err.error_type, LemmyErrorType::NotFound),
+    "ADR-017: non-author appeal must be denied with NotFound, got {:?}",
+    err.error_type,
+  );
+
+  Ok(())
+}
+
+// ============================================================================
+// ADR-017 — backfill migration round-trip
+// ============================================================================
+//
+// The status-scoped backfill (migrations/2026-06-01-000000-0000_backfill_
+// author_defendant) populates moderation_case.target_person_id for the
+// post/comment-targeted historical tail, EXCLUDING the three pre-jury-
+// assignment statuses (Open / ThresholdMet / EmergencyRemove) so it can
+// never retroactively resize an in-flight or seated jury (ADR-010).
+//
+// This mirrors the phase1 round-trip harness: a vanilla container, the real
+// `schema_setup::run` runner (raw diesel CLI is blocked by forbid_diesel_cli),
+// reverting/re-applying the one backfill migration. It asserts:
+//   - after up:   a Decided post case gets target_person_id = post.creator_id
+//   - after up:   an Open post case is left NULL (status-scope proof)
+//   - after down: both are NULL again (reversibility)
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_author_defendant_round_trip() -> lemmy_utils::error::LemmyResult<()> {
+  use actix_web::web::Data;
+  use diesel::QueryDsl;
+  use diesel_async::{AsyncConnection as _, AsyncPgConnection, RunQueryDsl};
+  use lemmy_api_utils::{context::LemmyContext, request::client_builder};
+  use lemmy_db_schema::source::{
+    governance::moderation_case::ModerationCaseInsertForm,
+    instance::Instance,
+    post::{Post, PostInsertForm},
+    secret::Secret,
+  };
+  use lemmy_db_schema_file::{
+    PersonId,
+    enums::{CaseSeverity, CaseStatus, CaseTargetType},
+    schema::moderation_case,
+  };
+  use lemmy_diesel_utils::{
+    connection::{ActualDbPool, build_db_pool_for_tests},
+    schema_setup::{self, Options},
+    traits::Crud,
+  };
+  use lemmy_utils::{rate_limit::RateLimit, settings::SETTINGS};
+  use reqwest_middleware::ClientBuilder;
+
+  let _g_init = EnvVarGuard::set("LEMMY_INITIALIZE_WITH_DEFAULT_SETTINGS", "1");
+  let _g_gov = EnvVarGuard::set("GOVERNANCE_LOG_SIGNING_KEY", "0000000000000000000000000000000000000000000000000000000000000001");
+
+  let (_container, host_port) = governance_fixtures::start_postgres_vanilla()
+    .await
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+  let db_url = governance_fixtures::db_url(host_port);
+  let _g_db_url = EnvVarGuard::set("LEMMY_DATABASE_URL", &db_url);
+
+  // Apply the full migration set via the real runner (records migrations so
+  // revert(limit 1) targets the backfill cleanly).
+  schema_setup::run(Options::default().run(), &db_url)?;
+
+  let pool: ActualDbPool = build_db_pool_for_tests();
+  let client = client_builder(&SETTINGS).build()?;
+  let middleware_client = ClientBuilder::new(client).build();
+  let secret = Secret {
+    id: 0,
+    jwt_secret: String::new().into(),
+  };
+  let rate_limit = RateLimit::with_debug_config();
+  let context = Data::new(LemmyContext::create(
+    pool,
+    middleware_client.clone(),
+    middleware_client,
+    secret,
+    rate_limit,
+  ));
+
+  let instance = Instance::read_or_create(&mut context.pool(), "test.invalid").await?;
+  let (author, _author_view) =
+    governance_fixtures::seed_user(&context, instance.id, "adr017_rt_author", false).await?;
+  let community = governance_fixtures::seed_community(&context, instance.id).await?;
+  let post = Post::create(
+    &mut context.pool(),
+    &PostInsertForm::new("adr017 rt post".into(), author, community.id),
+  )
+  .await?;
+
+  let mut async_conn = AsyncPgConnection::establish(&db_url).await?;
+
+  // Two post-targeted cases with target_person_id intentionally NULL: one
+  // Decided (must be backfilled) and one Open (must be left NULL).
+  let base = ModerationCaseInsertForm {
+    community_id: None,
+    creator_id: None,
+    target_type: CaseTargetType::Post,
+    target_post_id: Some(post.id),
+    target_comment_id: None,
+    target_person_id: None,
+    target_community_id: None,
+    target_remote_url: None,
+    reason_code: "adr017_rt_decided".to_string(),
+    severity: CaseSeverity::Low,
+    status: CaseStatus::Decided,
+    threshold_score: 1,
+    ..Default::default()
+  };
+  let decided_case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&base)
+      .get_result(&mut async_conn)
+      .await?;
+  let open_form = ModerationCaseInsertForm {
+    reason_code: "adr017_rt_open".to_string(),
+    status: CaseStatus::Open,
+    ..base
+  };
+  let open_case: lemmy_db_schema::source::governance::moderation_case::ModerationCase =
+    diesel::insert_into(moderation_case::table)
+      .values(&open_form)
+      .get_result(&mut async_conn)
+      .await?;
+
+  // Re-apply the backfill: revert it (no-op on these NULL rows) then run it.
+  schema_setup::run(Options::default().revert().limit(1), &db_url)?;
+  schema_setup::run(Options::default().run(), &db_url)?;
+
+  let decided_after: Option<PersonId> = moderation_case::table
+    .find(decided_case.id)
+    .select(moderation_case::target_person_id)
+    .first(&mut async_conn)
+    .await?;
+  let open_after: Option<PersonId> = moderation_case::table
+    .find(open_case.id)
+    .select(moderation_case::target_person_id)
+    .first(&mut async_conn)
+    .await?;
+  assert_eq!(
+    decided_after,
+    Some(author),
+    "ADR-017 up.sql: Decided post case must be backfilled with the post author",
+  );
+  assert_eq!(
+    open_after, None,
+    "ADR-017 up.sql: Open post case must be left NULL (status-scope proof)",
+  );
+
+  // Down: nulls the backfilled value again.
+  schema_setup::run(Options::default().revert().limit(1), &db_url)?;
+  let decided_reverted: Option<PersonId> = moderation_case::table
+    .find(decided_case.id)
+    .select(moderation_case::target_person_id)
+    .first(&mut async_conn)
+    .await?;
+  assert_eq!(
+    decided_reverted, None,
+    "ADR-017 down.sql: backfilled target_person_id must be restored to NULL",
   );
 
   Ok(())

--- a/docs/brehon-law-inspired-network/04-data-model-and-api.md
+++ b/docs/brehon-law-inspired-network/04-data-model-and-api.md
@@ -260,6 +260,8 @@ Request/response types live in `crates/api/api_common/src/governance.rs`. Groupe
   - `ThresholdsSnapshot` → `jury_reliability/reporting_accuracy/endorsement_strength: i64`.
   - `CapabilityCounts` → `jury_eligible_count/trusted_reporter_count/can_sponsor_count: i64`.
   - `FounderEventStats` → `active_count/expired_count: i64`.
+- **`AdminReputationRollup`** → `person_id: PersonId` (**required** — the per-person scoping id; `GET /governance/admin/reputation/rollup`).
+- **`AdminReputationRollupResponse`** → `rollup: Option<ReputationSnapshot>` (instance-wide snapshot, `community_id IS NULL`; `None` until the rollup cron has run or if all the person's communities are banned), `contributing: Vec<ReputationSnapshot>` (the per-community snapshots that fed the rollup; may be empty).
 
 ### Admin config (v1-AD-b)
 

--- a/docs/brehon-law-inspired-network/04-data-model-and-api.md
+++ b/docs/brehon-law-inspired-network/04-data-model-and-api.md
@@ -81,6 +81,12 @@ This is the implementation reference. It holds migrations, tables, enums, Diesel
 
 > **Cumulative config-seed count invariant:** 34 (v1-AD seed at #7) + 27 (#16) + 27 (#21) + 13 (#25) + 26 (#29) = **127**, plus 11 federation-inbound (#30) = **138** instance-scoped rows seeded across the lifecycle. The reputation-snapshot/recompute job and admin-config handler assert subsets of these counts (`EXPECTED_SEED_COUNT_V1_*` consts in `crates/api/api/src/governance/config.rs`).
 
+### ADR-017 author-as-defendant backfill
+
+| # | Migration dir | What it does |
+|---|---|---|
+| 31 | `2026-06-01-000000_backfill_author_defendant` | **Data-only backfill** (no DDL). Sets `moderation_case.target_person_id` to the content author's `creator_id` for the historical post/comment-targeted tail (ADR-017), making the author a first-class defendant. **Status-scoped:** excludes `Open`/`ThresholdMet`/`EmergencyRemove` (the three statuses from which a jury can still be sized) so it cannot retroactively resize an in-flight or seated jury (ADR-010). PascalCase enum literals (`'Post'`/`'Comment'` + status tokens) per the verbatim DB convention. Reversible: `down.sql` nulls only rows whose value still equals the content author. |
+
 ---
 
 ## 2. Enums
@@ -137,6 +143,7 @@ All governance enums live in `crates/db_schema_file/src/enums.rs` as Rust `enum`
 ### Core case workflow
 
 - **`moderation_case.rs` → `ModerationCase`** (table `moderation_case`). The central artefact. Fields: `id`, `community_id: Option<CommunityId>`, `creator_id: Option<PersonId>`, `target_type: CaseTargetType`, `target_post_id/comment_id/person_id/community_id: Option<…>`, `target_remote_url: Option<String>`, `reason_code: String`, `severity: CaseSeverity`, `status: CaseStatus`, `threshold_score: i64`, `opened_at`, `decided_at: Option<…>`, `closed_at: Option<…>`. **v1 additions:** `applied_config_snapshot: Option<Value>` (v1-AD-a), `rule_set_version_id: Option<RuleSetVersionId>` (v1-AD-a/c), `severity_tier: SeverityTier` + `status_tier: CaseStatusTier` + `panel_size_snapshot/quorum_snapshot/threshold_count_snapshot: Option<i32>` + `appeal_window_expires_at: Option<…>` (v1-JM-a), `winning_decision: Option<JuryDecision>` (v1-JM-d), `grace_expires_at: Option<…>` + `liability_escape_reason: Option<Value>` (v1-SL-a). InsertForm + `AsChangeset` (snapshot/tier writes flow through `update().set()`).
+  > **`target_person_id` semantics (ADR-017).** For person-targeted cases this is the reported person. **For `Post`/`Comment`-targeted cases it is now the content author's `creator_id`** — the case is dual-populated (`target_post_id`/`target_comment_id` *and* `target_person_id` both set). This makes the author a first-class defendant for appeal (`request_appeal` resolves the defendant via `target_person_id == caller`), sanction inheritance (`submit_jury_vote` §8.5), reputation ban-math, sponsor-liability, and juror exclusion. Populated at report-creation (`create_report::resolve_target`), emergency-removal (`admin_emergency_remove`), and for history via migration #31. Federation is agnostic — `publish_sanction_notice` resolves the AP URL from `target_post_id`/`target_comment_id`, never `target_person_id`. Community-targeted cases leave it NULL (no single author).
 - **`case_evidence.rs` → `CaseEvidence`** — `case_id`, `uploader_id`, `storage_key`, `sha256`, `mime_type`, `visibility: EvidenceVisibility`, `created_at`.
 - **`sanction.rs` → `Sanction`** — `case_id`, `scope: SanctionScope`, `action: SanctionAction`, `target_*: Option<…>`, `starts_at`, `ends_at: Option<…>`, `active: bool` (InsertForm `Option<bool>`).
 - **`appeal.rs` → `Appeal`** — `case_id`, `requester_id`, `reason`, `status: AppealStatus`, `created_at`, `decided_at: Option<…>`. **v1-JM-d:** `requester_role: AppealRequesterRole`, `panel_size_snapshot: Option<i32>`, `threshold_count_snapshot: Option<i32>` (NULL until `select_appeal_panel` runs).
@@ -489,3 +496,40 @@ Registered in `scheduled_tasks::setup`; `crates/server/src/governance.rs::schedu
 - **Entry-kind registry (authoritative):** `.claude/rules/governance-log-entry-kind-registry.md`
 - **Harness-observability JSONL sidecar (NOT product):** [governance-log-kinds-jsonl.md](governance-log-kinds-jsonl.md)
 - **v1 PRDs (design intent — secondary to code):** `.claude/PRPs/prds/v1-*.prd.md`
+
+---
+
+## 14. API behaviour notes (Docker smoke-test reconciliation — CODE WINS)
+
+End-to-end Docker smoke testing surfaced six API behaviours that differ from
+a naive reading of the DTOs/routes above. They are **intended** behaviour and
+recorded here so callers (and future doc readers) aren't surprised. No code
+change accompanies this reconciliation pass.
+
+- **DIFF-1 — governance enums serialize lowercase over JSON.** The Postgres
+  enum literal is PascalCase (`'Post'`, `'Warning'`) per the `verbatim` DB
+  convention (§2), but the serde/wire representation is snake_case/lowercase
+  (`"post"`, `"warning"`). **Both are correct at their own layer:** SQL
+  (including migrations) must use the PascalCase DB token; API request/response
+  bodies use the lowercase serde token. Conflating them silently matches
+  nothing (this is exactly why migration #31's status filter uses `'Open'`,
+  not `'open'`).
+- **DIFF-2 — `GET /governance/modlog` returns summarised `public_case_log`
+  rows, not raw `governance_log`.** The public modlog is the redacted
+  case-summary surface (ADR-015 scrubbed). Hash-chain / pseudonym audit of the
+  raw append-only log is a DB-level or future admin-only endpoint concern, not
+  this route.
+- **DIFF-3 — double-endorse returns `not_found`, not a true idempotency
+  conflict.** A repeat endorsement within the 48h cooldown
+  (`liability.revoke_rate_limit_per_day`) surfaces as `not_found` rather than a
+  semantic `conflict`/`already_endorsed`. **Known wart (opaque error).**
+  *Future:* return `conflict`/`already_endorsed`. No code change this pass.
+- **DIFF-4 — `modlog` returns a bare JSON array on success, a dict on
+  rate-limit.** Callers must handle both shapes (array = results; object =
+  rate-limit envelope).
+- **DIFF-5 — `POST /admin/config` requires a non-empty `reason`; `value` is a
+  raw JSON scalar.** Not `value_int`/`value_text` split fields — a single
+  `value` carrying the JSON scalar, plus a mandatory `reason` string.
+- **DIFF-6 — admin GETs require their scoping id.** `GET /admin/rule-sets`
+  requires `community_id`; `GET /admin/reputation/rollup` requires `person_id`.
+  Omitting them is a client error, not an unscoped "list all".

--- a/docs/brehon-law-inspired-network/04-data-model-and-api.md
+++ b/docs/brehon-law-inspired-network/04-data-model-and-api.md
@@ -334,6 +334,7 @@ Admin enforcement is **in the handlers** (capability checks reading `reputation_
 | POST | `/governance/admin/close-case` | `admin_close_case` |
 | POST | `/governance/admin/trigger-appeal-rejury` | `admin_trigger_appeal_rejury` |
 | GET | `/governance/admin/reputation-stats` | `admin_reputation_stats` |
+| GET | `/governance/admin/reputation/rollup` | `admin_reputation_rollup` |
 | GET | `/governance/admin/dashboard` | `admin_dashboard` |
 | GET | `/governance/admin/dashboard/view` | `admin_dashboard_html` |
 | POST | `/governance/admin/config` | `admin_set_config` |
@@ -530,6 +531,10 @@ change accompanies this reconciliation pass.
 - **DIFF-5 — `POST /admin/config` requires a non-empty `reason`; `value` is a
   raw JSON scalar.** Not `value_int`/`value_text` split fields — a single
   `value` carrying the JSON scalar, plus a mandatory `reason` string.
-- **DIFF-6 — admin GETs require their scoping id.** `GET /admin/rule-sets`
-  requires `community_id`; `GET /admin/reputation/rollup` requires `person_id`.
-  Omitting them is a client error, not an unscoped "list all".
+- **DIFF-6 — some admin GETs require their scoping id.** `GET /governance/admin/rule-sets`
+  requires `community_id` (`AdminListRuleSetsRequest.community_id`); `GET /governance/admin/reputation/rollup`
+  requires `person_id` (`AdminReputationRollup.person_id`). Omitting them is a client error,
+  not an unscoped "list all". **Do not confuse `/reputation/rollup` (per-person, `person_id`
+  required) with the sibling `GET /governance/admin/reputation-stats`, whose `community_id`
+  is *optional*** (absent → instance-wide stats). Both routes exist in code (`routes/src/lib.rs:503-504`);
+  the §7 table above now lists both.

--- a/docs/brehon-law-inspired-network/99-decisions-and-open-questions.md
+++ b/docs/brehon-law-inspired-network/99-decisions-and-open-questions.md
@@ -309,6 +309,34 @@ Lightweight Architecture Decision Records. Each has: ID, title, date, status, co
   - Future companion doc `08-cross-app-governance.md` (deferred — written when M1 sub-PRD is scheduled and the protocol-level detail is concrete)
   - Future ADR-017 onward (each new app integration cites this contract)
 
+### ADR-017 — Post/comment authors are first-class governance defendants
+
+- **Date:** 2026-06-01
+- **Status:** Accepted
+- **Context:** A `moderation_case` records *who/what* is under governance via a `target_type` discriminator plus the matching FK column (`target_post_id` / `target_comment_id` / `target_person_id` / `target_community_id`). Through v0, post- and comment-targeted cases left `target_person_id` **NULL** — only person-targeted cases populated it. But every downstream consumer that asks "who is the affected person?" reads `target_person_id`: the appeal handler resolves the **defendant** via `case.target_person_id == Some(caller_id)`, the sanction row inherits `target_person_id`, reputation ban-math counts sanctions keyed on it, and sponsor-liability fires only when it is `Some(_)`. The consequence is a confirmed bug (smoke-test BUG-1): **a post or comment author cannot appeal a case against their own content** — `POST /governance/appeal` returns `not_found` because the author has no defendant path. More broadly, the content author — the person actually accountable for the content — was invisible to the governance machinery for post/comment cases.
+- **Decision:** For post- and comment-targeted cases, `target_person_id` is populated with the **content author's `creator_id`**, making the author the first-class defendant for appeal, sanction, reputation, and sponsor-liability purposes. The case remains dual-populated (`target_post_id`/`target_comment_id` *and* `target_person_id` both set) — the post/comment FK still identifies the specific content (and is what federation resolves the AP URL from); `target_person_id` identifies the accountable person. Population happens at three sites:
+  1. **Report-creation** (`create_report.rs::resolve_target`, Post/Comment arms) — write-time, forward.
+  2. **Emergency removal** (`admin_emergency_remove.rs`) — the admin-override takedown path also resolves the author, so an author can appeal an emergency takedown. (The case `creator_id` here is the acting admin, not a reporter; the author is the *target*, not the creator.)
+  3. **Historical backfill** — a reversible, status-scoped migration populates the existing terminal tail (see Consequences for the scope constraint).
+- **Consequences:**
+  - **Goal achieved:** post/comment authors get a Defendant appeal path — BUG-1 fixed with no change to the appeal handler itself (the existing `target_person_id == Some(caller_id)` check just works once the column is populated).
+  - **Sponsor-liability now applies to authors:** when an author's content is sanctioned, the author's sponsors (sureties) enter the grace window / bear the reputation delta. This is the most significant behaviour change — previously post/comment sanctions never touched sponsors. (`submit_jury_vote.rs` §8.5; the prior "GOTCHA-56h skip silently" carve-out no longer applies.)
+  - **Reputation ban-math now counts post/comment sanctions** for the author's community-ban calculation.
+  - **The author is excluded from juries on their own content** (`admin_assign_jury.rs` juror-exclusion set), closing a fairness gap.
+  - **Federation is unaffected:** `publish_sanction_notice.rs` resolves the ActivityPub URL directly from `target_post_id`/`target_comment_id` and ignores `target_person_id`.
+  - **Migration scope is load-bearing for reversibility (ADR-010):** jury panel size and juror exclusion read `target_person_id` only at jury-assignment time, which fires exclusively from `Open` / `ThresholdMet` / `EmergencyRemove` and atomically freezes `panel_size_snapshot`. The backfill therefore **excludes** those three statuses so it cannot retroactively resize an in-flight or already-seated jury; only post/comment cases past jury assignment (frozen panels) are backfilled. Hard-deleted content nulls its FK (`ON DELETE SET NULL`), so orphaned cases fall out of the backfill and stay NULL — correct.
+  - **No PII implication (ADR-015):** `target_person_id` is an integer FK to `person`, never a direct identifier; the governance log and `actor_pseudonym` mapping are untouched.
+- **Alternatives considered:**
+  - **Localized read-time fix in `request_appeal.rs` (rejected):** resolve the author on the fly when the case is post/comment-targeted and the caller matches. Fixes only the appeal bug with zero blast radius, but leaves the data model inconsistent — sanction/reputation/liability would still treat post/comment cases as having no affected person, so the author is a defendant for appeal but not for anything else. The decision is explicitly to make the author a genuine, system-wide defendant.
+  - **Forward-only (no backfill) (rejected as default, kept as fallback):** ship only the handler change so new cases are correct and leave history NULL. Chosen only if the terminal post/comment tail is empty at deploy time; otherwise the historical appeal bug persists for already-decided cases.
+  - **Community-targeted defendant semantics (out of scope):** a community has no single author, so there is no natural person to name as defendant. Deferred to a separate ADR if ever wanted.
+- **Enacted in:**
+  - [04-data-model-and-api.md](04-data-model-and-api.md) (`target_person_id` semantics: populated with content author for post/comment cases)
+  - `crates/api/api_crud/src/governance/create_report.rs` (`resolve_target` Post/Comment arms)
+  - `crates/api/api/src/governance/admin_emergency_remove.rs` (author resolution for emergency takedowns)
+  - `migrations/<ts>_backfill_author_defendant/` (status-scoped reversible backfill)
+  - `crates/api/api_crud/src/governance/request_appeal.rs` (defendant path — verified, no change required)
+
 ---
 
 ## Open Questions
@@ -684,3 +712,6 @@ OQ-028 (named governance-profile bundles for v1 tuning rollout) opened. Captures
 
 **2026-05-23** — *99*
 ADR-016 added: Brehon is a cross-app governance backplane; federated app planes. Codifies the three-component federation contract (B-fetch evidence retrieval; B-publish sanction events; B-actor portable IDs) and reframes the V2 messaging PRD as the first reference integration (M1/M2/M3 — renamed from V2a/V2b/V2c to end the ADR-010 v2 naming collision). ADR-004 amended (header) to note the extension. Four new OQs opened — OQ-ADR016-01 (B-fetch SPI), OQ-ADR016-02 (B-publish schema), OQ-ADR016-03 (B-actor link UX), OQ-ADR016-04 (sanction translation per app). PRD edit and design-doc updates (03 §4, 06 §2.2/§7, 07 §1.2/§5) deferred to M1 schedule time. Rejected alternatives: per-app signed-evidence (forks every app), Brehon-as-super-admin via app admin APIs (blast radius + trust gate), advisory-only sanctions (undermines cross-app value), OIDC IdP (Brehon as identity SPOF), per-app-identity-no-roll-up (parallel silos).
+
+**2026-06-01** — *99, 04*
+ADR-017 added: post/comment authors are first-class governance defendants. Post/comment-targeted `moderation_case` rows now populate `target_person_id` with the content author's `creator_id` (at report-creation, emergency-removal, and via a status-scoped reversible backfill), fixing smoke-test BUG-1 (post/comment authors could not appeal — `POST /governance/appeal` returned `not_found`). System-wide consequence (not a localized patch): the author becomes the affected person for appeal, sanction inheritance, reputation ban-math, sponsor-liability, and juror-exclusion. Federation is unaffected (AP URL resolves from `target_post_id`). Backfill excludes `Open`/`ThresholdMet`/`EmergencyRemove` so it cannot retroactively resize an in-flight or seated jury (ADR-010 reversibility). No PII implication (integer FK only, ADR-015). Rejected alternatives: localized read-time appeal-only fix (leaves data model inconsistent), community-targeted defendant semantics (no single author — deferred). Enacted in `create_report.rs`, `admin_emergency_remove.rs`, the backfill migration, and 04 (`target_person_id` semantics).

--- a/migrations/2026-06-01-000000-0000_backfill_author_defendant/down.sql
+++ b/migrations/2026-06-01-000000-0000_backfill_author_defendant/down.sql
@@ -1,0 +1,24 @@
+-- Reverse of ADR-017 task 3 up.sql.
+-- Guarded reverse-backfill: nulls target_person_id ONLY on post/comment cases
+-- whose current value still equals the content author's creator_id (i.e. rows
+-- this migration's up.sql could have set). Person-targeted cases, and any
+-- post/comment case whose target_person_id was set to some other person by a
+-- different code path, are left untouched.
+-- ============================================================
+-- ADR exception trail (protected governance table — moderation_case)
+-- ============================================================
+-- DATA-only reverse UPDATE. governance_log untouched (ADR-008); integer FK
+-- only, no PII (ADR-015); reversibility per ADR-010 / ADR-017.
+--
+-- Orphan-safe: if the content was hard-deleted after up ran, the subquery
+-- returns NULL, the equality is NULL (not true), and the row is left as-is.
+-- ============================================================
+
+UPDATE moderation_case mc
+SET target_person_id = NULL
+WHERE mc.target_person_id IS NOT NULL
+  AND mc.target_type IN ('Post', 'Comment')
+  AND (
+    mc.target_person_id = (SELECT p.creator_id FROM post p    WHERE p.id = mc.target_post_id)
+    OR mc.target_person_id = (SELECT c.creator_id FROM comment c WHERE c.id = mc.target_comment_id)
+  );

--- a/migrations/2026-06-01-000000-0000_backfill_author_defendant/up.sql
+++ b/migrations/2026-06-01-000000-0000_backfill_author_defendant/up.sql
@@ -1,0 +1,55 @@
+-- ADR-017 task 3: backfill moderation_case.target_person_id for the
+-- historical post/comment-targeted tail, making the content author a
+-- first-class governance defendant (appeal/sanction/reputation/liability).
+-- ============================================================
+-- ADR exception trail (protected governance table — moderation_case)
+-- ============================================================
+-- This migration is a DATA BACKFILL only (UPDATE on moderation_case).
+-- No DDL changes; no column additions; no index changes; no constraint
+-- changes. moderation_case has no CHECK constraint, and co-populating
+-- target_post_id/target_comment_id alongside target_person_id is valid
+-- (the dual-population shape already exists for the modlog table).
+--
+-- Authority trail:
+--   - ADR-017 (99-decisions-and-open-questions.md): post/comment authors are
+--     first-class defendants; target_person_id = content author's creator_id.
+--   - ADR-008: governance_log is NOT touched (no audit row rewritten/inserted).
+--   - ADR-015: target_person_id is an integer FK to person — NOT a direct
+--     identifier; the actor_pseudonym mapping is untouched, no PII implication.
+--   - ADR-010 (reversibility): the status filter below is LOAD-BEARING.
+--     Jury panel size + juror exclusion read target_person_id ONLY at
+--     jury-assignment time, which fires exclusively from the three statuses
+--     Open / ThresholdMet / EmergencyRemove and atomically freezes
+--     panel_size_snapshot. Excluding exactly those three statuses guarantees
+--     this backfill cannot retroactively resize an in-flight or already-seated
+--     jury. Cases past jury assignment have a frozen panel and are safe.
+--
+-- Enum literals are PascalCase ('Post','Comment', status literals) per the
+-- DbValueStyle = verbatim Postgres enum definitions in
+-- 2026-04-15-100000-0000_add_governance_enums/up.sql. Lowercase would match
+-- nothing and silently invert the scope filter — do NOT lowercase.
+--
+-- Hard-deleted content nulls its FK (target_post_id/target_comment_id are
+-- ON DELETE SET NULL), so orphaned cases fall out of the WHERE and stay NULL.
+--
+-- Idempotent: the `target_person_id IS NULL` guard makes re-running across
+-- down/up cycles a no-op on rows already backfilled.
+--
+-- Smoke check at retro time:
+--   SELECT status, count(*) FROM moderation_case
+--   WHERE target_type IN ('Post','Comment') AND target_person_id IS NULL
+--   GROUP BY status;
+-- After up: Decided/Appealed/Closed/etc. post/comment rows are populated;
+-- Open/ThresholdMet/EmergencyRemove rows are intentionally left NULL.
+-- ============================================================
+
+UPDATE moderation_case mc
+SET target_person_id = CASE mc.target_type
+    WHEN 'Post'    THEN (SELECT p.creator_id FROM post p    WHERE p.id = mc.target_post_id)
+    WHEN 'Comment' THEN (SELECT c.creator_id FROM comment c WHERE c.id = mc.target_comment_id)
+    ELSE mc.target_person_id
+  END
+WHERE mc.target_person_id IS NULL
+  AND mc.target_type IN ('Post', 'Comment')
+  AND (mc.target_post_id IS NOT NULL OR mc.target_comment_id IS NOT NULL)
+  AND mc.status NOT IN ('Open', 'ThresholdMet', 'EmergencyRemove');


### PR DESCRIPTION
## Summary

Fixes smoke-test **BUG-1**: a post or comment author could not appeal a moderation case against their own content (`POST /governance/appeal` returned `not_found`). Root cause: `moderation_case.target_person_id` was `NULL` for post/comment-targeted cases, so the appeal handler's defendant check (`target_person_id == Some(caller)`) had no author to match.

Per **ADR-017** (this PR), post/comment-targeted cases now populate `target_person_id` with the content author's `creator_id`, making the author a first-class defendant for appeal, sanction inheritance, reputation ban-math, sponsor-liability, and juror exclusion. Federation is unaffected (AP URL resolves from `target_post_id`/`target_comment_id`).

## ADR impact matrix

| ADR | Impact | How honoured |
|---|---|---|
| **ADR-017** (new) | Establishes post/comment authors as first-class defendants. | Decision recorded in `99-decisions-and-open-questions.md`; enacted in the handlers + migration + `04`. |
| ADR-010 (reversibility / no retroactive jury invalidation) | Backfill must not resize an in-flight or seated jury. | Status filter excludes `Open`/`ThresholdMet`/`EmergencyRemove` — the only states a jury can still be sized from (panel snapshot is frozen at assignment). `down.sql` is a guarded reverse-backfill. |
| ADR-013 (emergency-remove) | Emergency-removed authors should be accountable/appealable. | `admin_emergency_remove` resolves the author into `target_person_id`. |
| ADR-015 (GDPR / pseudonymisation) | No new PII. | `target_person_id` is an integer FK to `person`; `actor_pseudonym` + governance log untouched. |
| ADR-008 (append-only governance log) | Audit chain must not be rewritten. | Migration is a data-only `UPDATE` on `moderation_case`; no governance-log rows touched. |
| ADR-006 / ADR-014 (federation) | Federation semantics must not change. | `publish_sanction_notice` resolves the AP URL from `target_post_id`/`target_comment_id`, never `target_person_id` — verified agnostic. |

## Changes

**Code (the fix)**
- `create_report.rs::resolve_target` — Post/Comment arms bind the read and set `target_person_id: Some(creator_id)`.
- `admin_emergency_remove.rs` — resolves the content author in-transaction so emergency takedowns are appealable too.
- `submit_jury_vote.rs` — refreshed the now-stale `GOTCHA-56h` comment (post/comment cases now enter sponsor-liability).
- `request_appeal.rs` — verified, no edit required.

**Migration** — `2026-06-01-000000-0000_backfill_author_defendant/`
- Status-scoped backfill excluding `Open`/`ThresholdMet`/`EmergencyRemove`. PascalCase enum literals; guarded reversible `down.sql`; ADR-exception-trail comment block.

**Tests** — `crates/server/tests/e2e.rs`
- `post_comment_author_appeal_succeeds_nonauthor_denied` — post/comment author appeals succeed; non-author denied with `NotFound` (§12.4 spoofing invariant preserved).
- `admin_emergency_remove_post_sets_author_defendant` — exercises the new in-transaction author-resolution block end-to-end.
- `backfill_author_defendant_round_trip` — up populates a Decided post case, leaves an Open one NULL, down restores NULL.
- Prepended the migration to `MIGRATIONS_TO_REVERT_PHASE_1` so the non-ignored `phase1_revert_list_matches_disk` guard stays green.

**Docs**
- `99-decisions-and-open-questions.md` — ADR-017 + change-log entry.
- `04-data-model-and-api.md` — migration #31 row, `target_person_id` semantics, the six smoke-test API DIFFs reconciled (code-wins), and the `AdminReputationRollup` route + DTO.

## Definition of Done

- [x] `cargo check -p lemmy_api -p lemmy_api_crud --features full` — **exit 0** (clean).
- [x] `cargo test --workspace --features full --test e2e --no-run` — **exit 0** (e2e target compiles clean, no warnings).
- [x] `adr-compliance` CI workflow — **passed**.
- [x] CodeRabbit review — **no actionable comments** on the latest pass; Copilot + CodeRabbit findings addressed (see below).
- [ ] e2e **runtime** (`cargo test --workspace --features full --test e2e`) — **NOT RUN**: needs Docker/testcontainers, unavailable in the authoring environment. The cargo workflows here are `workflow_dispatch`-only; dispatch `cargo-test-e2e.yml` for runtime confidence before merge.
- [ ] Migration **round-trip at runtime** — NOT RUN (same Docker dependency); the round-trip is compile-verified via the e2e test above.

## Rollback strategy

- **Code:** additive only (populates a previously-NULL field at write time); revert the commits to restore prior behaviour.
- **Data:** the migration's `down.sql` is a guarded reverse-backfill — it nulls `target_person_id` only on post/comment rows whose value still equals the content author, leaving person-targeted and externally-set rows untouched. Reversible via `lemmy_diesel_utils` revert.

## AI review findings acknowledgement

- **Copilot** — emergency-remove author-resolution path lacked a test → added `admin_emergency_remove_post_sets_author_defendant`. ✅
- **CodeRabbit DIFF-6** (endpoint/path mismatch) → corrected paths + disambiguated `/reputation/rollup` (person_id) vs `/reputation-stats` (optional community_id) + added the missing route row. ✅
- **CodeRabbit §5 DTO** → documented `AdminReputationRollup`/`…Response`. ✅
- **CodeRabbit "missing PRP plan file" (Critical)** — **declined (not applicable):** `.claude/PRPs/plans/*.plan.md` are advisor meta-work committed direct on `governance-v0` (per `phase-branch.md`), not code-PR artifacts; this is a bugfix mini-phase, not a numbered roadmap sub-phase. CodeRabbit did not regenerate this finding on its latest pass.

Plan reference: advisor plan for the ADR-017 author-defendant fix (governance-semantics change, not a localized patch).

https://claude.ai/code/session_018fNn8vVGrjMHru8opyVMo8

---
_Generated by [Claude Code](https://claude.ai/code/session_018fNn8vVGrjMHru8opyVMo8)_


## Summary by CodeRabbit

* **New Features**
  * Content authors are now the primary defendant for post/comment moderation cases; community-targeted cases remain unchanged.
  * Emergency admin removals now attribute the content author as the defendant for affected cases.

* **Documentation**
  * Added ADR-017 and updated API docs, including a new admin reputation rollup route and behaviour notes.

* **Tests**
  * Added coverage for author appeal rights, non-author appeal rejection, emergency-remove behaviour and migration round-trips.

* **Chores**
  * Reversible backfill migration to populate historical cases with author defendants.