### PR TITLE
feat(db_schema,api): M3 town-hall chair/mute entry-kind consts + shim + ROOM_KINDS 10→13

### DIFF
--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,6 +1,32 @@
 {
   "schema_version": 3,
-  "pending": [],
+  "pending": [
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop",
+      "timestamp": "2026-06-17T00:00:00Z",
+      "question": "Validate workspace compiles with --features full after M3 chair/mute consts + shim (task 1+2)",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "3 M3 chair/mute entry-kind consts added to crates/db_schema governance_log.rs + api shim re-exports + ROOM_KINDS extended 10→13. Laptop advisor runs cargo-check.sh --workspace --features full to confirm compile-accept.",
+      "commands": [
+        "./scripts/brehon/cargo-check.sh --workspace --features full"
+      ],
+      "branch": "phase-m3-core-entry-kinds",
+      "phase_task": 1,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "id": "47341df311f4-001"
+    }
+  ],
   "resolved": [
     {
       "id": "8533df2ad37d-001",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,32 +1,6 @@
 {
   "schema_version": 3,
-  "pending": [
-    {
-      "from": "impl",
-      "kind": "validate-pending-laptop",
-      "timestamp": "2026-06-17T00:00:00Z",
-      "question": "Validate workspace compiles with --features full after M3 chair/mute consts + shim (task 1+2)",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "3 M3 chair/mute entry-kind consts added to crates/db_schema governance_log.rs + api shim re-exports + ROOM_KINDS extended 10→13. Laptop advisor runs cargo-check.sh --workspace --features full to confirm compile-accept.",
-      "commands": [
-        "./scripts/brehon/cargo-check.sh --workspace --features full"
-      ],
-      "branch": "phase-m3-core-entry-kinds",
-      "phase_task": 1,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null,
-      "result": null,
-      "log_slice": null,
-      "failed_commands": null,
-      "id": "47341df311f4-001"
-    }
-  ],
+  "pending": [],
   "resolved": [
     {
       "id": "8533df2ad37d-001",
@@ -7518,6 +7492,31 @@
       "approved_by": null,
       "approved_at": null,
       "id": "a3d0e9941441-062"
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop",
+      "timestamp": "2026-06-17T00:00:00Z",
+      "question": "Validate workspace compiles with --features full after M3 chair/mute consts + shim (task 1+2)",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "3 M3 chair/mute entry-kind consts added to crates/db_schema governance_log.rs + api shim re-exports + ROOM_KINDS extended 10→13. Laptop advisor runs cargo-check.sh --workspace --features full to confirm compile-accept.",
+      "commands": [
+        "./scripts/brehon/cargo-check.sh --workspace --features full"
+      ],
+      "branch": "phase-m3-core-entry-kinds",
+      "phase_task": 1,
+      "answer": "cargo-check.sh --workspace --features full passed (Finished, no errors); lemmy_server + lemmy_api shim + ROOM_KINDS(13) gate compile-accept. Level-5 invariants pass: db_schema=72, shim=72, no dup literals, ROOM_KINDS len=13.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-18T00:35:00Z",
+      "approved_by": null,
+      "approved_at": null,
+      "result": "pass",
+      "log_slice": null,
+      "failed_commands": null,
+      "id": "47341df311f4-001"
     }
   ]
 }

--- a/.claude/runlog/m3-core-entry-kinds-runlog.md
+++ b/.claude/runlog/m3-core-entry-kinds-runlog.md
@@ -1,0 +1,7 @@
+## bm: cut phase-m3-core-entry-kinds off governance-v0 @ 0438d2b — 2026-06-17T00:00:00Z
+- **branch:** phase-m3-core-entry-kinds
+- **off:** governance-v0 @ 0438d2b64
+- **plan:** .claude/PRPs/plans/m3-core-entry-kinds.plan.md
+- **pushed:** yes — origin/phase-m3-core-entry-kinds (upstream tracking set via -u)
+- **verified:** gh api branch endpoint confirmed
+- **next:** advisor authors impl-task briefs; worker forks from phase-m3-core-entry-kinds

--- a/.claude/runlog/m3-core-entry-kinds-runlog.md
+++ b/.claude/runlog/m3-core-entry-kinds-runlog.md
@@ -5,3 +5,10 @@
 - **pushed:** yes — origin/phase-m3-core-entry-kinds (upstream tracking set via -u)
 - **verified:** gh api branch endpoint confirmed
 - **next:** advisor authors impl-task briefs; worker forks from phase-m3-core-entry-kinds
+
+## bm: PR opened — 2026-06-17T23:50:00Z
+- **PR:** #200 — feat(db_schema,api): M3 town-hall chair/mute entry-kind consts + shim + ROOM_KINDS 10→13
+- **URL:** https://github.com/barrie-cork/lemmy/pull/200
+- **Base ← Head:** governance-v0 ← phase-m3-core-entry-kinds
+- **Body source:** brief template + commit log
+- **Next:** wait ~5–10 min for CR; then `/bm-poll-cr 200`

--- a/crates/api/api/src/governance/governance_log.rs
+++ b/crates/api/api/src/governance/governance_log.rs
@@ -58,8 +58,10 @@ pub use lemmy_db_schema::source::governance::governance_log::{
   ENTRY_KIND_PANEL_ASSEMBLED, ENTRY_KIND_PARTICIPATION_CRON_TICK, ENTRY_KIND_PUBLIC_LOG_PUBLISHED,
   ENTRY_KIND_REPORT_CREATED, ENTRY_KIND_REPUTATION_DELTA, ENTRY_KIND_RESTORATION_COMPLETED,
   ENTRY_KIND_ROLLUP_RECOMPUTED, ENTRY_KIND_ROOM_ARCHIVED, ENTRY_KIND_ROOM_BRIDGE_ERROR,
+  ENTRY_KIND_ROOM_CHAIR_OVERRIDE, ENTRY_KIND_ROOM_CHAIR_TRANSFERRED,
   ENTRY_KIND_ROOM_CREATED, ENTRY_KIND_ROOM_DECISION_RELAYED, ENTRY_KIND_ROOM_IDENTITY_REVEALED,
   ENTRY_KIND_ROOM_LIFECYCLE_EVENT, ENTRY_KIND_ROOM_MEMBER_ADDED, ENTRY_KIND_ROOM_MEMBER_REMOVED,
+  ENTRY_KIND_ROOM_MUTE_ALL,
   ENTRY_KIND_ROOM_RECORDING_UPLOADED, ENTRY_KIND_ROOM_TRANSCRIPT_READY,
   ENTRY_KIND_RULE_SET_VERSION_CREATED, ENTRY_KIND_SANCTION_CREATED,
   ENTRY_KIND_SANCTION_EVENT_DELIVERY_FAILED, ENTRY_KIND_SANCTION_PUBLISHED,
@@ -94,25 +96,28 @@ pub struct RoomEventPayload {
   pub member_count: Option<i32>,
 }
 
-/// The 10 allowed `entry_kind` values for [`append_room_event`].
+/// The 13 allowed `entry_kind` values for [`append_room_event`].
 /// Any kind not in this set is rejected (ADR-008 integrity gate).
 #[cfg(feature = "full")]
 const ROOM_KINDS: &[&str] = &[
   ENTRY_KIND_ROOM_ARCHIVED,
   ENTRY_KIND_ROOM_BRIDGE_ERROR,
+  ENTRY_KIND_ROOM_CHAIR_OVERRIDE,
+  ENTRY_KIND_ROOM_CHAIR_TRANSFERRED,
   ENTRY_KIND_ROOM_CREATED,
   ENTRY_KIND_ROOM_DECISION_RELAYED,
   ENTRY_KIND_ROOM_IDENTITY_REVEALED,
   ENTRY_KIND_ROOM_LIFECYCLE_EVENT,
   ENTRY_KIND_ROOM_MEMBER_ADDED,
   ENTRY_KIND_ROOM_MEMBER_REMOVED,
+  ENTRY_KIND_ROOM_MUTE_ALL,
   ENTRY_KIND_ROOM_RECORDING_UPLOADED,
   ENTRY_KIND_ROOM_TRANSCRIPT_READY,
 ];
 
 /// Typed, kind-validated path to the governance log for Room lifecycle events.
 ///
-/// Accepts only the 10 `ENTRY_KIND_ROOM_*` kinds (ADR-008 integrity gate —
+/// Accepts only the 13 `ENTRY_KIND_ROOM_*` kinds (ADR-008 integrity gate —
 /// the bridge can only write Room::* kinds through this wrapper, never
 /// arbitrary entry kinds). Serialises `payload` to JSON and delegates to
 /// [`append`], which runs `scrub_json` and the hash-chain + signing steps.

--- a/crates/db_schema/src/source/governance/governance_log.rs
+++ b/crates/db_schema/src/source/governance/governance_log.rs
@@ -247,6 +247,13 @@ pub const ENTRY_KIND_ROOM_DECISION_RELAYED: &str = "room_decision_relayed";
 pub const ENTRY_KIND_ROOM_BRIDGE_ERROR: &str = "room_bridge_error";
 pub const ENTRY_KIND_ROOM_LIFECYCLE_EVENT: &str = "room_lifecycle_event";
 
+// M3 town-hall chair/mute kinds (3) — zero-migration; entry_kind is TEXT.
+// Call sites land bridge-side in M3 phase 3 (_CHAIR_TRANSFERRED / _CHAIR_OVERRIDE)
+// and phase 4 (_MUTE_ALL) via append_room_event. Pre-landed-const exemption.
+pub const ENTRY_KIND_ROOM_CHAIR_TRANSFERRED: &str = "room_chair_transferred";
+pub const ENTRY_KIND_ROOM_CHAIR_OVERRIDE: &str = "room_chair_override";
+pub const ENTRY_KIND_ROOM_MUTE_ALL: &str = "room_mute_all";
+
 // m2-late-1 additions: B-publish sanction propagation (Task 3). Call sites
 // land in Task 4 enqueue_sanction_event (sanction_publisher.rs) per the
 // pre-landed-const exemption. SANCTION_PUBLISHED fires when ≥1 subscriber


### PR DESCRIPTION
## Summary

- Registers 3 new governance-log entry-kind string consts for M3 town halls (Phase 2): `ENTRY_KIND_ROOM_CHAIR_TRANSFERRED` (`room_chair_transferred`), `ENTRY_KIND_ROOM_CHAIR_OVERRIDE` (`room_chair_override`), `ENTRY_KIND_ROOM_MUTE_ALL` (`room_mute_all`) in `crates/db_schema/src/source/governance/governance_log.rs`
- Re-exports all 3 through the api shim `pub use` block (alphabetical) in `crates/api/api/src/governance/governance_log.rs`
- Extends the `ROOM_KINDS` integrity-gate array 10 → 13 (the ADR-008 `append_room_event` allow-list); both doc comments bumped 10→13
- Zero-migration: `entry_kind` is TEXT (mirrors the M2 room-kinds pattern)
- Pre-landed consts: no emitters this phase. Call sites land bridge-side in M3 phase 3 (`_CHAIR_TRANSFERRED` / `_CHAIR_OVERRIDE`) and phase 4 (`_MUTE_ALL`) via `append_room_event` (pre-landed-const exemption)
- Entry-kind registry count 69 → 72 (advisor meta-work, landed direct on `governance-v0` @ `35b16907a`)

## Plan reference

`.claude/PRPs/plans/m3-core-entry-kinds.plan.md` — Task 1 (db_schema consts), Task 2 (api shim + ROOM_KINDS), Task 4 (advisor registry reconcile)

## Validation

- Windows cargo check (`--workspace --features full`): EXIT 0 @ `f377c9444` (Finished 17m58s, lemmy_server + shim + ROOM_KINDS(13) gate compile-accept)
- Linux-compile gate: N/A — pure-logic diff (3 string consts + shim + array; no Cargo.toml/migrations/cfg touch), Windows-green == Linux-green
- e2e: N/A — const-only SCHEMA phase, no test files in diff
- Level-5 registry invariants: db_schema distinct consts = 72, shim parity = 72, no duplicate literals, ROOM_KINDS len = 13

## Commits

- fa9c971ab chore(merge): finalize m3-core-entry-kinds task-1 consts+shim (job-689)
- 267ed9d95 chore(decision-queue): impl raised validate-pending-laptop for m3-core-entry-kinds task-1
- d31c45beb feat(db_schema,api): add 3 M3 chair/mute entry-kind consts + shim + ROOM_KINDS 10→13 (task 1+2)
- 33efbb27f Merge branch 'governance-v0' into phase-m3-core-entry-kinds
- 5f62485e4 chore(bm-task): log branch cut phase-m3-core-entry-kinds post-planning approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced support for three new room governance events: chair transfer, chair override, and room mute functionality, expanding moderation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->