### PR TITLE
feat(rtc,bridge): M3 town-hall stage mode — chair-controlled mic-passing, FIFO raised-hand queue, 30s grace auto-revoke, chair transfer/override, FIRST room_chair_* chain emission

### DIFF
--- a/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-2.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-2.md
@@ -1,0 +1,63 @@
+# Brief: m3-core-stage-mode fix-impl-2 (Task 3 clippy unwrap_or_default)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-fix-impl2-stage-load-error-propagate — see .claude/PRPs/briefs/m3-core-stage-mode-fix-impl-2.md`
+
+## §2 Scope
+
+**Fix the ONE clippy error that failed Task 3's `validate-pending-laptop-linux` validation** (DQ `e1256574bda6-001`, CLIPPY_EXIT_101). `cargo check` PASSES and all 6 `stage` tests PASS (incl. the marquee `fifo_mic_pass_in_sequence`); the ONLY blocker is a single disallowed-method clippy error.
+
+**The failing lint (verbatim):**
+```
+error: use of a disallowed method `core::result::Result::unwrap_or_default`
+  --> src/stage.rs:61:18
+```
+
+In `Stage::load`, a malformed persisted `queue_state` JSON is silently swallowed to an empty queue via `.unwrap_or_default()` — losing the raised-hand FIFO order on a corrupt row. **User decision (2026-06-19): propagate the parse error** so a corrupt `queue_state` surfaces instead of vanishing. This is the semantically-correct fix (a corrupt raised-hand queue must not silently reset).
+
+**Produces (exactly 1 file edit, ONE commit):**
+1. `services/bridge/src/stage.rs` — two changes:
+   - **Import:** line 5 is `use anyhow::{anyhow, Result};` → add `Context`: `use anyhow::{anyhow, Context, Result};`.
+   - **`Stage::load` (the `Some(json) =>` arm at ~line 58-61):** replace `.unwrap_or_default()` with `.context("corrupt bridge_room.queue_state")?`:
+     ```rust
+     // before:
+     Some(json) => serde_json::from_str::<Vec<String>>(&json)
+         .map(|v| v.into_iter().collect())
+         .unwrap_or_default(),
+     // after:
+     Some(json) => serde_json::from_str::<Vec<String>>(&json)
+         .map(|v| v.into_iter().collect())
+         .context("corrupt bridge_room.queue_state")?,
+     None => VecDeque::new(),
+     ```
+   `Stage::load` already returns `Result<Self>`, so `?` propagates cleanly. No signature change.
+
+**Do NOT:**
+- Change any other line of `stage.rs` — only the import + the one `.unwrap_or_default()` → `.context(...)?` swap.
+- Touch any test (all 6 pass; the `Stage::load` test callers at lines 214/327/335 use well-formed data — the fix does NOT break them, verified by advisor).
+- Touch any other file, any `crates/**`, any migration, `Cargo.toml`/`Cargo.lock`.
+- Add any `#[allow]` — this is a real fix (error propagation), not a suppression.
+
+**Branch:** forks from the **Task 3 worker branch** `junior/role-impl-task-m3-core-stage-mode-task3-stage-fifo-mic-pass-see-claude-prps-briefs-m3-core-stage-mode-impl-3-md-711` (tip `d26d87ba2`) — so the fix lands on Task 3's lineage.
+
+## §3 Required reading
+
+- `services/bridge/src/stage.rs:1-70` — the `use anyhow::{...}` import (line 5) + the `Stage::load` fn (`:56-66`) with the `.unwrap_or_default()` at `:61`.
+- **Lessons (mandatory, §2.4 file-class — `services/bridge/**`):**
+  - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml` (Docker `rust:1.95`).
+  - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; the laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+  - `feedback_clippy_test_style.md` — the disallowed-method list (`unwrap_or_default`, `unwrap`, `expect`) is enforced under `-D warnings`; propagate with `?` + `.context()`.
+
+## §4 Constraints
+
+- **ONE commit, 1 file** — `fix(rtc): propagate corrupt queue_state parse error in Stage::load (fix-impl 2)`.
+- **Error-propagation, NOT suppression** — replace `.unwrap_or_default()` with `.context("corrupt bridge_room.queue_state")?`. Do NOT `#[allow(clippy::disallowed_methods)]` — the lint is correct; a corrupt persisted queue must surface.
+- **Add `Context` to the existing anyhow import** — `use anyhow::{anyhow, Context, Result};` (line 5). Without it, `.context(...)` won't resolve.
+- **No behavior change to the happy path** — well-formed `queue_state` still parses to the FIFO; only the malformed case now errors instead of resetting. The 6 existing tests must still pass (they use well-formed data).
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+
+## §3a Handover from prior cohort
+
+Task 3 (#711) shipped `stage.rs` with the full chair-seat + FIFO + mic-pass state machine + 6 deterministic tests (all PASS incl. the marquee `fifo_mic_pass_in_sequence`). `cargo check` PASSED. The ONLY validation blocker is a single `unwrap_or_default` clippy error at `stage.rs:61` in `Stage::load` (corrupt-queue_state silent swallow). This fix-impl propagates that parse error per the user's decision; nothing else about Task 3 changes.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-3.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-3.md
@@ -1,0 +1,64 @@
+# Brief: m3-core-stage-mode fix-impl-3 (Task 4 tokio time/test-util feature gate)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-fix-impl3-tokio-time-feature-gate — see .claude/PRPs/briefs/m3-core-stage-mode-fix-impl-3.md`
+
+## §2 Scope
+
+**Apply the advisor's resolution of blocker DQ `6302ef3b3382-001`** (raised by Task 4 #713). Task 4's `stage.rs` is committed (`53b8c5612`) and correct — it uses `tokio::time::sleep` in `run_grace` (runtime) + `#[tokio::test(start_paused = true)]` / `tokio::time::advance` in the two grace tests (test-only). The bridge's `tokio` dep currently has only `features = ["rt-multi-thread", "macros"]` — both `time` and `test-util` are missing, so the crate does not compile. This is the ONLY blocker; the code is done.
+
+**ADVISOR DECISION (2026-06-19): option-a — split runtime vs test feature.**
+- `time` is a genuine RUNTIME dependency (`run_grace` calls `tokio::time::sleep` in the production cancel-future path) → goes in `[dependencies]`.
+- `test-util` (source of `pause`/`advance`/`start_paused`) has ZERO production callsites — only the two virtual-time tests use it → goes in `[dev-dependencies]`.
+- option-b (both in `[dependencies]`) was rejected: shipping `test-util` into the prod binary alters runtime timer semantics and is a reviewer red-flag. The clean split is idiomatic.
+
+This is a feature-toggle on an EXISTING dep (`tokio` is already a bridge dep) — NOT a new crate, so the plan's "no new dependency" watchpoint is satisfied. Enabling `test-util` fulfils plan §10.7's mandated `start_paused`/`advance` virtual-time test pattern.
+
+**Produces (exactly 1 file edit, ONE commit):**
+1. `services/bridge/Cargo.toml` — two changes:
+   - **`[dependencies]` tokio line (currently line ~14):** add `"time"` to the features array:
+     ```toml
+     # before:
+     tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+     # after:
+     tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+     ```
+   - **Add a `[dev-dependencies]` section** (none exists yet — add it after the `[dependencies]` block, before any other section). Enable `test-util` on tokio there:
+     ```toml
+     [dev-dependencies]
+     tokio = { version = "1", features = ["test-util"] }
+     ```
+     Cargo unions feature sets across `[dependencies]` + `[dev-dependencies]` for the test build, so the test target gets `rt-multi-thread + macros + time + test-util`; the prod binary gets only the `[dependencies]` set (no `test-util`).
+
+**Do NOT:**
+- Add `test-util` to the `[dependencies]` tokio entry (that is the rejected option-b — `test-util` must be test-only).
+- Add any NEW crate — only toggle features on the existing `tokio` dep.
+- Touch `services/bridge/src/stage.rs` or any other source file — the code is already correct and committed; this is a Cargo.toml-only fix.
+- Touch `Cargo.lock` by hand — cargo regenerates it on the next build (the laptop validate step). If `Cargo.lock` changes as a side-effect of a local cargo run, do NOT run cargo yourself; leave it to the laptop validate.
+- Touch any `crates/**`, any migration, any other manifest.
+
+**Also resolve DQ `6302ef3b3382-001`:** move it from `pending[]` to `resolved[]` with `answer` = "option-a per advisor 2026-06-19: `time` added to [dependencies], `test-util` added to a new [dev-dependencies] section; test-only, prod binary unaffected.", `answered_by: "advisor"`, `resolved_at: <now ISO8601>`. (The advisor authored this decision in the brief; you are applying it.) Use the Read+Edit JSON approach or `python` to mutate the entry; commit the DQ change in the SAME commit as the Cargo.toml edit.
+
+**Branch:** forks from the **Task 4 #713 worker branch** `junior/role-impl-task-m3-core-stage-mode-task4-30s-grace-boundary-see-claude-prps-briefs-m3-core-stage-mode-impl-4-md-713` (tip `9d035ade5`) — so the fix lands on Task 4's lineage with the committed `stage.rs`.
+
+## §3 Required reading
+
+- `services/bridge/Cargo.toml:1-40` — the `[dependencies]` block + the `tokio` line at ~14; confirm NO `[dev-dependencies]` section exists yet.
+- `services/bridge/src/stage.rs:163-180` — the `run_grace` async fn using `tokio::time::sleep` (confirms `time` is a runtime need); `:392-445` the two `#[tokio::test(start_paused = true)]` tests (confirm `test-util` is test-only).
+- **Lessons (mandatory, §2.4 file-class — `services/bridge/**` + Cargo.toml):**
+  - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml` (Docker `rust:1.95`).
+  - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; the laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+
+## §4 Constraints
+
+- **ONE commit, ≤2 files** (Cargo.toml + decision-queue.json) — `fix(rtc): enable tokio time + test-util features for stage grace timer (fix-impl 3)`.
+- **`time` in `[dependencies]`, `test-util` in `[dev-dependencies]`** — the split is the advisor decision; do NOT collapse to one section.
+- **No new crate, no source edit** — Cargo.toml feature toggle only + the DQ resolution.
+- **Resolve DQ `6302ef3b3382-001`** in the same commit (move pending→resolved, `answered_by: "advisor"`).
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+
+## §3a Handover from prior cohort
+
+Task 4 (#713) committed `stage.rs` @ `53b8c5612` — the `run_grace` async grace-timer (separate async method, sync `promote_next`/`on_grace_expired` unchanged, so the 6 Task-3 tests are intact) + 2 new `#[tokio::test(start_paused = true)]` grace tests (`grace_no_activate_auto_revokes_and_promotes_next` asserting `RevokePublish(W1)` THEN `GrantPublish(W2)`, + a contrast test where activation cancels the grace). DoD-grep PASSED (R7: zero `thread::sleep`, uses `tokio::time::sleep` in `tokio::select!`). The crate does not compile only because tokio's `time` + `test-util` features are off. This fix-impl toggles them per the advisor's option-a decision; nothing else changes.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-4.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-4.md
@@ -1,0 +1,71 @@
+# Brief: m3-core-stage-mode fix-impl-4 (Task 4 stage.rs doc-overindent clippy)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-fix-impl4-stage-doc-overindent — see .claude/PRPs/briefs/m3-core-stage-mode-fix-impl-4.md`
+
+## §2 Scope
+
+**§G4 allowlist match — verbatim row (anti-paraphrase gate):**
+
+> | `clippy::doc_overindented_list_items` warning | re-indent the doc-list continuation to clippy's suggested column (4 spaces under `///`) per the `help: try using` hint | n/a (mechanical; added 2026-06-19 m3-core-stage-mode Task 4 — sibling of `doc_lazy_continuation`) |
+
+**Fix the ONE clippy error that failed Task 4's `validate-pending-laptop-linux` validation** (DQ `13fd7f8da89b-001`). `cargo check` PASSES and the bridge compiles; the ONLY blocker is a single doc-comment formatting lint.
+
+**The failing lint (verbatim):**
+```
+error: doc list item overindented
+   --> src/stage.rs:161:9
+    |
+161 |     ///            `std::future::ready(())` when activation already happened.
+    |         ^^^^^^^^^^^ help: try using `    ` (4 spaces)
+    |
+    = note: `-D clippy::doc-overindented-list-items` implied by `-D warnings`
+```
+
+The `run_grace` doc comment (stage.rs ~155-162) has a two-item list:
+```rust
+/// Callers supply the cancel Future:
+///   - Tests: `std::future::pending::<()>()` for the boundary case;
+///            `std::future::ready(())` when activation already happened.
+///   - Production (Task 5+): a `oneshot::Receiver<()>` that `on_activate` fires.
+```
+The continuation line (`std::future::ready...`) is over-indented relative to the `- Tests:` bullet. clippy wants list items + continuations aligned to a consistent 4-space indent under `///`.
+
+**Produces (exactly 1 file edit, ONE commit):**
+1. `services/bridge/src/stage.rs` — fix ONLY the doc-comment indentation in the `run_grace` doc block (~lines 159-162) so clippy's `doc_overindented_list_items` passes. The clean form clippy accepts:
+   ```rust
+   /// Callers supply the cancel Future:
+   /// - Tests: `std::future::pending::<()>()` for the boundary case;
+   ///   `std::future::ready(())` when activation already happened.
+   /// - Production (Task 5+): a `oneshot::Receiver<()>` that `on_activate` fires.
+   ```
+   (List markers `- ` directly after `/// `; continuation indented 2 spaces under the marker. This is the standard markdown-in-rustdoc list form clippy expects. If clippy still flags after this, follow the exact `help: try using` column it prints.)
+
+**Do NOT:**
+- Change any code line, signature, test, or non-doc-comment text — this is a pure doc-comment whitespace fix.
+- Add `#[allow(clippy::doc_overindented_list_items)]` — re-indent properly, do not suppress.
+- Touch any other file, any `crates/**`, any migration, `Cargo.toml`/`Cargo.lock`.
+- Touch the two grace tests or any of the 6 Task-3 tests.
+
+**Branch:** forks from the **fix-impl-3 #715 worker branch** `junior/role-impl-task-m3-core-stage-mode-fix-impl3-tokio-time-feature-gate-see-claude-prps-briefs-m3-core-stage-mode-fix-i-715` (tip `8c9f0ec56`) — so the fix lands on the lineage that already has the Cargo.toml feature toggle + the committed stage.rs.
+
+## §3 Required reading
+
+- `services/bridge/src/stage.rs:155-165` — the `run_grace` doc comment with the over-indented list.
+- **Lessons (mandatory, §2.4 file-class — `services/bridge/**`):**
+  - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+  - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; the laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+
+## §4 Constraints
+
+- **ONE commit, 1 file** — `fix(rtc): re-indent run_grace doc list to satisfy clippy doc-overindent (fix-impl 4)`.
+- **Re-indent, NOT suppress** — fix the whitespace; no `#[allow]`.
+- **Pure doc-comment change** — no code/test/signature touched; the 8 tests are unaffected.
+- **Resolve DQ `13fd7f8da89b-001`** in the same commit (move pending→resolved, `answered_by: "advisor"`, `answer` = "doc-overindent fixed per advisor §G4 allowlist 2026-06-19").
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+
+## §3a Handover from prior cohort
+
+Task 4 (#713 code @ `53b8c5612`) + fix-impl-3 (#715 Cargo.toml feature toggle @ `8c9f0ec56`) landed the 30s grace timer + the tokio `time`/`test-util` features. The bridge now `cargo check`s clean on Linux. The ONLY remaining validation blocker is a single `doc_overindented_list_items` clippy lint at `stage.rs:161` in the `run_grace` doc comment (the cancel-future callers list). This is a pure doc-comment whitespace fix; the 8 tests + all code are correct and unchanged.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-5.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-5.md
@@ -1,0 +1,75 @@
+# Brief: m3-core-stage-mode fix-impl-5 (Task 5 dead_code — scaffold-ahead-of-caller)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-fix-impl5-task5-deadcode-allow — see .claude/PRPs/briefs/m3-core-stage-mode-fix-impl-5.md`
+
+## §2 Scope
+
+**Fix the 3 clippy `dead_code` errors that failed Task 5's `validate-pending-laptop-linux` validation** (DQ `7677417db9fb-001`). `cargo check` PASSES, the 2 `room_event_client` JSON-shape tests PASS, and the 11 `stage` tests PASS; the ONLY blocker is clippy `-D warnings` flagging 3 scaffold-ahead-of-caller items.
+
+**The failing lints (verbatim):**
+```
+error: field `brehon_room_event_url` is never read
+  --> src/config.rs:37:9
+error: struct `RoomEventRequest` is never constructed
+  --> src/room_event_client.rs:27:8
+error: function `post_room_event` is never used
+  --> src/room_event_client.rs:36:14
+```
+
+**Why dead (not a defect):** Task 5 used the emit-intent seam (`Stage::pending_emits: Vec<EmitIntent>`) so `transfer_chair`/`chair_override` stay synchronous (keeping the 11 stage tests green). The actual *drain-and-POST* — the async bridge controller that drains `pending_emits` and calls `post_room_event(state.http_client, config.brehon_room_event_url, ...)` — is **Task 6** scope. So `post_room_event`, `RoomEventRequest`, and the consumed `brehon_room_event_url` field have no caller **yet**. This is the SAME scaffold-ahead-of-caller situation as Task 2's `mint_access_token`/`VideoGrant` (which carried `#[allow(dead_code)]` until Task 3 referenced them).
+
+**USER DECISION (2026-06-19):** `#[allow(dead_code)]` the 3 items now (scaffold-ahead-of-caller), AND Task 6 will wire the async-controller drain + remove these allows when the caller lands. (The advisor will extend the Task 6 brief with the explicit drain requirement.)
+
+**Produces (exactly 1 commit, ≤2 files):**
+1. `services/bridge/src/room_event_client.rs` — add `#[allow(dead_code)]`:
+   - above `struct RoomEventRequest<'a>` (currently line ~26, above `#[derive(serde::Serialize)]` or directly above `struct` — place it so it applies to the struct):
+     ```rust
+     // ponytail: scaffold-ahead-of-caller — Task 6 wires the async controller drain that constructs this.
+     #[allow(dead_code)]
+     struct RoomEventRequest<'a> { ... }
+     ```
+     (Place `#[allow(dead_code)]` directly above the item; keep the existing `#[derive(serde::Serialize)]`.)
+   - above `pub async fn post_room_event(` (line ~36):
+     ```rust
+     #[allow(dead_code)] // Task 6: the async bridge controller drains Stage::pending_emits and calls this.
+     pub async fn post_room_event( ... )
+     ```
+2. `services/bridge/src/config.rs` — add `#[allow(dead_code)]` above `pub brehon_room_event_url: String,` (line ~37):
+   ```rust
+   /// URL for POST /api/v4/governance/room-event (binary callback). Read from
+   /// BREHON_ROOM_EVENT_URL; consumed by the room-event emitters (Task 6 controller drain).
+   #[allow(dead_code)] // Task 6: removed when the controller reads this to call post_room_event.
+   pub brehon_room_event_url: String,
+   ```
+
+**Do NOT:**
+- Touch `RoomEventPayload` (it IS used — by the tests + `EmitIntent`), the `EmitIntent` struct, `pending_emits`, `stage.rs`, `main.rs`, or any test.
+- Remove the `#[allow(dead_code)]` on the 3 livekit config fields (still unconsumed).
+- Wire a real caller / async controller — that is Task 6 (the allows are deliberate placeholders).
+- Touch any `crates/**`, any migration, `Cargo.toml`/`Cargo.lock`.
+
+**Branch:** forks from the **Task 5 #717 worker branch** `junior/role-impl-task-m3-core-stage-mode-task5-room-event-client-emitters-see-claude-prps-briefs-m3-core-stage-mode-impl-5-717` (tip `efb9c9d9d`) — so the fix lands on Task 5's lineage.
+
+## §3 Required reading
+
+- `services/bridge/src/room_event_client.rs:26-50` — `RoomEventRequest` (`:27`) + `post_room_event` (`:36`); confirm `RoomEventPayload` (`:6`) is NOT touched.
+- `services/bridge/src/config.rs:35-40` — the `brehon_room_event_url` field (`:37`).
+- **Lessons (mandatory, §2.4 file-class — `services/bridge/**` + config):**
+  - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+  - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; the laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+
+## §4 Constraints
+
+- **ONE commit, ≤2 files** (room_event_client.rs + config.rs) — `fix(rtc): allow(dead_code) on room-event emitter scaffold pending Task 6 drain (fix-impl 5)`.
+- **`#[allow(dead_code)]` only on the 3 named items** — `RoomEventRequest`, `post_room_event`, `brehon_room_event_url`. NOT on `RoomEventPayload` (used).
+- **Each allow carries a `// Task 6:` comment** noting it's removed when the controller drain lands — so the next reader knows it's intentional scaffold, not debt.
+- **No caller wiring, no test change** — pure suppression-until-consumer.
+- **Resolve DQ `7677417db9fb-001`** in the same commit (move pending→resolved, `answered_by: "advisor"`, `answer` = "dead_code allowed per user 2026-06-19 — scaffold-ahead-of-caller; Task 6 controller drain removes the allows").
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+
+## §3a Handover from prior cohort
+
+Task 5 (#717 @ `efb9c9d9d`) landed `room_event_client.rs` (post_room_event + RoomEventPayload/RoomEventRequest + 2 JSON-shape tests), the config URL fix (`/api/v4`), `main.rs mod`, and the `stage.rs` emit-intent wiring (`EmitIntent` + `pending_emits`, transfer_chair/chair_override push intents; 11 stage tests pass). `cargo check` PASSES. The ONLY validation blocker is 3 `dead_code` clippy errors — the emitter scaffold has no caller until Task 6's async controller drains `pending_emits`. This fix-impl suppresses the 3 with `#[allow(dead_code)]` (Task-2 precedent) per the user's decision; Task 6 wires the drain + removes the allows.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-cr4.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-fix-impl-cr4.md
@@ -1,0 +1,97 @@
+# Brief: m3-core-stage-mode fix-impl-cr4 (CR #202 cr-4 — single-presenter revoke-before-grant)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-fix-impl-cr4-single-presenter-revoke — see .claude/PRPs/briefs/m3-core-stage-mode-fix-impl-cr4.md`
+
+## §2 Scope
+
+**Fix CodeRabbit finding cr-4 (Major/critical) on PR #202** — the single-presenter invariant violation in `services/bridge/src/stage.rs`. User-approved fix-in-PR (gate-3, 2026-06-19).
+
+**The defect (VERIFIED against code by advisor):** `promote_next` (`:105-113`) and `chair_override(Override::ForcePromote)` (`:237-260`) issue `GrantCmd::GrantPublish` for the new participant and overwrite `self.current` **WITHOUT** first issuing `GrantCmd::RevokePublish` for the prior `self.current` holder. So when a promote happens while a previous participant is still seated (the back-to-back mic-pass flow — `promote_next` → `on_activate` → `promote_next` again, with no intervening revoke), the prior publisher keeps LiveKit publish rights → two concurrent publishers → the single-presenter guarantee breaks. The 30s-grace path (`on_grace_expired`) DOES revoke before promoting (Task 4); the direct-promote path does not.
+
+**Produces (exactly 1 file, ONE commit):** `services/bridge/src/stage.rs`
+
+1. **`promote_next` (`:105-113`)** — before `sink.apply(GrantCmd::GrantPublish(head.clone()));`, revoke any seated holder:
+   ```rust
+   pub fn promote_next(&mut self, sink: &mut dyn GrantSink, conn: &Connection) -> Result<()> {
+       let head = self
+           .fifo
+           .pop_front()
+           .ok_or_else(|| anyhow!("promote_next: FIFO is empty"))?;
+       // ponytail: single-presenter invariant — revoke the seated holder before granting the next.
+       if let Some((prev, _)) = self.current.take() {
+           sink.apply(GrantCmd::RevokePublish(prev));
+       }
+       sink.apply(GrantCmd::GrantPublish(head.clone()));
+       self.current = Some((head, SeatState::Promoted));
+       self.flush_queue(conn)?;
+       Ok(())
+   }
+   ```
+   (Take `self.current` so it's cleared before reassignment; the `pop_front` `?` stays FIRST so an empty-FIFO error does not revoke the current speaker.)
+
+2. **`chair_override(Override::ForcePromote)` (`:237`)** — same revoke-before-grant before `sink.apply(GrantCmd::GrantPublish(target.to_string()));` (`:242`):
+   ```rust
+   Override::ForcePromote => {
+       let case_id = self.case_id as i32;
+       let lifecycle_stage = self.room_type.clone();
+       let actor = self.chair.clone();
+       self.fifo.retain(|p| p.as_str() != target);
+       // ponytail: single-presenter invariant — revoke the seated holder before force-promoting.
+       if let Some((prev, _)) = self.current.take() {
+           sink.apply(GrantCmd::RevokePublish(prev));
+       }
+       sink.apply(GrantCmd::GrantPublish(target.to_string()));
+       self.current = Some((target.to_string(), SeatState::Promoted));
+       // ... (existing flush_queue + pending_emits.push EmitIntent UNCHANGED)
+   }
+   ```
+   Do NOT touch the `EmitIntent` push or `flush_queue` — only insert the revoke before the grant.
+
+3. **Update the `fifo_mic_pass_in_sequence` test (`:344-374`)** — the marquee test currently asserts only GrantPublish ORDER. With revoke-before-grant, the second+ `promote_next` calls now also emit `RevokePublish(prev)`. Update the assertion so it (a) still confirms the 4 grants fire in FIFO order, AND (b) confirms each handoff revokes the prior holder before granting the next. Per CR's proposed shape — assert the command SEQUENCE includes `RevokePublish(W1)` immediately before `GrantPublish(W2)` (and W2→W3, W3→W4). Keep the test deterministic (`Recorder` sink). A clean form:
+   ```rust
+   // Grants still fire in FIFO order:
+   let grants: Vec<&str> = sink.cmds.iter().filter_map(|c| {
+       if let GrantCmd::GrantPublish(p) = c { Some(p.as_str()) } else { None }
+   }).collect();
+   assert_eq!(grants, &["W1", "W2", "W3", "W4"], "GrantPublish must fire in FIFO order");
+   // Single-presenter: each handoff revokes the prior holder before granting the next.
+   assert!(
+       sink.cmds.windows(2).any(|w|
+           w[0] == GrantCmd::RevokePublish("W1".to_string())
+           && w[1] == GrantCmd::GrantPublish("W2".to_string())),
+       "handoff must RevokePublish(W1) before GrantPublish(W2)"
+   );
+   ```
+   (`GrantCmd` already derives `PartialEq` (`:25` `#[derive(Debug, Clone, PartialEq)]`) — the `windows(2)` `==` comparison works as-is. No derive change needed.)
+
+**Do NOT:**
+- Touch any other method, the grace path (`run_grace`/`on_grace_expired` already revoke), `room_event_client.rs`, `room_provisioner.rs`, `config.rs`, or any other test (the other 9 stage tests + 2 room_event_client tests must stay green).
+- Change the `EmitIntent` / `pending_emits` logic.
+- Touch any `crates/**`, migration, `Cargo.toml`/`Cargo.lock`.
+- Address CR cr-1/cr-2 (runlog doc-lint — advisor handles those separately) or cr-3 (rebutted, intentional scaffold).
+
+**Branch:** forks from `phase-m3-core-stage-mode` (current tip `9152aa4d6` — Tasks 1-6 complete).
+
+## §3 Required reading
+
+- `services/bridge/src/stage.rs` (WHOLE file, phase tip `9152aa4d6`) — `promote_next` (`:105`), `chair_override` (`:183`, ForcePromote arm `:237`), `on_grace_expired` (the revoke-before-promote precedent — mirror it), `GrantCmd` enum (`:23`), `fifo_mic_pass_in_sequence` (`:344`), the `Recorder` test sink (`:239+`).
+- PR #202 CR finding cr-4 (the proposed diff is the canonical fix shape).
+- **Lessons (mandatory, §2.4 — `services/bridge/**`):**
+  - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+  - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; laptop runs `cargo-linux.sh`; merge gates on `result:pass`.
+  - `feedback_clippy_test_style.md` — no `unwrap`/`expect`/`unwrap_or_default`; tests return `Result<()>` + `?`.
+
+## §4 Constraints
+
+- **ONE commit, 1 file** (`stage.rs`) — `fix(rtc): revoke prior publisher before granting next — single-presenter invariant (CR cr-4, PR #202)`.
+- **Revoke-before-grant in BOTH `promote_next` AND `ForcePromote`** — the take()+revoke must run BEFORE the GrantPublish; in `promote_next` the FIFO `pop_front()?` stays first (empty-FIFO error must not revoke the seated speaker).
+- **The 9 other stage tests + 2 room_event_client tests stay green** — only `fifo_mic_pass_in_sequence` changes (it gains the revoke-before-grant assertion).
+- **No `unwrap`/`expect`/`unwrap_or_default`** (clippy `-D warnings`).
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+
+## §3a Handover from prior cohort
+
+Tasks 1-6 shipped on `phase-m3-core-stage-mode` @ `9152aa4d6` (PR #202 open). CodeRabbit flagged cr-4: `promote_next` + `chair_override(ForcePromote)` grant publish to the new participant without revoking the prior `self.current` holder, breaking the single-presenter guarantee on back-to-back promotes. The grace path (`on_grace_expired`) already revokes-before-promote (Task 4) — this fix brings the direct-promote paths in line. User approved fix-in-PR at gate-3. The fix is ~6 lines (2 revoke-before-grant blocks) + updating the marquee `fifo_mic_pass_in_sequence` test to assert the revoke-before-grant handoff. cr-1/cr-2 (runlog doc-lint) + cr-3 (intentional scaffold, rebutted) are NOT this task.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-impl-3.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-impl-3.md
@@ -1,0 +1,64 @@
+# Brief: m3-core-stage-mode impl-3 (Task 3 — stage-mode core: chair seat + FIFO + mic-pass machine)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-task3-stage-fifo-mic-pass — see .claude/PRPs/briefs/m3-core-stage-mode-impl-3.md`
+
+## §2 Scope
+
+**Task 3 of plan `.claude/PRPs/plans/m3-core-stage-mode.plan.md` (lines 488–524).** Add `services/bridge/src/stage.rs` (NEW) — the chair-seat + **persisted FIFO raised-hand queue** + type-state mic-pass state machine that emits `GrantCmd` to a `GrantSink` — plus the `bridge_room` queue/chair accessors. This is the **marquee of the phase**: the 4-mic-pass-in-sequence test is the §16a Story 1 DoD.
+
+`requires: task 2` (satisfied — Task 2 `mint_access_token(can_publish)` landed on `phase-m3-core-stage-mode` tip `ee630ad71`). Task 3 references the `can_publish` grant *concept* via the `GrantSink` trait; the real LiveKit-re-minting `GrantSink` adapter is wired later — **Task 3's `GrantSink` is a trait + a test recorder impl only.**
+
+**Produces (exactly 1 new file + 2 modified, ONE commit):**
+1. **CREATE** `services/bridge/src/stage.rs` — per plan §10.6:
+   - `pub enum SeatState { Watcher, Promoted, Speaking }`
+   - `pub enum GrantCmd { GrantPublish(String), RevokePublish(String) }`
+   - `pub trait GrantSink { fn apply(&mut self, cmd: GrantCmd); }`
+   - `pub struct Stage { chair: Option<String>, fifo: VecDeque<String>, current: Option<(String, SeatState)>, /* … */ }`
+   - methods: `raise_hand(&mut self, p: &str)` (FIFO append, **no dup**), `promote_next(&mut self, sink: &mut dyn GrantSink)` (pop FIFO head → `GrantPublish` → `SeatState::Promoted`; **no 30s timer yet — Task 4 adds it**), `on_activate(&mut self, p: &str)` (`Promoted`→`Speaking`), `chair_override(&mut self, action: Override, target: &str, sink: &mut dyn GrantSink)` (force_demote/force_promote out of FIFO order + grant/revoke), `transfer_chair(&mut self, to: &str) -> (String, String)` (returns `(from, to)` for the chain entry — Task 5 emits).
+   - **Persist** FIFO + chair to `bridge_room` on every mutation (`write_queue_state` / `write_chair_id`); `Stage::load` reads them back.
+   - **Unit tests (deterministic, NO docker):** (a) **4-mic-pass-in-sequence** — 4× `raise_hand` + 4× `promote_next`/`on_activate`; assert the test `GrantSink` recorded `GrantPublish` in **FIFO order** for all 4 (§16a Story 1 marquee DoD); (b) **chair-override reorder** — `force_promote` a watcher out of FIFO order, assert it's granted **before** the FIFO head; `force_demote` the speaker, assert `RevokePublish`.
+2. **MODIFY** `services/bridge/src/bridge_room.rs` — add `read/write_queue_state` + `read/write_chair_id` per §10.5 (mirror the `upsert`/`set_watermark` shape at `:69-100`). Add a `#[cfg(test)]` test: write a queue JSON → read it back equal; write a chair_id → read it back.
+3. **MODIFY** `services/bridge/src/main.rs` — `mod stage;` (alphabetical position).
+
+**Do NOT:**
+- Add the **30s grace timer** or `on_grace_expired` — that is **Task 4** (`promote_next` leaves the `Promoted` participant awaiting activation with NO timer; Task 4 adds the `tokio::select!` boundary). Adding it here is scope creep.
+- Build the real LiveKit-re-minting `GrantSink` adapter — Task 3 only defines the trait + a test recorder. (The real adapter calling `mint_access_token(can_publish)` comes with later wiring.)
+- Build the `room_event_client` / chain emission — that is **Task 5**.
+- Read `event.chair_pseudonym` / dual-source the chair seat — that is **Task 6**.
+- Touch any `crates/**` file, any migration, `Cargo.toml`/`Cargo.lock` (no new dep — `VecDeque` is std).
+
+**Branch:** forks from `phase-m3-core-stage-mode` (current tip `ee630ad71` — has Task 1 + Task 2 + the dead_code allows).
+
+## §3 Required reading
+
+- `.claude/PRPs/plans/m3-core-stage-mode.plan.md` — Task 3 (488–524), **§10.5** (FIFO persistence in `bridge_room.queue_state`, the `write_queue_state`/`Stage::load` round-trip), **§10.6** (the `stage.rs` `SeatState`/`GrantCmd`/`GrantSink`/`Stage` skeleton — code-block to follow), §8 flow (108–117 the seat-state-machine + FIFO + override rows).
+- `services/bridge/src/bridge_room.rs:13-100` — the `chair_id` + `queue_state` columns (already exist, lines 13-14) and the `upsert` (`:69`) / `set_watermark` (`:94`) accessor shapes to MIRROR for `read/write_queue_state` + `read/write_chair_id`.
+- `services/bridge/src/main.rs` — the existing `mod` declaration block (add `mod stage;` alphabetically).
+- **Lessons (mandatory):**
+  - `feedback_governance_type_state_handlers.md` — **the type-state pattern is the load-bearing design** (plan MIRROR cites it). Invalid transitions (promote empty FIFO, activate a non-promoted participant) must be **unrepresentable or return an error**, NOT silent no-ops. Mirror the phantom-typed / `TryFrom`-guard idiom.
+  - `feedback_build_what_tests_exercise.md` — the 4-mic-pass test must **EXERCISE the real flow** (drive `raise_hand`×4 + `promote_next`/`on_activate` and assert the `GrantSink`-recorded `GrantPublish` ORDER), NOT assert on struct/config shape. A test that only asserts a single successful promote does NOT satisfy the DoD.
+  - **Bridge file-class (§2.4 — `services/bridge/**`):**
+    - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml` (Docker `rust:1.95`); Windows-local fails `ruma-common` E0119.
+    - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; the laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+    - `feedback_clippy_test_style.md` — tests use `anyhow::Result<()>` / `LemmyResult`-style with `?`, no `unwrap`/`expect` (clippy denies them under `-D warnings`).
+
+## §4 Constraints
+
+- **ONE commit** — `feat(rtc): stage-mode core — chair seat + persisted FIFO + mic-pass state machine (task 3)`.
+- **Type-state load-bearing (per `feedback_governance_type_state_handlers.md`):** `SeatState` transitions are guarded — `promote_next` on an empty FIFO returns an error; `on_activate(p)` where `p` is not the `Promoted` participant returns an error. Do NOT make invalid transitions silent no-ops. DoD: the override-reorder test exercises at least one guarded-error path (or the type makes it unrepresentable).
+- **FIFO single-writer, but PERSISTED** (per §10.6 GOTCHA): the chair's bridge controller is the sole writer (no lock needed), BUT the queue MUST flush to `bridge_room.queue_state` on every mutation and `Stage::load` must read it back — the raised-hand order survives bridge restart (the PRD model; the in-memory-only alternative loses order on restart and is wrong).
+- **NO 30s timer in Task 3** — `promote_next` ends at `Promoted` awaiting activation; the timer is Task 4. Keep the seam clean (`on_grace_expired` may be declared as a stub/signature per §10.6 but its timer wiring is Task 4).
+- **NO new dependency** — `VecDeque` is std; `serde_json` for queue serialisation already in the bridge. If you find yourself wanting a new dep, STOP and raise a `kind: "blocker"` DQ (the plan asserts no new dep — watchpoint).
+- **ADR-015 (pseudonyms-only):** the FIFO + chair store **pseudonym strings** (opaque), never `person_id`/username. `queue_state` JSON is `Vec<pseudonym>`; `chair_id` is a pseudonym. No content/speech field touches `stage.rs`.
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push on the worker branch, stop.
+- End the commit body with a `LESSON:` trailer if you find anything durable.
+
+## §3a Handover from prior cohort (Cohort A)
+
+Cohort A (Tasks 1+2) landed on `phase-m3-core-stage-mode` @ `ee630ad71`:
+- **Task 1** added the binary `RoomEventPayload` 5 optional chair-action fields (`action`, `target_pseudonym`, `from_pseudonym`, `to_pseudonym`, `at`, all `skip_serializing_if`) + `CaseTransitionEvent.chair_pseudonym` — the DTO Task 5 will populate when emitting chain entries.
+- **Task 2** added `can_publish` to `mint_access_token`/`VideoGrant` — the LiveKit publish-grant mechanism the real `GrantSink` adapter (later) re-mints. Task 2's `mint_access_token`/`VideoGrant`/`Claims` carry `#[allow(dead_code)]` until a caller exists; **your `stage.rs` `GrantSink` trait does NOT call `mint_access_token` yet** (it's a trait + test recorder), so those allows stay until the real adapter lands.
+- Both validated Linux-clean (check+clippy+test). Task 3 forks from this tip.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-impl-4.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-impl-4.md
@@ -1,0 +1,59 @@
+# Brief: m3-core-stage-mode impl-4 (Task 4 — 30s grace auto-revoke + next-promote boundary)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-task4-30s-grace-boundary — see .claude/PRPs/briefs/m3-core-stage-mode-impl-4.md`
+
+## §2 Scope
+
+**Task 4 of plan `.claude/PRPs/plans/m3-core-stage-mode.plan.md` (lines 526–558).** Wire a **30s grace timer** into `stage.rs`: a promoted-but-not-activated speaker is **auto-revoked at 30s** and the next queued watcher is promoted. This is the **load-bearing boundary** (plan R7) — the test MUST fire the 30s boundary via `tokio::time` virtual-time, NOT a happy-path assert.
+
+`requires: task 3` (satisfied — Task 3 `Stage` machine + `GrantSink` landed on `phase-m3-core-stage-mode` tip `806f0d3b6`). Task 4 EXTENDS the Task-3 `Stage`.
+
+**Produces (exactly 1 file modified, ONE commit):**
+1. **MODIFY** `services/bridge/src/stage.rs`:
+   - `const GRACE_SECS: u64 = 30;`
+   - Wire the grace timer per §10.7: a `tokio::time::sleep(Duration::from_secs(GRACE_SECS))` inside a `tokio::select!` raced against an activation signal; on grace-elapsed-without-activation → `on_grace_expired(p, sink)` → `RevokePublish(p)` + `promote_next` (the next FIFO head). The `on_grace_expired` signature was declared in Task 3 (§10.6) — wire its body + the timer now.
+   - **Unit test (deterministic, the §16a Story 2 DoD):** `#[tokio::test(start_paused = true)]` `grace_no_activate_auto_revokes_and_promotes_next` — promote W1 (W2 queued), `tokio::time::advance(Duration::from_secs(30)).await` WITHOUT activating W1, assert the test `GrantSink` recorded `RevokePublish(W1)` **THEN** `GrantPublish(W2)`.
+   - **Contrast test:** promote W1, `on_activate(W1)` **before** 30s, advance 30s, assert **NO** revoke fired (activation cancels the grace).
+
+**SEAM NOTE (read carefully — likely the one judgment call):** Task 3's `promote_next` is **synchronous** (`fn promote_next(&mut self, sink, conn) -> Result<()>`). The grace timer is **async** (`tokio::select!` / `tokio::time::sleep`). Do NOT force `async` onto the existing sync `promote_next` signature if that breaks the Task-3 callers/tests. The clean approaches (pick whichever fits the Task-3 shape with least churn):
+   - (a) keep `promote_next` sync; add a **separate async** method (e.g. `run_grace(&mut self, p, sink)` or a `promote_next_with_grace`) that does the `select!` and calls the sync `promote_next` for the actual promotion; OR
+   - (b) the grace `select!` lives in an async helper the test drives directly, with `promote_next` unchanged.
+   The 6 existing Task-3 tests MUST still pass. If you cannot wire the timer without changing a Task-3 public signature that has callers, raise a `kind: "blocker"` DQ rather than guessing.
+
+**Do NOT:**
+- Use `std::thread::sleep` or any wall-clock sleep — the timer MUST be `tokio::time` (cancellable + virtual-time-controllable). A wall-clock sleep makes the test wait 30 real seconds and fails R7.
+- Write a test that only asserts a successful promote — the DoD is the 30s-no-activate boundary firing `RevokePublish` THEN `GrantPublish(next)`.
+- Build the real LiveKit `GrantSink` adapter, the `room_event_client` (Task 5), or chair dual-sourcing (Task 6).
+- Touch any `crates/**`, any other `services/bridge/**` file, any migration, `Cargo.toml`/`Cargo.lock` (tokio is already a bridge dep).
+
+**Branch:** forks from `phase-m3-core-stage-mode` (current tip `806f0d3b6` — has Tasks 1+2+3).
+
+## §3 Required reading
+
+- `.claude/PRPs/plans/m3-core-stage-mode.plan.md` — Task 4 (526–558), **§10.7** (the `#[tokio::test(start_paused = true)]` + `tokio::time::advance(30s)` virtual-time pattern — the canonical test shape to mirror), §8 flow line 109-110 (`promote → 30s grace → on no-activate auto-revoke + promote next`).
+- `services/bridge/src/stage.rs` (the WHOLE file, on phase tip `806f0d3b6`) — the Task-3 `Stage`/`SeatState`/`GrantCmd`/`GrantSink`/`promote_next`/`on_activate`/`on_grace_expired` (declared) + the 6 existing tests (mirror their `GrantSink`-recorder test idiom for the new grace tests).
+- **Lessons (mandatory):**
+  - `feedback_build_what_tests_exercise.md` — the grace test must EXERCISE the real 30s-no-activate flow (advance virtual clock, assert the `RevokePublish`→`GrantPublish` order), NOT a happy-path promote.
+  - **Bridge file-class (§2.4 — `services/bridge/**`):**
+    - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+    - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+    - `feedback_clippy_test_style.md` — no `unwrap`/`expect`/`unwrap_or_default` (Task 3 just got bitten by `unwrap_or_default` — use `?` + `.context()`); tests return `Result<()>` / use `anyhow`.
+
+## §4 Constraints
+
+- **ONE commit, 1 file** — `feat(rtc): 30s grace auto-revoke + next-promote boundary (task 4)`.
+- **`tokio::time` ONLY (R7 load-bearing):** the grace timer is `tokio::time::sleep` in a `tokio::select!` against an activation signal. NEVER wall-clock. The test uses `#[tokio::test(start_paused = true)]` + `tokio::time::advance(Duration::from_secs(30)).await`.
+- **The boundary test is the DoD** — `grace_no_activate_auto_revokes_and_promotes_next` asserts `RevokePublish(W1)` THEN `GrantPublish(W2)`; the contrast test asserts activation-before-30s cancels the grace (NO revoke). A successful-promote-only test does NOT satisfy §16a Story 2.
+- **Don't break Task-3's 6 tests** — keep `promote_next`/`on_activate` working for their existing callers. Reconcile the sync/async seam per the SEAM NOTE; blocker-DQ if it forces a Task-3 signature break.
+- **No `unwrap_or_default`/`unwrap`/`expect`** (clippy `-D warnings` — Task 3 fix-impl-2 was exactly this; don't repeat). Propagate with `?` + `.context()`.
+- **ADR-015 (pseudonyms-only):** the grace timer operates on pseudonym strings (the FIFO entries) — never `person_id`/username.
+- **NO new dependency** — `tokio` (with `time` feature) is already a bridge dep. If `tokio`'s `time`/`macros`/`test-util` feature is missing for `start_paused`, that is a `Cargo.toml` feature-flag question — raise a `kind: "blocker"` DQ (do NOT add a new crate; a feature toggle on an existing dep may be needed and is a scope call).
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP**. Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+- End the commit body with a `LESSON:` trailer if you find anything durable.
+
+## §3a Handover from prior cohort
+
+Task 3 (#711/#712) landed `stage.rs` on phase @ `806f0d3b6` — the full chair-seat + persisted FIFO + mic-pass machine + 6 tests (incl. the marquee `fifo_mic_pass_in_sequence`). `promote_next` leaves the promoted participant at `SeatState::Promoted` awaiting activation **with NO timer** — that's deliberate; Task 4 adds the 30s timer. `on_grace_expired(p, sink)` was declared in Task 3 per §10.6 but its body/timer-wiring is YOUR job. **Watch the sync/async seam** (Task-3 `promote_next` is sync; the grace timer is async — see §2 SEAM NOTE). Task 3's fix-impl-2 was a clippy `unwrap_or_default` bust — do NOT reintroduce any disallowed-method.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-impl-5.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-impl-5.md
@@ -1,0 +1,83 @@
+# Brief: m3-core-stage-mode impl-5 (Task 5 — bridge→binary room-event client + chair-action EMITTERS)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-task5-room-event-client-emitters — see .claude/PRPs/briefs/m3-core-stage-mode-impl-5.md`
+
+## §2 Scope
+
+**Task 5 of plan `.claude/PRPs/plans/m3-core-stage-mode.plan.md` (lines 560–600).** Add `services/bridge/src/room_event_client.rs` (NEW) — the bridge→binary outbound POST client — and wire the **chair-transfer + chair-override emitters**. This is the **FIRST emission** of `room_chair_transferred` / `room_chair_override` chain entries from the bridge. The binary side (`room_event_handler.rs`, `ROOM_KINDS`) already accepts these kinds (M3 Phases 1+2).
+
+`requires: task 1` (RoomEventPayload wire shape — landed) + `task 4` (Stage transfer/override paths — landed @ phase `29b16adf0`).
+
+**Produces (1 new file + 3 modified, ONE commit):**
+
+1. **CREATE** `services/bridge/src/room_event_client.rs` — copy the §10.3 skeleton (plan lines 188–221) verbatim as the starting point:
+   - `#[derive(serde::Serialize)] pub struct RoomEventPayload` with fields `case_id: i32`, and `Option<String>`/`Option<i32>` fields `matrix_room_id`, `lifecycle_stage` (String, NOT optional), `member_count`, `action`, `target_pseudonym`, `from_pseudonym`, `to_pseudonym`, `at` — each Option field `#[serde(skip_serializing_if = "Option::is_none")]`.
+   - `#[derive(serde::Serialize)] struct RoomEventRequest<'a> { entry_kind: &'a str, payload: RoomEventPayload, actor_pseudonym: Option<String> }`.
+   - `pub async fn post_room_event(client: &reqwest::Client, url: &str, secret: &str, entry_kind: &str, payload: RoomEventPayload, actor_pseudonym: Option<String>) -> anyhow::Result<()>` — `client.post(url).header("Authorization", format!("Bearer {secret}")).json(&req).send().await?.error_for_status()?; Ok(())`.
+   - **`#[cfg(test)]` tests (JSON-shape, NO live POST):**
+     - `room_chair_override` request → `serde_json::to_value(&RoomEventRequest{...})` → assert `entry_kind == "room_chair_override"`, `payload.action` present, `payload.target_pseudonym` present, and the transfer fields (`from_pseudonym`/`to_pseudonym`) are ABSENT (skip_serializing_if omits them).
+     - `room_chair_transferred` request → assert `from_pseudonym`/`to_pseudonym`/`at` present.
+   - (The live POST is the docker-gated Task-6 test, NOT here.)
+
+2. **MODIFY** `services/bridge/src/config.rs`:
+   - Change the `brehon_room_event_url` default (currently line ~83-84) from `"http://localhost:8536/governance/room-event"` to `"http://localhost:8536/api/v4/governance/room-event"`. Keep the `BREHON_ROOM_EVENT_URL` env override.
+   - **Remove the `#[allow(dead_code)]`** on `brehon_room_event_url` (line ~39) — it's now consumed by the emitter. Do NOT remove the other 3 `#[allow(dead_code)]` (link_confirm/livekit fields — still unconsumed until later).
+
+3. **MODIFY** `services/bridge/src/main.rs` — add `mod room_event_client;` (alphabetical position).
+
+4. **MODIFY** `services/bridge/src/stage.rs` — wire the emitters into `transfer_chair` + `chair_override`. **READ THE SEAM NOTE BELOW FIRST.**
+
+**SEAM NOTE (read carefully — the one judgment call):** `transfer_chair(&mut self, to: &str, conn: &Connection) -> Result<(String, String)>` and `chair_override(&mut self, action, target, sink, conn) -> Result<()>` are **synchronous** and have **existing test callers** (`chair_override_reorder` etc — they must keep passing). `post_room_event` is **async** and needs a `reqwest::Client` + `url` + `secret` the `Stage` does not currently hold. Do NOT force `async` onto the sync `transfer_chair`/`chair_override` signatures if it breaks the existing test callers. The clean approaches (pick whichever fits with least churn):
+   - **(a) Emit-intent return (preferred):** `transfer_chair`/`chair_override` stay sync and additionally RETURN the `(entry_kind, RoomEventPayload, actor_pseudonym)` emit-intent (or push it to a `Vec<EmitIntent>` field on `Stage`); the async bridge controller (Task 6 wiring) drains the intent and calls `post_room_event`. The §16a Story 3/4 DoD is satisfied by the JSON-shape test in `room_event_client.rs` + a stage-side test asserting `transfer_chair` produces the right emit-intent. Keep the existing 8 tests green.
+   - **(b) Async helper method:** add a separate `async fn emit_chair_transferred(&self, client, url, secret) -> Result<()>` that builds the payload from Stage state + calls `post_room_event`; `transfer_chair` stays sync and only mutates state. The test asserts the payload builder.
+   If you cannot wire the emitter without changing a sync signature that has callers, raise a `kind: "blocker"` DQ rather than guessing or breaking tests.
+
+**ENTRY-KIND STRINGS:** the bridge does NOT depend on `lemmy_db_schema`, so pass the literal strings `"room_chair_transferred"` / `"room_chair_override"` (the binary's `ROOM_KINDS` admits them — M3 Phase 2 added them). Do NOT import an entry-kind const from a crate.
+
+**Do NOT:**
+- Make a live HTTP POST in any test — JSON-shape assertions only (the live POST is Task 6, docker-gated).
+- Build the stage-mode provisioning / Q&A sidebar / `room_provisioner.rs` changes — that is **Task 6**.
+- Break any of the 8 existing `stage` tests.
+- Touch any `crates/**`, any migration, `Cargo.toml`/`Cargo.lock` (reqwest + serde + serde_json already bridge deps).
+
+**Branch:** forks from `phase-m3-core-stage-mode` (current tip `29b16adf0` — has Tasks 1+2+3+4).
+
+## §3 Required reading
+
+- `.claude/PRPs/plans/m3-core-stage-mode.plan.md` — Task 5 (560–600), **§10.3** (lines 184–224, the `room_event_client.rs` skeleton — copy it), §10.11 (metadata-only).
+- `crates/api/api_utils/src/bridge_notify.rs:62-72` — **the canonical Bearer-POST MIRROR**: `client.post(url).header("Authorization", format!("Bearer {}", secret)).json(&payload).send().await` + the **fire-and-forget warn-on-error** idiom (`if let Err(e) = ... { tracing::warn!("... non-fatal: {e}"); }`). The GOTCHA's "transport errors logged + swallowed, never block the loop" = this exact pattern — mirror it at the emitter callsite (NOT inside `post_room_event`, which propagates via `?`; the CALLER swallows + warns).
+- `services/bridge/src/room_provisioner.rs:573-591` — reqwest via a shared client (the client-handle shape).
+- `services/bridge/src/stage.rs` (the WHOLE file, phase tip `29b16adf0`) — `transfer_chair` (`:216`), `chair_override` (`:183`), `Override` enum (`:37`), the 8 existing tests (mirror their recorder-test idiom).
+- `services/bridge/src/config.rs:35-84` — the `brehon_room_event_url` field (`:39-40` allow+field), default (`:83-84`).
+- **Lessons (mandatory):**
+  - `feedback_governance_type_state_handlers.md` — emit only from the valid transition path; the emit-intent must reflect the state mutation that actually happened.
+  - `feedback_build_what_tests_exercise.md` — the JSON-shape test must assert the REAL serialised wire shape (entry_kind + present/absent fields), not a struct-field read.
+  - `feedback_cheap_model_arm_drops_adr_constraints.md` — the ADR-015 pseudonym gate below is **load-bearing**, not a nit.
+  - **Bridge file-class (§2.4 — `services/bridge/**`):**
+    - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+    - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+    - `feedback_clippy_test_style.md` — no `unwrap`/`expect`/`unwrap_or_default`; tests return `Result<()>` + `?` + `.context()`.
+
+## §4 Constraints
+
+- **ONE commit, ≤4 files** — `feat(rtc): bridge→binary room-event client + chair-action emitters (task 5)`.
+- **ADR-015 (pseudonyms-only) — LOAD-BEARING:** every payload field (`from_pseudonym`/`to_pseudonym`/`target_pseudonym`/`actor_pseudonym`) is a **pseudonym string** the `Stage` already holds (sourced from LiveKit-identity pseudonyms). **Why it can't be deferred:** a real identity (person_id / username / `@user:server` MXID) written into a hash-chained chair entry is permanent and unscrubable — a GDPR violation baked into the immutable governance log. **DoD: `rg -i 'person_id|username|@.*:' services/bridge/src/room_event_client.rs` returns NOTHING identity-shaped** (only pseudonym strings). State this grep result in the commit body.
+- **ADR-016 (metadata-only):** `post_room_event` payload carries METADATA only (case_id, lifecycle_stage, action, pseudonyms, timestamp) — **never** Q&A text, speech, or video. No content field on `RoomEventPayload`.
+- **URL DoD:** after the config fix, `rg 'api/v4/governance/room-event' services/bridge/src/config.rs` MUST match (the missing `/api/v4` was a silent-404 footgun — plan §10.3 GOTCHA + §15.5).
+- **Fire-and-forget at the callsite:** `post_room_event` returns `Result` (propagates via `?`); the EMITTER callsite (in stage.rs or the controller) wraps it `if let Err(e) = ... { tracing::warn!(...) }` — a bridge→binary transport failure must NEVER block or panic the stage loop (best-effort chain entry). Mirror `bridge_notify.rs:69-72`.
+- **Don't break the 8 stage tests** — reconcile the sync/async seam per the §2 SEAM NOTE; blocker-DQ if it forces a sync-signature break with callers.
+- **No `unwrap`/`expect`/`unwrap_or_default`** (clippy `-D warnings`). Propagate with `?` + `.context()`.
+- **NO new dependency** — reqwest/serde/serde_json/anyhow already bridge deps.
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+- End the commit body with a `LESSON:` trailer if you find anything durable.
+
+## §3a Handover from prior cohort
+
+Tasks 1–4 landed on `phase-m3-core-stage-mode` @ `29b16adf0`:
+- **Task 1** — `RoomEventPayload` 5 optional chair-action fields (`action`/`target_pseudonym`/`from_pseudonym`/`to_pseudonym`/`at`) on the BINARY struct (`crates/api/api_common/src/governance.rs`) + `room_event_handler.rs`. Your bridge-side `RoomEventPayload` (Serialize mirror) MUST match this wire shape (same field names, same skip_serializing_if).
+- **Task 2** — `mint_access_token(can_publish)` (the publish-grant mint).
+- **Task 3** — `stage.rs` `Stage`/`SeatState`/FIFO/`transfer_chair`/`chair_override` + 6 tests.
+- **Task 4** — 30s grace timer (`run_grace`/`on_grace_expired`/`GRACE_SECS`) + 2 grace tests (8 total). Task 4's seam was reconciled with a separate async `run_grace` method (sync `promote_next`/`on_grace_expired` unchanged). **Apply the same discipline to the Task-5 emit seam** — keep `transfer_chair`/`chair_override` sync if making them async would break their callers; use emit-intent return or an async helper per the §2 SEAM NOTE.

--- a/.claude/PRPs/briefs/m3-core-stage-mode-impl-6.md
+++ b/.claude/PRPs/briefs/m3-core-stage-mode-impl-6.md
@@ -1,0 +1,92 @@
+# Brief: m3-core-stage-mode impl-6 (Task 6 — stage-mode provisioning + Q&A sidebar + drain-emits + docker-gated e2e)
+
+## §1 Role + dispatch line
+
+`[role:impl-task] m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e — see .claude/PRPs/briefs/m3-core-stage-mode-impl-6.md`
+
+## §2 Scope
+
+**Task 6 of plan `.claude/PRPs/plans/m3-core-stage-mode.plan.md` (lines 602–639).** The LAST impl task. Extend the bridge town-hall provisioning to open in **stage mode** (chair presenter, watchers muted), seat the dual-sourced chair into `chair_id`, attach the Q&A sidebar (= Matrix text timeline), **wire the async controller drain of `Stage::pending_emits → post_room_event`** (the user-decision extension — see §2.1), and add the docker-gated `#[ignore]` end-to-end test.
+
+`requires: task 2` (presenter/watcher token mint — landed) + `task 5` (`Stage::pending_emits` + `post_room_event` + `room_event_client` — landed).
+
+**Produces (1 new file + 2 modified, ONE commit):**
+
+1. **MODIFY** `services/bridge/src/room_provisioner.rs`:
+   - Add `#[serde(default)] pub chair_pseudonym: Option<String>` to the bridge `CaseTransitionEvent` mirror (`:19-33` — the struct with `case_id`/`juror_pseudonyms`/`new_status`/`old_status`/`community_id`). Mirror the existing `#[serde(default)]` idiom. This field is READ here (Phase-3); the binary-side population is Phase-6.
+   - Add a town-hall stage-mode provisioning path (extend `provision_community_event_room` `:187` or add a sibling `provision_townhall_stage_room`). Mirror the `:183-237` shape: `bridge_room::open` → `bridge_room::lookup` idempotent-skip → `provision::create_community_room` → `bridge_room::upsert`. **Additionally**, on `state.config.rtc_enabled`:
+     - Seat `chair_id` from `event.chair_pseudonym` ?? `event.juror_pseudonyms.first()` (foreperson fallback, OQ-V2-05); `bridge_room::write_chair_id`.
+     - Initialise `queue_state` to `[]` (`bridge_room::write_queue_state(conn, case_id, room_type, "[]")`).
+     - Mint the chair a **presenter token** (`mint_access_token(..., can_publish = true)`) and watchers **watcher tokens** (`can_publish = false`). (Token plumbing is the Task-2 `can_publish` param; if there is no participant list at provisioning time, mint only the chair presenter token + leave watcher minting to join-time — note which in the commit body.)
+   - The Q&A sidebar is the Matrix room's **native text timeline** — NO new room type, NO content field, NO hashing (ADR-016). Provisioning the Matrix room IS provisioning the Q&A sidebar; add a one-line comment saying so.
+
+2. **MODIFY** `services/bridge/src/room_event_client.rs` — **wire the drain (the user-decision extension, §2.1) + REMOVE the 3 dead_code allows:**
+   - Add `pub async fn drain_emits(stage: &mut crate::stage::Stage, client: &reqwest::Client, url: &str, secret: &str)` that loops `for intent in stage.pending_emits.drain(..) { if let Err(e) = post_room_event(client, url, secret, intent.entry_kind, intent.payload, intent.actor_pseudonym).await { tracing::warn!("room-event POST failed (non-fatal — best-effort chain entry): {e}"); } }`. **Fire-and-forget warn-on-error** per `bridge_notify.rs:62-72`.
+   - **REMOVE** `#[allow(dead_code)]` from `post_room_event` (`:38`), from `RoomEventRequest` (`:28`), and (in `config.rs`) from `brehon_room_event_url` (`:37`) — `drain_emits` is the real production caller; `post_room_event` constructs `RoomEventRequest`; the provisioning path reads `config.brehon_room_event_url`. Once `drain_emits` is reachable from a non-test caller, all three are live and clippy `-D warnings` passes WITHOUT the allows.
+   - **DO NOT touch** `RoomEventPayload` or its fields (used) or any `room_event_client` test.
+
+3. **CREATE** `services/bridge/tests/stage_mode.rs` per §10.9 — the docker-gated `#[ignore]` end-to-end test (`four_mic_pass_then_grace_boundary_emits_chair_entries`). Mirror `services/bridge/tests/room_provisioning.rs:12-21,36-42` (the `#[tokio::test] #[ignore = "requires docker-compose stack"]` + step-comment + `todo!(...)` convention). Steps (comments only, `todo!()` body — pilot-grade, live run is Phase-6):
+   - provision a stage room (chair + 4 watchers); drive 4 raise-hand + promote/activate passes; drive a 5th promote with no activation → assert auto-revoke + next-promote at 30s; drive a chair transfer + override; query `governance_log` → assert `room_chair_transferred {from_pseudonym, to_pseudonym, at}` + `room_chair_override {action, target_pseudonym}` rows exist with **PSEUDONYM** payload fields (never `person_id` / `@user:domain` MXID).
+
+### §2.1 The drain wiring — WHY it's load-bearing (user decision 2026-06-19)
+
+Task 5 used the **emit-intent seam**: `transfer_chair`/`chair_override`/`promote_next` stay synchronous and push an `EmitIntent { entry_kind, payload, actor_pseudonym }` to `Stage::pending_emits: Vec<EmitIntent>` (keeping the 11 stage tests green). The actual async POST to the binary was deferred — which left `post_room_event` + `RoomEventRequest` + `brehon_room_event_url` with **no production caller**, flagged `dead_code` and carried under `#[allow(dead_code)]` (fix-impl-5).
+
+**The user decided (2026-06-19):** Task 6 wires the async controller drain (`drain_emits`) AND removes the 3 allows now that the caller exists. **Why it can't be deferred again:** leaving the allows means the emit path is never exercised by production code — `pending_emits` would accumulate forever with nothing draining them, and the FIRST-emission DoD (`room_chair_transferred`/`room_chair_override` actually POST) would be a phantom. The drain is the seam closure that makes the emit-intent design real.
+
+**Scope-honest note:** there is currently NO production HTTP endpoint that calls `Stage::transfer_chair`/`chair_override` (only `#[cfg(test)]` callers). So at provisioning time `pending_emits` is empty and `drain_emits` loops zero times — `post_room_event` is **reachable** (clippy dead_code satisfied, allows removable) but not yet *driven* by a live stage-action. The live stage-action HTTP endpoint that populates `pending_emits` and calls `drain_emits` per-action is **Phase-6** (the binary-side chair-action trigger). Task 6 ships the drain function + makes it reachable from the provisioning path (even an empty drain after seat-chair counts as a real caller). Do NOT build the stage-action HTTP endpoint — that is Phase-6 (§12). If `drain_emits` cannot be made reachable from a non-test caller without building the Phase-6 endpoint, raise a `kind: "blocker"` DQ rather than guessing.
+
+**Do NOT:**
+- Build the Phase-6 stage-action HTTP endpoint (the live transfer/override/promote trigger). Task 6 ships the drain function + provisioning + e2e stub only.
+- Add content hashing / a Q&A content field / a new room type — the Q&A sidebar IS the Matrix text timeline (ADR-016).
+- Run the `#[ignore]` test body (it needs the live docker stack); it must COMPILE under `--no-run` only.
+- Touch any `crates/**`, any migration, `Cargo.toml`/`Cargo.lock` (no new dep; reqwest/serde/anyhow already bridge deps).
+- Break any of the 11 `stage` tests or the 2 `room_event_client` tests.
+- Re-add a new `ENTRY_KIND_*` const or touch the entry-kind registry (`ROOM_KINDS` admits the kinds already — M3 Phase 2).
+
+**Branch:** forks from `phase-m3-core-stage-mode` (tip AFTER Task 5 + fix-impl-5 finalize-merge — the advisor will state the exact SHA in the dispatch; it has Tasks 1–5 + the 3 dead_code allows that THIS task removes).
+
+## §3 Required reading
+
+- `.claude/PRPs/plans/m3-core-stage-mode.plan.md` — Task 6 (602–639), **§10.8** (provisioning, 300–304), **§10.9** (test harness skeleton, 306–324), §10.10 (ADR-015 pin), §10.11 (ADR-016 metadata-only), §16a Story 5 (743–748).
+- `services/bridge/src/room_provisioner.rs:19-33` — the `CaseTransitionEvent` mirror (add `chair_pseudonym`). `:183-237` — `provision_community_event_room` (the provisioning MIRROR: open/lookup/create/upsert idempotent shape). `:573-591` — shared reqwest client handle shape.
+- `services/bridge/src/room_event_client.rs` (WHOLE file) — `post_room_event` (`:39`), `RoomEventRequest` (`:29`), `RoomEventPayload` (`:6`, do NOT touch), the 3 `#[allow(dead_code)]` to remove (`:28`, `:38`, + config.rs `:37`). `EmitIntent` is in `stage.rs:47`.
+- `services/bridge/src/stage.rs:47-69` — `EmitIntent { entry_kind: &'static str, payload: RoomEventPayload, actor_pseudonym: Option<String> }` + `Stage::pending_emits` field (`:68`). The drain consumes these directly (field names match `post_room_event` args).
+- `services/bridge/src/main.rs` — `AppState` (`http_client: reqwest::Client` at `:62`; `config: Arc<BridgeConfig>`). The drain takes `&state.http_client`, `&config.brehon_room_event_url`, `&config.bridge_callback_secret`.
+- `crates/api/api_utils/src/bridge_notify.rs:62-72` — **the fire-and-forget warn-on-error MIRROR** for the drain callsite (`if let Err(e) = ...post(...).send().await { tracing::warn!("... non-fatal: {e}"); }`).
+- `services/bridge/tests/room_provisioning.rs:12-42` — the `#[ignore]`-stub + step-comment + `todo!()` convention to mirror for `stage_mode.rs`.
+- **Lessons (mandatory):**
+  - `feedback_cheap_model_arm_drops_adr_constraints.md` — the ADR-015 pseudonym gate (§4) is **load-bearing**, not a nit.
+  - `feedback_build_what_tests_exercise.md` — provisioning seats chair + mints tokens; the `#[ignore]` e2e asserts REAL `governance_log` rows (not a struct read).
+  - `feedback_governance_type_state_handlers.md` — provision only on the valid transition; idempotent-skip via `bridge_room::lookup`.
+  - **Bridge file-class (§2.4 — `services/bridge/**`):**
+    - `feedback_bridge_validates_on_linux_not_windows.md` — bridge cargo runs **Linux ONLY** via `scripts/brehon/cargo-linux.sh --manifest-path services/bridge/Cargo.toml`.
+    - `feedback_linux_compile_proof_is_a_gate.md` — write a `validate-pending-laptop-linux` DQ; laptop runs `cargo-linux.sh`; `bm-pr` gates on `result:pass`.
+    - `feedback_clippy_test_style.md` — no `unwrap`/`expect`/`unwrap_or_default`; tests return `Result<()>` + `?` + `.context()`.
+
+## §4 Constraints
+
+- **ONE commit, ≤3 files** (`room_provisioner.rs` + `room_event_client.rs` + new `tests/stage_mode.rs`; config.rs allow-removal is part of the same commit if the allow is there — count it as a 4th touch only if needed) — `feat(rtc): stage-mode provisioning + Q&A sidebar + room-event drain + e2e stub (task 6)`.
+- **REMOVE the 3 `#[allow(dead_code)]`** (`post_room_event`, `RoomEventRequest` in room_event_client.rs; `brehon_room_event_url` in config.rs). **DoD: `grep -rn 'allow(dead_code)' services/bridge/src/room_event_client.rs` returns NOTHING; `grep -n 'allow(dead_code)' services/bridge/src/config.rs` returns ONLY the 3 livekit fields (lines ~54/57/60), NOT brehon_room_event_url.** State both grep results in the commit body.
+- **`drain_emits` MUST be reachable from a non-test caller** (the provisioning path) — that is what removes the dead_code. **DoD: `grep -n 'drain_emits' services/bridge/src/room_provisioner.rs` returns a callsite** (or another non-test prod path). If you cannot wire a reachable caller without building the Phase-6 endpoint → blocker-DQ.
+- **ADR-015 (pseudonyms-only) — LOAD-BEARING:** `chair_id` is seated from `chair_pseudonym` ?? `juror_pseudonyms.first()` — both **pseudonyms**. The e2e asserts every chair-payload field is a pseudonym string. **Why it can't be deferred:** a real identity in a hash-chained chair entry is permanent + unscrubable (GDPR violation in the immutable log). **DoD: `rg -i 'person_id|username|mxid|@.*:' services/bridge/src/room_provisioner.rs services/bridge/tests/stage_mode.rs` returns NOTHING identity-shaped.** State the grep result in the commit body.
+- **ADR-016 (metadata-only):** the Q&A sidebar is the Matrix text timeline — NEVER hashed or POSTed to the chain. No content field on any payload. No new room type.
+- **Watcher tokens `can_publish=false`, chair `can_publish=true`** — stage mode = one presenter slot at open.
+- **No `unwrap`/`expect`/`unwrap_or_default`** (clippy `-D warnings`). Propagate with `?` + `.context()`.
+- **NO new dependency.** **NO new migration** (no `bridge_room` column add — `chair_id`/`queue_state` already exist from Task 3).
+- **The `#[ignore]` e2e must COMPILE under `--no-run`, not run.**
+- **Bridge compiles on Linux ONLY.** Write a `validate-pending-laptop-linux` DQ with `commands: ["scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml", "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml --test stage_mode --no-run", "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"]`. Use `bash scripts/brehon/dq-v3-new-entry.sh` for the id; `bash scripts/brehon/dq-v3-append-fragment.sh <frag>.json --pending` to append. Commit + push the DQ on the worker branch, then **STOP** — do NOT run cargo/Docker yourself (laptop advisor validates). Per `feedback_validate_pending_laptop_write_then_stop.md`.
+- **DQ mid-task discipline:** any blocker → `kind: "blocker"` DQ, commit + push, stop.
+- End the commit body with a `LESSON:` trailer if you find anything durable (the emit-intent → drain seam closure is a candidate).
+
+## §3a Handover from prior cohort
+
+Tasks 1–5 + fix-impl-5 landed on `phase-m3-core-stage-mode` (advisor states exact SHA at dispatch):
+- **Task 1** — `RoomEventPayload` 5 optional chair-action fields + `CaseTransitionEvent.chair_pseudonym` binary-side.
+- **Task 2** — `mint_access_token(can_publish)` (presenter/watcher mint).
+- **Task 3** — `stage.rs` `Stage`/FIFO/`transfer_chair`/`chair_override` + 6 tests.
+- **Task 4** — 30s grace (`run_grace`/`on_grace_expired`/`GRACE_SECS`) + 2 grace tests; separate async `run_grace` (sync methods unchanged).
+- **Task 5** — `room_event_client.rs` (`post_room_event` + `RoomEventPayload`/`RoomEventRequest` + 2 JSON-shape tests) + config URL fix (`/api/v4`) + `main.rs mod` + the **emit-intent seam** (`EmitIntent` + `Stage::pending_emits`; `transfer_chair`/`chair_override`/`promote_next` push intents; 11 stage tests). The async POST was deferred to THIS task.
+- **fix-impl-5** — `#[allow(dead_code)]` on `post_room_event`/`RoomEventRequest`/`brehon_room_event_url` (scaffold-ahead-of-caller). **THIS task removes all 3** by wiring `drain_emits` (the production caller).
+
+Task 6 closes the seam: provisioning opens stage mode + seats the chair + drains emits; the e2e stub asserts the FIRST `room_chair_*` chain entries land with pseudonyms. After Task 6 validates + merges, the phase is impl-complete (6/6) → bm-pr → CR triage (gate 3).

--- a/.claude/PRPs/debug/dq-task1-frag.json
+++ b/.claude/PRPs/debug/dq-task1-frag.json
@@ -1,0 +1,24 @@
+{
+  "id": "3a93f5eebf23-001",
+  "from": "impl",
+  "kind": "validate-pending-laptop",
+  "timestamp": "2026-06-18T00:00:00Z",
+  "question": "Validate Task 1 cargo check + clippy on laptop",
+  "options": ["pass", "fail"],
+  "context": "Task 1 (RoomEventPayload chair fields + CaseTransitionEvent.chair_pseudonym) committed. 3 files changed: governance_log.rs (5 optional fields + serde roundtrip test), api_common/governance.rs (chair_pseudonym on CaseTransitionEvent), bridge_notify.rs (chair_pseudonym: None in constructor). No cargo run on daemon per brief §4.",
+  "answer": null,
+  "answered_by": null,
+  "resolved_at": null,
+  "approved_by": null,
+  "approved_at": null,
+  "commands": [
+    "cmd //c \"scripts\\\\brehon\\\\cargo-check.bat --workspace --features full\"",
+    "cmd //c \"scripts\\\\brehon\\\\cargo-clippy.bat --workspace --features full --no-deps -- -D warnings\""
+  ],
+  "branch": "junior/role-impl-task-m3-core-stage-mode-task1-roomeventpayload-chair-fields-see-claude-prps-briefs-m3-core-stage-mode-imp-708",
+  "phase_task": "m3-core-stage-mode task 1",
+  "result": null,
+  "log_slice": null,
+  "failed_commands": null,
+  "e2e_filter": null
+}

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -54,6 +54,32 @@
       "log_slice": null,
       "failed_commands": null,
       "e2e_filter": null
+    },
+    {
+      "id": "e1256574bda6-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-18T00:00:00Z",
+      "question": "Run cargo-linux.sh (check + clippy + test stage) for Task 3 stage.rs; report pass or fail.",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 3 adds services/bridge/src/stage.rs + bridge_room.rs accessors + mod stage in main.rs. Bridge compiles Linux-only (ruma-common E0119 on Windows). Commands: check + clippy --no-deps -D warnings + test stage. Commit 77731ea73 on branch junior/role-impl-task-m3-core-stage-mode-task3-stage-fifo-mic-pass-see-claude-prps-briefs-m3-core-stage-mode-impl-3-md-711.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task3-stage-fifo-mic-pass-see-claude-prps-briefs-m3-core-stage-mode-impl-3-md-711",
+      "phase_task": "task3",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "result": null,
+      "log_slice": null,
+      "approved_by": null,
+      "approved_at": null
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,31 +83,6 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
-    },
-    {
-      "from": "impl",
-      "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T00:00:00Z",
-      "question": "Run cargo-linux.sh to validate bridge Task 6 (stage-mode provisioning + drain-emits + e2e stub) on Linux target.",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "Task 6 commit 425eb6a25 on branch junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719. Adds provision_townhall_stage_room + drain_emits + removes 3 dead_code allows + new tests/stage_mode.rs. Bridge compiles on Linux only (cargo-linux.sh). Check: cargo check, clippy -D warnings, stage_mode --no-run, stage unit tests.",
-      "commands": [
-        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
-        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml --test stage_mode --no-run",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
-      ],
-      "branch": "junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719",
-      "phase_task": "6",
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null,
-      "id": "bc10e175f0da-001"
     }
   ],
   "resolved": [
@@ -8053,6 +8028,34 @@
       "log_slice": null,
       "failed_commands": null,
       "id": "33017c985c6a-001"
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run cargo-linux.sh to validate bridge Task 6 (stage-mode provisioning + drain-emits + e2e stub) on Linux target.",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 6 commit 425eb6a25 on branch junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719. Adds provision_townhall_stage_room + drain_emits + removes 3 dead_code allows + new tests/stage_mode.rs. Bridge compiles on Linux only (cargo-linux.sh). Check: cargo check, clippy -D warnings, stage_mode --no-run, stage unit tests.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml --test stage_mode --no-run",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719",
+      "phase_task": "6",
+      "answer": "cargo-linux PASS: check rc=0, clippy -D warnings rc=0 (3 dead_code allows removed; drain_emits makes post_room_event/RoomEventRequest/brehon_room_event_url live), test --test stage_mode --no-run rc=0 (docker-gated #[ignore] compiles, not run), test stage 10 passed (incl fifo_mic_pass + grace boundary + 2 emit tests). validate-719 @ b3fdfa9ab.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T04:00:32.027473+00:00",
+      "approved_by": null,
+      "approved_at": null,
+      "id": "bc10e175f0da-001",
+      "result": "pass",
+      "log_slice": null,
+      "failed_commands": null
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,6 +83,33 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run bridge cargo-linux check+clippy+test for task 5 room_event_client + stage emitters",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 5 (m3-core-stage-mode) adds services/bridge/src/room_event_client.rs (NEW) and modifies config.rs, main.rs, stage.rs. Bridge compiles on Linux only (ruma-common E0119 on Windows). Laptop advisor must run cargo-linux.sh to validate. DoD: rg -i 'person_id|username|@.*:' room_event_client.rs = 0 hits (PASS); rg 'api/v4/governance/room-event' config.rs = match (PASS).",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task5-room-event-client-emitters-see-claude-prps-briefs-m3-core-stage-mode-impl-5-717",
+      "phase_task": "5",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "id": "7677417db9fb-001"
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,6 +83,23 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
+    },
+    {
+      "id": "6302ef3b3382-001",
+      "from": "impl",
+      "kind": "blocker",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Should we add tokio `time` + `test-util` features to services/bridge/Cargo.toml to unblock Task 4 compilation?",
+      "options": [
+        "option-a: add `time` to [dependencies].tokio.features AND add `tokio = { version = \"1\", features = [\"test-util\"] }` under [dev-dependencies]",
+        "option-b: add `time` and `test-util` to the single [dependencies] tokio entry (simpler; test-util in prod is harmless — only activates when tokio::time::pause() is called)"
+      ],
+      "context": "Task 4 stage.rs implementation is committed (53b8c5612). It uses tokio::time::sleep (requires `time` feature) in run_grace and #[tokio::test(start_paused = true)] (requires `test-util` feature) in the two new grace tests. Current bridge Cargo.toml has tokio = { version = \"1\", features = [\"rt-multi-thread\", \"macros\"] } — both `time` and `test-util` are missing. The brief prohibits touching Cargo.toml without advisor scope approval; it explicitly says to raise a kind:blocker DQ when these features are absent.",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,6 +83,31 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run cargo-linux.sh to validate bridge Task 6 (stage-mode provisioning + drain-emits + e2e stub) on Linux target.",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 6 commit 425eb6a25 on branch junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719. Adds provision_townhall_stage_room + drain_emits + removes 3 dead_code allows + new tests/stage_mode.rs. Bridge compiles on Linux only (cargo-linux.sh). Check: cargo check, clippy -D warnings, stage_mode --no-run, stage unit tests.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml --test stage_mode --no-run",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task6-stage-mode-provisioning-drain-emits-e2e-see-claude-prps-briefs-m3-core-stag-719",
+      "phase_task": "6",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "id": "bc10e175f0da-001"
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -85,31 +85,31 @@
       ]
     },
     {
-      "id": "13fd7f8da89b-001",
       "from": "impl",
       "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T01:10:58Z",
-      "question": "Does the bridge crate compile cleanly on Linux (Docker rust:1.95) after adding tokio `time` to [dependencies] and `test-util` to [dev-dependencies]?",
+      "timestamp": "2026-06-19T01:40:35Z",
+      "question": "Does the bridge crate compile + pass clippy cleanly on Linux (Docker rust:1.95) after fixing the doc_overindented_list_items lint in stage.rs run_grace doc block?",
       "options": [
         "pass: cargo check + clippy + test all succeed on Linux",
         "fail: at least one command exits non-zero on Linux"
       ],
-      "context": "fix-impl-3 toggled tokio features in services/bridge/Cargo.toml (time in [dependencies], test-util in [dev-dependencies]). Bridge compiles on Linux ONLY per feedback_bridge_validates_on_linux_not_windows.md. Laptop advisor must run cargo-linux.sh to confirm no Linux-only errors.",
-      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl3-tokio-time-feature-gate-see-claude-prps-briefs-m3-core-stage-mode-fix-i-715",
-      "phase_task": "m3-core-stage-mode fix-impl-3 (task 4 lineage)",
+      "context": "fix-impl-4 re-indented the run_grace doc list (stage.rs ~159-162) to satisfy clippy::doc-overindented-list-items. This is the only remaining blocker from the fix-impl-3 validate-pending-laptop-linux (DQ 13fd7f8da89b-001). No code changes. Laptop advisor must run cargo-linux.sh to confirm clippy now passes.",
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl4-stage-doc-overindent-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-716",
+      "phase_task": "m3-core-stage-mode fix-impl-4 (task 4 lineage)",
       "commands": [
         "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
         "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
       ],
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
       "result": null,
       "log_slice": null,
       "failed_commands": null,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
       "approved_by": null,
-      "approved_at": null
+      "approved_at": null,
+      "id": "e5510f969130-001"
     }
   ],
   "resolved": [
@@ -7945,6 +7945,33 @@
       "approved_by": null,
       "approved_at": null,
       "failed_commands": null
+    },
+    {
+      "id": "13fd7f8da89b-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T01:10:58Z",
+      "question": "Does the bridge crate compile cleanly on Linux (Docker rust:1.95) after adding tokio `time` to [dependencies] and `test-util` to [dev-dependencies]?",
+      "options": [
+        "pass: cargo check + clippy + test all succeed on Linux",
+        "fail: at least one command exits non-zero on Linux"
+      ],
+      "context": "fix-impl-3 toggled tokio features in services/bridge/Cargo.toml (time in [dependencies], test-util in [dev-dependencies]). Bridge compiles on Linux ONLY per feedback_bridge_validates_on_linux_not_windows.md. Laptop advisor must run cargo-linux.sh to confirm no Linux-only errors.",
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl3-tokio-time-feature-gate-see-claude-prps-briefs-m3-core-stage-mode-fix-i-715",
+      "phase_task": "m3-core-stage-mode fix-impl-3 (task 4 lineage)",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "answer": "doc-overindent fixed per advisor §G4 allowlist 2026-06-19",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-06-19T01:40:35Z",
+      "result": "pass",
+      "log_slice": null,
+      "failed_commands": null,
+      "approved_by": null,
+      "approved_at": null
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,6 +83,34 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
+    },
+    {
+      "id": "d6dcd385fffa-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run Linux clippy+check+test for fix-impl-2 stage.rs context() change — pass or fail?",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "fix-impl-2: replaced .unwrap_or_default() with .context(...)? in Stage::load (stage.rs:61); bridge compiles Linux-only; cargo-linux.sh is the gate.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl2-stage-load-error-propagate-see-claude-prps-briefs-m3-core-stage-mode-fi-712",
+      "phase_task": "fix-impl-2",
+      "workflow_run_id": 0,
+      "result": null,
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,33 +83,6 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
-    },
-    {
-      "from": "impl",
-      "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T10:00:00Z",
-      "question": "Run bridge cargo-linux check+clippy+test for fix-impl-5 task5-deadcode-allow (#[allow(dead_code)] on 3 scaffold items)",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "fix-impl-5 adds #[allow(dead_code)] to RoomEventRequest, post_room_event (room_event_client.rs) and brehon_room_event_url (config.rs). Resolves the 3 clippy dead_code errors that blocked Task 5 validate-pending 7677417db9fb-001. Bridge compiles Linux only. Laptop advisor must validate via cargo-linux.sh.",
-      "commands": [
-        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
-        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"
-      ],
-      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl5-task5-deadcode-allow-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-718",
-      "phase_task": "5-fix",
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null,
-      "result": null,
-      "log_slice": null,
-      "failed_commands": null,
-      "id": "33017c985c6a-001"
     }
   ],
   "resolved": [
@@ -8028,6 +8001,33 @@
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ],
       "id": "7677417db9fb-001"
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T10:00:00Z",
+      "question": "Run bridge cargo-linux check+clippy+test for fix-impl-5 task5-deadcode-allow (#[allow(dead_code)] on 3 scaffold items)",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "fix-impl-5 adds #[allow(dead_code)] to RoomEventRequest, post_room_event (room_event_client.rs) and brehon_room_event_url (config.rs). Resolves the 3 clippy dead_code errors that blocked Task 5 validate-pending 7677417db9fb-001. Bridge compiles Linux only. Laptop advisor must validate via cargo-linux.sh.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl5-task5-deadcode-allow-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-718",
+      "phase_task": "5-fix",
+      "answer": "cargo-linux PASS: check rc=0, clippy -D warnings rc=0 (3 dead_code allows present), test room_event_client 2 passed, test stage 10 passed (incl fifo_mic_pass_in_sequence + grace_no_activate boundary + 2 emit-intent tests). validate-718 worktree @ f8df98092.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T03:17:26.692592Z",
+      "approved_by": null,
+      "approved_at": null,
+      "result": "pass",
+      "log_slice": null,
+      "failed_commands": null,
+      "id": "33017c985c6a-001"
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,6 +83,33 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
+    },
+    {
+      "id": "8c61e18ffcea-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Does services/bridge compile + clippy-clean + stage tests pass on Linux after the cr-4 single-presenter revoke fix?",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "fix(rtc) commit 0258fef07 adds revoke-before-grant in promote_next and chair_override(ForcePromote) in services/bridge/src/stage.rs. Bridge only compiles on Linux (ruma-common E0119 on Windows). Laptop advisor runs cargo-linux.sh to validate.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl-cr4-single-presenter-revoke-see-claude-prps-briefs-m3-core-stage-mode-fi-722",
+      "phase_task": "fix-impl-cr4",
+      "result": null,
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null
     }
   ],
   "resolved": [

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,33 +83,6 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
-    },
-    {
-      "from": "impl",
-      "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T01:40:35Z",
-      "question": "Does the bridge crate compile + pass clippy cleanly on Linux (Docker rust:1.95) after fixing the doc_overindented_list_items lint in stage.rs run_grace doc block?",
-      "options": [
-        "pass: cargo check + clippy + test all succeed on Linux",
-        "fail: at least one command exits non-zero on Linux"
-      ],
-      "context": "fix-impl-4 re-indented the run_grace doc list (stage.rs ~159-162) to satisfy clippy::doc-overindented-list-items. This is the only remaining blocker from the fix-impl-3 validate-pending-laptop-linux (DQ 13fd7f8da89b-001). No code changes. Laptop advisor must run cargo-linux.sh to confirm clippy now passes.",
-      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl4-stage-doc-overindent-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-716",
-      "phase_task": "m3-core-stage-mode fix-impl-4 (task 4 lineage)",
-      "commands": [
-        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
-        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
-      ],
-      "result": null,
-      "log_slice": null,
-      "failed_commands": null,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null,
-      "id": "e5510f969130-001"
     }
   ],
   "resolved": [
@@ -7972,6 +7945,33 @@
       "failed_commands": null,
       "approved_by": null,
       "approved_at": null
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T01:40:35Z",
+      "question": "Does the bridge crate compile + pass clippy cleanly on Linux (Docker rust:1.95) after fixing the doc_overindented_list_items lint in stage.rs run_grace doc block?",
+      "options": [
+        "pass: cargo check + clippy + test all succeed on Linux",
+        "fail: at least one command exits non-zero on Linux"
+      ],
+      "context": "fix-impl-4 re-indented the run_grace doc list (stage.rs ~159-162) to satisfy clippy::doc-overindented-list-items. This is the only remaining blocker from the fix-impl-3 validate-pending-laptop-linux (DQ 13fd7f8da89b-001). No code changes. Laptop advisor must run cargo-linux.sh to confirm clippy now passes.",
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl4-stage-doc-overindent-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-716",
+      "phase_task": "m3-core-stage-mode fix-impl-4 (task 4 lineage)",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "result": "pass",
+      "log_slice": null,
+      "failed_commands": null,
+      "answer": "cargo-linux PASS: check ok, clippy -D warnings ok (doc-overindent fixed), test stage 8 passed 0 failed (incl fifo_mic_pass_in_sequence + grace_no_activate_auto_revokes_and_promotes_next).",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T01:55:58.379494Z",
+      "approved_by": null,
+      "approved_at": null,
+      "id": "e5510f969130-001"
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,6 +1,34 @@
 {
   "schema_version": 3,
-  "pending": [],
+  "pending": [
+    {
+      "id": "3a93f5eebf23-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop",
+      "timestamp": "2026-06-18T00:00:00Z",
+      "question": "Validate Task 1 cargo check + clippy on laptop",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 1 (RoomEventPayload chair fields + CaseTransitionEvent.chair_pseudonym) committed. 3 files changed: governance_log.rs (5 optional fields + serde roundtrip test), api_common/governance.rs (chair_pseudonym on CaseTransitionEvent), bridge_notify.rs (chair_pseudonym: None in constructor). No cargo run on daemon per brief §4.",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "commands": [
+        "cmd //c \"scripts\\\\brehon\\\\cargo-check.bat --workspace --features full\"",
+        "cmd //c \"scripts\\\\brehon\\\\cargo-clippy.bat --workspace --features full --no-deps -- -D warnings\""
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task1-roomeventpayload-chair-fields-see-claude-prps-briefs-m3-core-stage-mode-imp-708",
+      "phase_task": "m3-core-stage-mode task 1",
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "e2e_filter": null
+    }
+  ],
   "resolved": [
     {
       "id": "8533df2ad37d-001",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -85,6 +85,35 @@
       ]
     },
     {
+      "id": "13fd7f8da89b-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T01:10:58Z",
+      "question": "Does the bridge crate compile cleanly on Linux (Docker rust:1.95) after adding tokio `time` to [dependencies] and `test-util` to [dev-dependencies]?",
+      "options": [
+        "pass: cargo check + clippy + test all succeed on Linux",
+        "fail: at least one command exits non-zero on Linux"
+      ],
+      "context": "fix-impl-3 toggled tokio features in services/bridge/Cargo.toml (time in [dependencies], test-util in [dev-dependencies]). Bridge compiles on Linux ONLY per feedback_bridge_validates_on_linux_not_windows.md. Laptop advisor must run cargo-linux.sh to confirm no Linux-only errors.",
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl3-tokio-time-feature-gate-see-claude-prps-briefs-m3-core-stage-mode-fix-i-715",
+      "phase_task": "m3-core-stage-mode fix-impl-3 (task 4 lineage)",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null,
+      "approved_by": null,
+      "approved_at": null
+    }
+  ],
+  "resolved": [
+    {
       "id": "6302ef3b3382-001",
       "from": "impl",
       "kind": "blocker",
@@ -95,14 +124,12 @@
         "option-b: add `time` and `test-util` to the single [dependencies] tokio entry (simpler; test-util in prod is harmless — only activates when tokio::time::pause() is called)"
       ],
       "context": "Task 4 stage.rs implementation is committed (53b8c5612). It uses tokio::time::sleep (requires `time` feature) in run_grace and #[tokio::test(start_paused = true)] (requires `test-util` feature) in the two new grace tests. Current bridge Cargo.toml has tokio = { version = \"1\", features = [\"rt-multi-thread\", \"macros\"] } — both `time` and `test-util` are missing. The brief prohibits touching Cargo.toml without advisor scope approval; it explicitly says to raise a kind:blocker DQ when these features are absent.",
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
+      "answer": "option-a per advisor 2026-06-19: `time` added to [dependencies], `test-util` added to a new [dev-dependencies] section; test-only, prod binary unaffected.",
+      "answered_by": "advisor",
+      "resolved_at": "2026-06-19T01:10:58Z",
       "approved_by": null,
       "approved_at": null
-    }
-  ],
-  "resolved": [
+    },
     {
       "id": "8533df2ad37d-001",
       "from": "impl",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,33 +83,6 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
-    },
-    {
-      "id": "8c61e18ffcea-001",
-      "from": "impl",
-      "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T00:00:00Z",
-      "question": "Does services/bridge compile + clippy-clean + stage tests pass on Linux after the cr-4 single-presenter revoke fix?",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "fix(rtc) commit 0258fef07 adds revoke-before-grant in promote_next and chair_override(ForcePromote) in services/bridge/src/stage.rs. Bridge only compiles on Linux (ruma-common E0119 on Windows). Laptop advisor runs cargo-linux.sh to validate.",
-      "commands": [
-        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
-        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
-      ],
-      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl-cr4-single-presenter-revoke-see-claude-prps-briefs-m3-core-stage-mode-fi-722",
-      "phase_task": "fix-impl-cr4",
-      "result": null,
-      "log_slice": null,
-      "failed_jobs": null,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null
     }
   ],
   "resolved": [
@@ -8082,6 +8055,34 @@
       "id": "bc10e175f0da-001",
       "result": "pass",
       "log_slice": null,
+      "failed_commands": null
+    },
+    {
+      "id": "8c61e18ffcea-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Does services/bridge compile + clippy-clean + stage tests pass on Linux after the cr-4 single-presenter revoke fix?",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "fix(rtc) commit 0258fef07 adds revoke-before-grant in promote_next and chair_override(ForcePromote) in services/bridge/src/stage.rs. Bridge only compiles on Linux (ruma-common E0119 on Windows). Laptop advisor runs cargo-linux.sh to validate.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl-cr4-single-presenter-revoke-see-claude-prps-briefs-m3-core-stage-mode-fi-722",
+      "phase_task": "fix-impl-cr4",
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": "Bridge Linux gate PASS @ worker tip 485d0c8d2 (brehon-fork-validate-722): cargo-linux check rc=0, clippy --no-deps -D warnings rc=0 (0 warnings), test stage 10 passed 0 failed (incl fifo_mic_pass_in_sequence marquee now asserting RevokePublish-before-GrantPublish on all 3 handoffs + grace boundary tests + 2 emit-intent tests). cr-4 single-presenter revoke-before-grant fix validated.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T09:35:24.659370Z",
+      "approved_by": null,
+      "approved_at": null,
       "failed_commands": null
     }
   ]

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -1,6 +1,34 @@
 {
   "schema_version": 3,
-  "pending": [],
+  "pending": [
+    {
+      "id": "8f77bcfc296e-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-18T21:36:55Z",
+      "question": "Run bridge cargo-linux check+clippy+test for task 2 can_publish change",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 2 (m3-core-stage-mode) modifies services/bridge/src/livekit_jwt.rs. Bridge compiles on Linux only (ruma-common E0119 on Windows). Laptop advisor must run cargo-linux.sh to validate.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml livekit_jwt"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task2-livekit-can-publish-see-claude-prps-briefs-m3-core-stage-mode-impl-2-md-709",
+      "phase_task": "2",
+      "answer": null,
+      "answered_by": null,
+      "resolved_at": null,
+      "approved_by": null,
+      "approved_at": null,
+      "result": null,
+      "log_slice": null,
+      "failed_commands": null
+    }
+  ],
   "resolved": [
     {
       "id": "8533df2ad37d-001",

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -83,34 +83,6 @@
       "failed_commands": [
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
       ]
-    },
-    {
-      "id": "d6dcd385fffa-001",
-      "from": "impl",
-      "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T00:00:00Z",
-      "question": "Run Linux clippy+check+test for fix-impl-2 stage.rs context() change — pass or fail?",
-      "options": [
-        "pass",
-        "fail"
-      ],
-      "context": "fix-impl-2: replaced .unwrap_or_default() with .context(...)? in Stage::load (stage.rs:61); bridge compiles Linux-only; cargo-linux.sh is the gate.",
-      "commands": [
-        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
-        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
-        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
-      ],
-      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl2-stage-load-error-propagate-see-claude-prps-briefs-m3-core-stage-mode-fi-712",
-      "phase_task": "fix-impl-2",
-      "workflow_run_id": 0,
-      "result": null,
-      "log_slice": null,
-      "failed_jobs": null,
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "approved_by": null,
-      "approved_at": null
     }
   ],
   "resolved": [
@@ -7900,6 +7872,35 @@
       "answered_by": "advisor",
       "resolved_at": "2026-06-18T20:48:21Z",
       "id": "a3d0e9941441-068"
+    },
+    {
+      "id": "d6dcd385fffa-001",
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run Linux clippy+check+test for fix-impl-2 stage.rs context() change — pass or fail?",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "fix-impl-2: replaced .unwrap_or_default() with .context(...)? in Stage::load (stage.rs:61); bridge compiles Linux-only; cargo-linux.sh is the gate.",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml stage"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl2-stage-load-error-propagate-see-claude-prps-briefs-m3-core-stage-mode-fi-712",
+      "phase_task": "fix-impl-2",
+      "workflow_run_id": 0,
+      "result": "pass",
+      "log_slice": null,
+      "failed_jobs": null,
+      "answer": "PASS. cargo-linux.sh check + clippy -D warnings + test stage all exit 0 (Docker rust:1.95). unwrap_or_default fix took (Stage::load now .context(corrupt bridge_room.queue_state)? propagates parse error). 6 stage tests pass incl marquee fifo_mic_pass_in_sequence (4-mic-pass) + chair_override_reorder + 2 guarded-error + no-dup + load-roundtrip.",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T00:34:27.667290+00:00",
+      "approved_by": null,
+      "approved_at": null,
+      "failed_commands": null
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -87,20 +87,20 @@
     {
       "from": "impl",
       "kind": "validate-pending-laptop-linux",
-      "timestamp": "2026-06-19T00:00:00Z",
-      "question": "Run bridge cargo-linux check+clippy+test for task 5 room_event_client + stage emitters",
+      "timestamp": "2026-06-19T10:00:00Z",
+      "question": "Run bridge cargo-linux check+clippy+test for fix-impl-5 task5-deadcode-allow (#[allow(dead_code)] on 3 scaffold items)",
       "options": [
         "pass",
         "fail"
       ],
-      "context": "Task 5 (m3-core-stage-mode) adds services/bridge/src/room_event_client.rs (NEW) and modifies config.rs, main.rs, stage.rs. Bridge compiles on Linux only (ruma-common E0119 on Windows). Laptop advisor must run cargo-linux.sh to validate. DoD: rg -i 'person_id|username|@.*:' room_event_client.rs = 0 hits (PASS); rg 'api/v4/governance/room-event' config.rs = match (PASS).",
+      "context": "fix-impl-5 adds #[allow(dead_code)] to RoomEventRequest, post_room_event (room_event_client.rs) and brehon_room_event_url (config.rs). Resolves the 3 clippy dead_code errors that blocked Task 5 validate-pending 7677417db9fb-001. Bridge compiles Linux only. Laptop advisor must validate via cargo-linux.sh.",
       "commands": [
         "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
         "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
         "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"
       ],
-      "branch": "junior/role-impl-task-m3-core-stage-mode-task5-room-event-client-emitters-see-claude-prps-briefs-m3-core-stage-mode-impl-5-717",
-      "phase_task": "5",
+      "branch": "junior/role-impl-task-m3-core-stage-mode-fix-impl5-task5-deadcode-allow-see-claude-prps-briefs-m3-core-stage-mode-fix-impl-718",
+      "phase_task": "5-fix",
       "answer": null,
       "answered_by": null,
       "resolved_at": null,
@@ -109,7 +109,7 @@
       "result": null,
       "log_slice": null,
       "failed_commands": null,
-      "id": "7677417db9fb-001"
+      "id": "33017c985c6a-001"
     }
   ],
   "resolved": [
@@ -7999,6 +7999,35 @@
       "approved_by": null,
       "approved_at": null,
       "id": "e5510f969130-001"
+    },
+    {
+      "from": "impl",
+      "kind": "validate-pending-laptop-linux",
+      "timestamp": "2026-06-19T00:00:00Z",
+      "question": "Run bridge cargo-linux check+clippy+test for task 5 room_event_client + stage emitters",
+      "options": [
+        "pass",
+        "fail"
+      ],
+      "context": "Task 5 (m3-core-stage-mode) adds services/bridge/src/room_event_client.rs (NEW) and modifies config.rs, main.rs, stage.rs. Bridge compiles on Linux only (ruma-common E0119 on Windows). Laptop advisor must run cargo-linux.sh to validate. DoD: rg -i 'person_id|username|@.*:' room_event_client.rs = 0 hits (PASS); rg 'api/v4/governance/room-event' config.rs = match (PASS).",
+      "commands": [
+        "scripts/brehon/cargo-linux.sh check --manifest-path services/bridge/Cargo.toml",
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings",
+        "scripts/brehon/cargo-linux.sh test --manifest-path services/bridge/Cargo.toml room_event_client"
+      ],
+      "branch": "junior/role-impl-task-m3-core-stage-mode-task5-room-event-client-emitters-see-claude-prps-briefs-m3-core-stage-mode-impl-5-717",
+      "phase_task": "5",
+      "answer": "dead_code allowed per user decision 2026-06-19 — scaffold-ahead-of-caller; Task 6 controller drain removes the allows",
+      "answered_by": "impl-self-resolved",
+      "resolved_at": "2026-06-19T10:00:00Z",
+      "approved_by": null,
+      "approved_at": null,
+      "result": "fail",
+      "log_slice": "error: field brehon_room_event_url is never read\nerror: struct RoomEventRequest is never constructed\nerror: function post_room_event is never used\n[FIXED by fix-impl-5 task5-deadcode-allow]",
+      "failed_commands": [
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
+      ],
+      "id": "7677417db9fb-001"
     }
   ]
 }

--- a/.claude/decision-queue.json
+++ b/.claude/decision-queue.json
@@ -73,13 +73,16 @@
       ],
       "branch": "junior/role-impl-task-m3-core-stage-mode-task3-stage-fifo-mic-pass-see-claude-prps-briefs-m3-core-stage-mode-impl-3-md-711",
       "phase_task": "task3",
-      "answer": null,
-      "answered_by": null,
-      "resolved_at": null,
-      "result": null,
-      "log_slice": null,
+      "answer": "FAIL on clippy: 1 error, unwrap_or_default disallowed at stage.rs:61 (Stage::load malformed-queue_state silent swallow). check PASS, test pending. NON-allowlist (unwrap_or_default not in §G4 allowlist) — advisor catch-fire to user. Cycle 1 for (unwrap_or_default, stage.rs).",
+      "answered_by": "advisor-laptop",
+      "resolved_at": "2026-06-19T00:06:00.611787+00:00",
+      "result": "fail",
+      "log_slice": "error: use of a disallowed method core::result::Result::unwrap_or_default --> src/stage.rs:61:18 (Stage::load: serde_json::from_str::<Vec<String>>(&json).map(...).unwrap_or_default() silently swallows a malformed persisted queue_state). error: could not compile brehon-bridge due to 1 previous error.",
       "approved_by": null,
-      "approved_at": null
+      "approved_at": null,
+      "failed_commands": [
+        "scripts/brehon/cargo-linux.sh clippy --manifest-path services/bridge/Cargo.toml --no-deps -- -D warnings"
+      ]
     }
   ],
   "resolved": [

--- a/.claude/runlog/m3-core-stage-mode-runlog.md
+++ b/.claude/runlog/m3-core-stage-mode-runlog.md
@@ -1,0 +1,10 @@
+# m3-core-stage-mode runlog
+
+## bm: cut phase-m3-core-stage-mode off governance-v0 @ c588c988 — 2026-06-18T22:28:15+0100
+
+- **branch:** phase-m3-core-stage-mode
+- **off:** governance-v0 @ c588c9882
+- **plan:** .claude/PRPs/plans/m3-core-stage-mode.plan.md
+- **pushed:** yes — origin/phase-m3-core-stage-mode (upstream tracking set via -u)
+- **verified:** gh api branch endpoint confirmed (c588c988)
+- **next:** advisor authors impl-task briefs; worker forks from phase-m3-core-stage-mode

--- a/.claude/runlog/m3-core-stage-mode-runlog.md
+++ b/.claude/runlog/m3-core-stage-mode-runlog.md
@@ -8,3 +8,10 @@
 - **pushed:** yes — origin/phase-m3-core-stage-mode (upstream tracking set via -u)
 - **verified:** gh api branch endpoint confirmed (c588c988)
 - **next:** advisor authors impl-task briefs; worker forks from phase-m3-core-stage-mode
+
+## bm: PR opened — 2026-06-19T12:00:00Z
+- **PR:** #202 — feat(rtc,bridge): M3 town-hall stage mode — chair-controlled mic-passing, FIFO raised-hand queue, 30s grace auto-revoke, chair transfer/override, FIRST room_chair_* chain emission
+- **URL:** https://github.com/barrie-cork/lemmy/pull/202
+- **Base ← Head:** governance-v0 ← phase-m3-core-stage-mode
+- **Body source:** plan + commits + validation
+- **Next:** wait ~5–10 min for CodeRabbit; then `/bm-poll-cr 202`

--- a/.claude/runlog/m3-core-stage-mode-runlog.md
+++ b/.claude/runlog/m3-core-stage-mode-runlog.md
@@ -1,12 +1,12 @@
 # m3-core-stage-mode runlog
 
-## bm: cut phase-m3-core-stage-mode off governance-v0 @ c588c988 — 2026-06-18T22:28:15+0100
+## bm: cut phase-m3-core-stage-mode off governance-v0 @ c588c9882 — 2026-06-18T22:28:15+0100
 
 - **branch:** phase-m3-core-stage-mode
 - **off:** governance-v0 @ c588c9882
 - **plan:** .claude/PRPs/plans/m3-core-stage-mode.plan.md
 - **pushed:** yes — origin/phase-m3-core-stage-mode (upstream tracking set via -u)
-- **verified:** gh api branch endpoint confirmed (c588c988)
+- **verified:** gh api branch endpoint confirmed (c588c9882)
 - **next:** advisor authors impl-task briefs; worker forks from phase-m3-core-stage-mode
 
 ## bm: PR opened — 2026-06-19T12:00:00Z

--- a/crates/api/api/src/governance/governance_log.rs
+++ b/crates/api/api/src/governance/governance_log.rs
@@ -94,6 +94,67 @@ pub struct RoomEventPayload {
   pub matrix_room_id: Option<String>,
   pub lifecycle_stage: String,
   pub member_count: Option<i32>,
+  // M3 stage-mode chair-action metadata (opt; only chair entries set them).
+  // ADR-015: pseudonyms only — never person_id/username/MXID.
+  // ADR-016: metadata only — never room content.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub action: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub target_pseudonym: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub from_pseudonym: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub to_pseudonym: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::RoomEventPayload;
+
+  #[test]
+  fn room_event_payload_chair_fields_skip_serializing_if_none() -> Result<(), serde_json::Error> {
+    // room_chair_override: action + target_pseudonym present; transfer fields omitted
+    let override_payload = RoomEventPayload {
+      case_id: 1,
+      matrix_room_id: None,
+      lifecycle_stage: "room_chair_override".to_string(),
+      member_count: None,
+      action: Some("force_demote".to_string()),
+      target_pseudonym: Some("pseu_x".to_string()),
+      from_pseudonym: None,
+      to_pseudonym: None,
+      at: None,
+    };
+    let v = serde_json::to_value(&override_payload)?;
+    assert!(v.get("action").is_some());
+    assert!(v.get("target_pseudonym").is_some());
+    assert!(v.get("from_pseudonym").is_none());
+    assert!(v.get("to_pseudonym").is_none());
+    assert!(v.get("at").is_none());
+
+    // room_chair_transferred: transfer fields present; action + target_pseudonym omitted
+    let transfer_payload = RoomEventPayload {
+      case_id: 2,
+      matrix_room_id: None,
+      lifecycle_stage: "room_chair_transferred".to_string(),
+      member_count: None,
+      action: None,
+      target_pseudonym: None,
+      from_pseudonym: Some("pseu_a".to_string()),
+      to_pseudonym: Some("pseu_b".to_string()),
+      at: Some("2026-06-18T00:00:00Z".to_string()),
+    };
+    let v = serde_json::to_value(&transfer_payload)?;
+    assert!(v.get("from_pseudonym").is_some());
+    assert!(v.get("to_pseudonym").is_some());
+    assert!(v.get("at").is_some());
+    assert!(v.get("action").is_none());
+    assert!(v.get("target_pseudonym").is_none());
+
+    Ok(())
+  }
 }
 
 /// The 13 allowed `entry_kind` values for [`append_room_event`].

--- a/crates/api/api_common/src/governance.rs
+++ b/crates/api/api_common/src/governance.rs
@@ -899,6 +899,12 @@ pub struct CaseTransitionEvent {
   /// real identity. The bridge renders each as `Juror-<suffix>`.
   #[serde(default)]
   pub juror_pseudonyms: Vec<String>,
+  /// Pre-resolved pseudonymous initial chair for a town-hall event (OQ-V2-05).
+  /// `None` for non-town-hall transitions. Populated binary-side by the Phase-6
+  /// governance trigger; Phase-3 bridge falls back to juror_pseudonyms[0]
+  /// (foreperson) for jury-adjacent town halls. ADR-015: pseudonym ONLY.
+  #[serde(default)]
+  pub chair_pseudonym: Option<String>,
 }
 
 /// Discriminated union of bridge-notify events. `type_` tag distinguishes

--- a/crates/api/api_utils/src/bridge_notify.rs
+++ b/crates/api/api_utils/src/bridge_notify.rs
@@ -140,6 +140,7 @@ pub async fn governance_case_after_transition(
     community_id: case.community_id.map(|c| c.0),
     target_type: case.target_type,
     juror_pseudonyms,
+    chair_pseudonym: None,
   });
   if let Err(e) = context
     .client()

--- a/services/bridge/Cargo.toml
+++ b/services/bridge/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 matrix-sdk = "0.18"
 ruma-appservice-api = "0.16"
 axum = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,3 +29,6 @@ time = "=0.3.47"
 ed25519-dalek = "2"
 hex = "0.4"
 jsonwebtoken = "9"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }

--- a/services/bridge/src/bridge_room.rs
+++ b/services/bridge/src/bridge_room.rs
@@ -99,6 +99,74 @@ pub fn set_watermark(conn: &Connection, case_id: i64, row_id: i64) -> Result<()>
     Ok(())
 }
 
+/// Persist the FIFO raised-hand queue (serialised as JSON text) to bridge_room.queue_state.
+/// Uses UPSERT so the caller need not pre-insert a row.
+pub fn write_queue_state(
+    conn: &Connection,
+    case_id: i64,
+    room_type: &str,
+    queue_json: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO bridge_room (case_id, room_type, queue_state)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(case_id, room_type) DO UPDATE SET queue_state = excluded.queue_state",
+        params![case_id, room_type, queue_json],
+    )?;
+    Ok(())
+}
+
+/// Read back the persisted FIFO queue JSON. Returns None when no row or queue_state is NULL.
+pub fn read_queue_state(
+    conn: &Connection,
+    case_id: i64,
+    room_type: &str,
+) -> Result<Option<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT queue_state FROM bridge_room WHERE case_id = ?1 AND room_type = ?2",
+    )?;
+    let mut rows = stmt.query(params![case_id, room_type])?;
+    if let Some(row) = rows.next()? {
+        Ok(row.get(0)?)
+    } else {
+        Ok(None)
+    }
+}
+
+/// Persist the current chair pseudonym to bridge_room.chair_id.
+/// Uses UPSERT so the caller need not pre-insert a row.
+pub fn write_chair_id(
+    conn: &Connection,
+    case_id: i64,
+    room_type: &str,
+    chair_pseudonym: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO bridge_room (case_id, room_type, chair_id)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(case_id, room_type) DO UPDATE SET chair_id = excluded.chair_id",
+        params![case_id, room_type, chair_pseudonym],
+    )?;
+    Ok(())
+}
+
+/// Read back the persisted chair pseudonym. Returns None when no row or chair_id is NULL.
+pub fn read_chair_id(
+    conn: &Connection,
+    case_id: i64,
+    room_type: &str,
+) -> Result<Option<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT chair_id FROM bridge_room WHERE case_id = ?1 AND room_type = ?2",
+    )?;
+    let mut rows = stmt.query(params![case_id, room_type])?;
+    if let Some(row) = rows.next()? {
+        Ok(row.get(0)?)
+    } else {
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,6 +188,23 @@ mod tests {
         assert!(cols.contains(&"chair_id".to_string()), "missing chair_id");
         assert!(cols.contains(&"queue_state".to_string()), "missing queue_state");
         assert!(cols.contains(&"recording_config".to_string()), "missing recording_config");
+    }
+
+    #[test]
+    fn queue_state_roundtrip() {
+        let conn = open(":memory:").expect("open db");
+        let json = r#"["alice-pseudo","bob-pseudo"]"#;
+        write_queue_state(&conn, 99, "governance", json).expect("write queue");
+        let back = read_queue_state(&conn, 99, "governance").expect("read queue");
+        assert_eq!(back.as_deref(), Some(json), "queue_state must round-trip");
+    }
+
+    #[test]
+    fn chair_id_roundtrip() {
+        let conn = open(":memory:").expect("open db");
+        write_chair_id(&conn, 99, "governance", "chair-pseudo-xyz").expect("write chair");
+        let back = read_chair_id(&conn, 99, "governance").expect("read chair");
+        assert_eq!(back.as_deref(), Some("chair-pseudo-xyz"), "chair_id must round-trip");
     }
 
     #[test]

--- a/services/bridge/src/config.rs
+++ b/services/bridge/src/config.rs
@@ -34,7 +34,6 @@ pub struct BridgeConfig {
     pub brehon_notify_url: String,
     /// URL for POST /api/v4/governance/room-event (binary callback). Read from
     /// BREHON_ROOM_EVENT_URL; consumed by the room-event emitters (Task 6 controller drain).
-    #[allow(dead_code)] // Task 6: removed when the controller reads this to call post_room_event.
     pub brehon_room_event_url: String,
     /// Bearer secret for bridge<->binary auth (BRIDGE_CALLBACK_SECRET).
     pub bridge_callback_secret: String,

--- a/services/bridge/src/config.rs
+++ b/services/bridge/src/config.rs
@@ -53,10 +53,13 @@ pub struct BridgeConfig {
     /// URL to POST LinkConfirmRequest to (e.g. "http://localhost:8536/api/v4/governance/link/confirm").
     pub brehon_link_confirm_url: String,
     /// Optional LiveKit server URL (e.g. "wss://livekit.example.com"). Required only when RTC is enabled.
+    #[allow(dead_code)]
     pub livekit_url: Option<String>,
     /// Optional LiveKit API key. Required only when RTC is enabled.
+    #[allow(dead_code)]
     pub livekit_api_key: Option<String>,
     /// Optional LiveKit API secret. Required only when RTC is enabled.
+    #[allow(dead_code)]
     pub livekit_api_secret: Option<String>,
 }
 

--- a/services/bridge/src/config.rs
+++ b/services/bridge/src/config.rs
@@ -33,7 +33,8 @@ pub struct BridgeConfig {
     /// (the URL the bridge POSTs inbound Matrix DMs to).
     pub brehon_notify_url: String,
     /// URL for POST /api/v4/governance/room-event (binary callback). Read from
-    /// BREHON_ROOM_EVENT_URL; consumed by the room-event emitters (Task 5+).
+    /// BREHON_ROOM_EVENT_URL; consumed by the room-event emitters (Task 6 controller drain).
+    #[allow(dead_code)] // Task 6: removed when the controller reads this to call post_room_event.
     pub brehon_room_event_url: String,
     /// Bearer secret for bridge<->binary auth (BRIDGE_CALLBACK_SECRET).
     pub bridge_callback_secret: String,

--- a/services/bridge/src/config.rs
+++ b/services/bridge/src/config.rs
@@ -32,11 +32,8 @@ pub struct BridgeConfig {
     /// HTTP endpoint for Brehon Matrix-to-Brehon relay callbacks
     /// (the URL the bridge POSTs inbound Matrix DMs to).
     pub brehon_notify_url: String,
-    /// URL for POST /governance/room-event (binary callback). Read from
-    /// BREHON_ROOM_EVENT_URL but not yet consumed — the bridge currently
-    /// receives room-events rather than POSTing them. Retained as config
-    /// surface for a future bridge→binary room-event callback.
-    #[allow(dead_code)]
+    /// URL for POST /api/v4/governance/room-event (binary callback). Read from
+    /// BREHON_ROOM_EVENT_URL; consumed by the room-event emitters (Task 5+).
     pub brehon_room_event_url: String,
     /// Bearer secret for bridge<->binary auth (BRIDGE_CALLBACK_SECRET).
     pub bridge_callback_secret: String,
@@ -81,7 +78,7 @@ impl BridgeConfig {
             brehon_notify_url: env::var("BREHON_NOTIFY_URL")
                 .context("BREHON_NOTIFY_URL env var required")?,
             brehon_room_event_url: std::env::var("BREHON_ROOM_EVENT_URL")
-                .unwrap_or_else(|_| "http://localhost:8536/governance/room-event".to_string()),
+                .unwrap_or_else(|_| "http://localhost:8536/api/v4/governance/room-event".to_string()),
             bridge_callback_secret: std::env::var("BRIDGE_CALLBACK_SECRET")
                 .expect("BRIDGE_CALLBACK_SECRET must be set"),
             legal_contact_mxid: std::env::var("LEGAL_CONTACT_MXID")

--- a/services/bridge/src/livekit_jwt.rs
+++ b/services/bridge/src/livekit_jwt.rs
@@ -7,6 +7,8 @@ struct VideoGrant {
     room: String,
     #[serde(rename = "roomJoin")]
     room_join: bool,
+    #[serde(rename = "canPublish")]
+    can_publish: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -28,6 +30,7 @@ pub fn mint_access_token(
     room: &str,
     identity: &str,
     ttl_secs: u64,
+    can_publish: bool,
 ) -> Result<String> {
     ensure!(ttl_secs > 0, "ttl_secs must be > 0");
     let now = SystemTime::now()
@@ -42,6 +45,7 @@ pub fn mint_access_token(
         video: VideoGrant {
             room: room.to_string(),
             room_join: true,
+            can_publish,
         },
     };
     let token = encode(
@@ -58,20 +62,35 @@ mod tests {
     use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 
     #[test]
-    fn mint_pseudonym_claims() {
+    fn mint_pseudonym_claims() -> Result<()> {
         let token =
-            mint_access_token("api-key", "secret", "room-1", "pseu_abc123", 3600).unwrap();
+            mint_access_token("api-key", "secret", "room-1", "pseu_abc123", 3600, true)?;
         let td = decode::<Claims>(
             &token,
             &DecodingKey::from_secret(b"secret"),
             &Validation::new(Algorithm::HS256),
-        )
-        .unwrap();
+        )?;
         let claims = td.claims;
         assert_eq!(claims.sub, "pseu_abc123");
         assert_eq!(claims.iss, "api-key");
         assert_eq!(claims.video.room, "room-1");
         assert!(claims.video.room_join);
+        assert!(claims.video.can_publish);
         assert!(claims.exp > claims.nbf);
+        Ok(())
+    }
+
+    #[test]
+    fn mint_watcher_token_no_publish() -> Result<()> {
+        let token =
+            mint_access_token("api-key", "secret", "room-1", "pseu_watcher456", 3600, false)?;
+        let td = decode::<Claims>(
+            &token,
+            &DecodingKey::from_secret(b"secret"),
+            &Validation::new(Algorithm::HS256),
+        )?;
+        let claims = td.claims;
+        assert!(!claims.video.can_publish);
+        Ok(())
     }
 }

--- a/services/bridge/src/livekit_jwt.rs
+++ b/services/bridge/src/livekit_jwt.rs
@@ -2,6 +2,8 @@ use anyhow::{ensure, Context, Result};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+// wired by stage.rs (Task 3)
+#[allow(dead_code)]
 #[derive(serde::Serialize, serde::Deserialize)]
 struct VideoGrant {
     room: String,
@@ -11,6 +13,7 @@ struct VideoGrant {
     can_publish: bool,
 }
 
+#[allow(dead_code)]
 #[derive(serde::Serialize, serde::Deserialize)]
 struct Claims {
     iss: String,
@@ -24,6 +27,7 @@ struct Claims {
 ///
 /// `identity` is the opaque pseudonym string (ADR-015); the caller must supply
 /// a pre-derived pseudonym. This function assigns it verbatim to the JWT `sub`.
+#[allow(dead_code)]
 pub fn mint_access_token(
     api_key: &str,
     api_secret: &str,

--- a/services/bridge/src/main.rs
+++ b/services/bridge/src/main.rs
@@ -20,6 +20,7 @@ mod puppet;
 mod relay;
 mod room_provisioner;
 mod sanction_handler;
+mod stage;
 mod soft_pause;
 
 use anyhow::Result;

--- a/services/bridge/src/main.rs
+++ b/services/bridge/src/main.rs
@@ -18,6 +18,7 @@ mod livekit_jwt;
 mod provision;
 mod puppet;
 mod relay;
+mod room_event_client;
 mod room_provisioner;
 mod sanction_handler;
 mod stage;

--- a/services/bridge/src/room_event_client.rs
+++ b/services/bridge/src/room_event_client.rs
@@ -24,8 +24,6 @@ pub struct RoomEventPayload {
 
 /// Wire shape sent to the binary's room-event handler. Mirrors room_event_handler.rs:19-23.
 #[derive(serde::Serialize)]
-// ponytail: scaffold-ahead-of-caller — Task 6 wires the async controller drain that constructs this.
-#[allow(dead_code)]
 struct RoomEventRequest<'a> {
     entry_kind: &'a str,
     payload: RoomEventPayload,
@@ -35,7 +33,6 @@ struct RoomEventRequest<'a> {
 /// POST to the binary's /api/v4/governance/room-event with Bearer auth.
 /// Propagates transport/status errors via `?`; the CALLER swallows them
 /// (fire-and-forget per bridge_notify.rs:62-72). ADR-016: payload is metadata only.
-#[allow(dead_code)] // Task 6: the async bridge controller drains Stage::pending_emits and calls this.
 pub async fn post_room_event(
     client: &reqwest::Client,
     url: &str,
@@ -53,6 +50,29 @@ pub async fn post_room_event(
         .await?
         .error_for_status()?;
     Ok(())
+}
+
+/// Drain all pending room-event POST intents from `stage.pending_emits`.
+///
+/// Called by the async provisioning controller after any stage-mutating operation.
+/// Fire-and-forget: transport errors are warned and swallowed per bridge_notify.rs:62-72.
+/// At provisioning time `pending_emits` is empty (no live stage-action HTTP endpoint yet —
+/// Phase-6 wires that); the drain loops zero times but makes `post_room_event` reachable
+/// from a non-test production caller, removing the dead_code scaffolding (§2.1).
+pub async fn drain_emits(
+    stage: &mut crate::stage::Stage,
+    client: &reqwest::Client,
+    url: &str,
+    secret: &str,
+) {
+    for intent in stage.pending_emits.drain(..) {
+        if let Err(e) =
+            post_room_event(client, url, secret, intent.entry_kind, intent.payload, intent.actor_pseudonym)
+                .await
+        {
+            tracing::warn!("room-event POST failed (non-fatal — best-effort chain entry): {e}");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/services/bridge/src/room_event_client.rs
+++ b/services/bridge/src/room_event_client.rs
@@ -24,6 +24,8 @@ pub struct RoomEventPayload {
 
 /// Wire shape sent to the binary's room-event handler. Mirrors room_event_handler.rs:19-23.
 #[derive(serde::Serialize)]
+// ponytail: scaffold-ahead-of-caller — Task 6 wires the async controller drain that constructs this.
+#[allow(dead_code)]
 struct RoomEventRequest<'a> {
     entry_kind: &'a str,
     payload: RoomEventPayload,
@@ -33,6 +35,7 @@ struct RoomEventRequest<'a> {
 /// POST to the binary's /api/v4/governance/room-event with Bearer auth.
 /// Propagates transport/status errors via `?`; the CALLER swallows them
 /// (fire-and-forget per bridge_notify.rs:62-72). ADR-016: payload is metadata only.
+#[allow(dead_code)] // Task 6: the async bridge controller drains Stage::pending_emits and calls this.
 pub async fn post_room_event(
     client: &reqwest::Client,
     url: &str,

--- a/services/bridge/src/room_event_client.rs
+++ b/services/bridge/src/room_event_client.rs
@@ -1,0 +1,120 @@
+/// Bridge-side Serialize mirror of the binary's room-event payload.
+/// Serializes to the exact JSON shape /api/v4/governance/room-event expects.
+/// ADR-015: all *_pseudonym fields are opaque pseudonym strings, never real identities.
+/// ADR-016: payload carries METADATA only — never Q&A text, speech, or video content.
+#[derive(serde::Serialize)]
+pub struct RoomEventPayload {
+    pub case_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matrix_room_id: Option<String>,
+    pub lifecycle_stage: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_count: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_pseudonym: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_pseudonym: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_pseudonym: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+}
+
+/// Wire shape sent to the binary's room-event handler. Mirrors room_event_handler.rs:19-23.
+#[derive(serde::Serialize)]
+struct RoomEventRequest<'a> {
+    entry_kind: &'a str,
+    payload: RoomEventPayload,
+    actor_pseudonym: Option<String>,
+}
+
+/// POST to the binary's /api/v4/governance/room-event with Bearer auth.
+/// Propagates transport/status errors via `?`; the CALLER swallows them
+/// (fire-and-forget per bridge_notify.rs:62-72). ADR-016: payload is metadata only.
+pub async fn post_room_event(
+    client: &reqwest::Client,
+    url: &str,
+    secret: &str,
+    entry_kind: &str,
+    payload: RoomEventPayload,
+    actor_pseudonym: Option<String>,
+) -> anyhow::Result<()> {
+    let req = RoomEventRequest { entry_kind, payload, actor_pseudonym };
+    client
+        .post(url)
+        .header("Authorization", format!("Bearer {secret}"))
+        .json(&req)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    /// room_chair_override JSON shape: entry_kind, action, target_pseudonym present;
+    /// transfer-only fields (from_pseudonym, to_pseudonym) ABSENT via skip_serializing_if.
+    #[test]
+    fn override_request_json_shape() -> Result<()> {
+        let req = RoomEventRequest {
+            entry_kind: "room_chair_override",
+            payload: RoomEventPayload {
+                case_id: 1,
+                matrix_room_id: None,
+                lifecycle_stage: "governance".to_string(),
+                member_count: None,
+                action: Some("force_demote".to_string()),
+                target_pseudonym: Some("pseudonym-abc".to_string()),
+                from_pseudonym: None,
+                to_pseudonym: None,
+                at: None,
+            },
+            actor_pseudonym: Some("chair-pseudonym".to_string()),
+        };
+        let v = serde_json::to_value(&req)?;
+        assert_eq!(v["entry_kind"], "room_chair_override", "entry_kind must be room_chair_override");
+        assert_eq!(v["payload"]["action"], "force_demote", "action must be present");
+        assert_eq!(v["payload"]["target_pseudonym"], "pseudonym-abc", "target_pseudonym must be present");
+        // skip_serializing_if = "Option::is_none" must omit absent-None fields entirely.
+        assert!(
+            v["payload"].get("from_pseudonym").is_none(),
+            "from_pseudonym must be absent (skip_serializing_if) in override request"
+        );
+        assert!(
+            v["payload"].get("to_pseudonym").is_none(),
+            "to_pseudonym must be absent (skip_serializing_if) in override request"
+        );
+        Ok(())
+    }
+
+    /// room_chair_transferred JSON shape: from_pseudonym, to_pseudonym, at all present.
+    #[test]
+    fn transferred_request_json_shape() -> Result<()> {
+        let req = RoomEventRequest {
+            entry_kind: "room_chair_transferred",
+            payload: RoomEventPayload {
+                case_id: 2,
+                matrix_room_id: None,
+                lifecycle_stage: "governance".to_string(),
+                member_count: None,
+                action: None,
+                target_pseudonym: None,
+                from_pseudonym: Some("pseudonym-from".to_string()),
+                to_pseudonym: Some("pseudonym-to".to_string()),
+                at: Some("2026-01-01T00:00:00Z".to_string()),
+            },
+            actor_pseudonym: Some("pseudonym-from".to_string()),
+        };
+        let v = serde_json::to_value(&req)?;
+        assert_eq!(v["entry_kind"], "room_chair_transferred", "entry_kind must be room_chair_transferred");
+        assert_eq!(v["payload"]["from_pseudonym"], "pseudonym-from", "from_pseudonym must be present");
+        assert_eq!(v["payload"]["to_pseudonym"], "pseudonym-to", "to_pseudonym must be present");
+        assert_eq!(v["payload"]["at"], "2026-01-01T00:00:00Z", "at must be present");
+        Ok(())
+    }
+}

--- a/services/bridge/src/room_provisioner.rs
+++ b/services/bridge/src/room_provisioner.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, atomic::Ordering};
 use anyhow::Context;
 use serde::Deserialize;
 
-use crate::{appservice::AppState, bridge_room, provision};
+use crate::{appservice::AppState, bridge_room, livekit_jwt, provision, room_event_client, stage};
 
 /// Bridge-local mirror of the governance.rs CaseTransitionEvent wire shape.
 /// Unknown fields are silently ignored (serde default).
@@ -30,6 +30,10 @@ pub struct CaseTransitionEvent {
     pub old_status: Option<String>,
     #[serde(default)]
     pub community_id: Option<i32>,
+    /// Chair pseudonym for stage-mode town-hall rooms (Phase-3 bridge read; binary populates Phase-6).
+    /// Falls back to juror_pseudonyms[0] (foreperson) when absent (OQ-V2-05).
+    #[serde(default)]
+    pub chair_pseudonym: Option<String>,
 }
 
 /// Bridge-local discriminated union for POST /brehon/room-event.
@@ -67,6 +71,7 @@ pub async fn handle_transition(state: Arc<AppState>, event: CaseTransitionEvent)
         Some("appealed") => provision_appeal_room(state, event).await,
         Some("in_review") if community_id.is_some() => provision_spinout_room(state, event).await,
         Some("decided") | Some("closed") => provision_membership_mirror(state, event).await,
+        Some("town_hall") => provision_townhall_stage_room(state, event).await,
         _ if community_id.is_some() => provision_community_event_room(state, event).await,
         _ => {
             tracing::debug!(
@@ -178,6 +183,184 @@ async fn provision_jury_room(state: Arc<AppState>, event: CaseTransitionEvent) {
             tracing::error!(err = %e, case_id = event.case_id, "bridge_room::upsert failed");
         }
     }
+}
+
+/// C2.X — Town-hall stage-mode room provisioning.
+///
+/// Triggered on `new_status == "town_hall"`. Provisions the Matrix room — the Q&A
+/// sidebar IS the Matrix room's native text timeline; no new room type, no content
+/// field, no hashing (ADR-016). When RTC is configured (livekit_api_key + secret),
+/// additionally enters stage mode: seats the chair, initialises the raised-hand queue
+/// to `[]`, and mints the chair a presenter token (`can_publish=true`). Watcher tokens
+/// are minted at join-time (no participant list at provisioning time).
+///
+/// After stage setup the provisioner drains `Stage::pending_emits` into the binary's
+/// room-event endpoint. At provisioning time the drain loops zero times (no live
+/// stage-action HTTP caller yet — Phase-6 wires that); the drain makes `post_room_event`
+/// reachable from a non-test production caller, closing the emit-intent seam (§2.1).
+async fn provision_townhall_stage_room(state: Arc<AppState>, event: CaseTransitionEvent) {
+    // (b) idempotency check — skip if townhall room already exists for this case.
+    {
+        let conn = match bridge_room::open(&state.bridge_db_path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(err = %e, case_id = event.case_id, "bridge_room::open failed");
+                return;
+            }
+        };
+        match bridge_room::lookup(&conn, event.case_id as i64, "townhall") {
+            Ok(Some(_)) => {
+                tracing::debug!(case_id = event.case_id, "townhall room already exists — idempotent skip");
+                return;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!(err = %e, case_id = event.case_id, "bridge_room::lookup failed");
+                return;
+            }
+        }
+    }
+
+    // (c) provision the Matrix room. The Q&A sidebar IS the Matrix room's native text
+    // timeline — no new room type, no content field, no hashing (ADR-016).
+    let room_alias = format!("townhall-case-{}", event.case_id);
+    let room_id = match provision::create_community_room(&state.config, &room_alias).await {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!(err = %e, case_id = event.case_id, "create_community_room failed for townhall");
+            return;
+        }
+    };
+
+    // (d) persist the room record.
+    {
+        let conn = match bridge_room::open(&state.bridge_db_path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(err = %e, case_id = event.case_id, "bridge_room::open for upsert failed");
+                return;
+            }
+        };
+        if let Err(e) =
+            bridge_room::upsert(&conn, event.case_id as i64, "townhall", &room_id, "active", None)
+        {
+            tracing::error!(err = %e, case_id = event.case_id, "bridge_room::upsert failed");
+            return;
+        }
+    }
+
+    // (e) stage mode — gated on RTC config (livekit_api_key + livekit_api_secret required).
+    let (api_key, api_secret) = match (
+        state.config.livekit_api_key.as_deref(),
+        state.config.livekit_api_secret.as_deref(),
+    ) {
+        (Some(k), Some(s)) => (k, s),
+        _ => {
+            tracing::debug!(
+                case_id = event.case_id,
+                "RTC not configured — skipping stage-mode setup"
+            );
+            return;
+        }
+    };
+
+    // Seat the chair: event.chair_pseudonym ?? juror_pseudonyms[0] (foreperson fallback, OQ-V2-05).
+    // ADR-015: both sources are opaque pseudonym strings — never a numeric DB identity or Matrix user ID.
+    let chair = match event
+        .chair_pseudonym
+        .as_deref()
+        .or_else(|| event.juror_pseudonyms.first().map(|s| s.as_str()))
+    {
+        Some(c) => c.to_string(),
+        None => {
+            tracing::warn!(
+                case_id = event.case_id,
+                "no chair_pseudonym or foreperson pseudonym — skipping stage-mode seat"
+            );
+            return;
+        }
+    };
+
+    // Persist chair_id and initialise raised-hand FIFO queue to empty.
+    {
+        let conn = match bridge_room::open(&state.bridge_db_path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(err = %e, case_id = event.case_id, "bridge_room::open for chair_id failed");
+                return;
+            }
+        };
+        if let Err(e) = bridge_room::write_chair_id(&conn, event.case_id as i64, "townhall", &chair)
+        {
+            tracing::error!(err = %e, case_id = event.case_id, "write_chair_id failed");
+            return;
+        }
+        if let Err(e) =
+            bridge_room::write_queue_state(&conn, event.case_id as i64, "townhall", "[]")
+        {
+            tracing::error!(err = %e, case_id = event.case_id, "write_queue_state failed");
+            return;
+        }
+    }
+
+    // Mint chair presenter token (can_publish=true). Watcher tokens are deferred to join-time
+    // (no participant list at provisioning time). Phase-6 distributes the chair token.
+    match livekit_jwt::mint_access_token(api_key, api_secret, &room_alias, &chair, 86400, true) {
+        Ok(_token) => {
+            tracing::debug!(
+                case_id = event.case_id,
+                chair = %chair,
+                "chair presenter token minted; watcher tokens minted at join-time"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                err = %e,
+                case_id = event.case_id,
+                "chair presenter token mint failed — non-fatal"
+            );
+        }
+    }
+
+    // Drain pending room-event emits. At provisioning time Stage::pending_emits is empty
+    // (transfer_chair/chair_override have no live HTTP caller yet — Phase-6 wires that).
+    // The drain here makes post_room_event reachable from a non-test caller, closing the
+    // emit-intent seam and allowing the 3 dead_code scaffolding allows to be removed (§2.1).
+    let mut stage = {
+        let conn = match bridge_room::open(&state.bridge_db_path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(
+                    err = %e,
+                    case_id = event.case_id,
+                    "bridge_room::open for stage drain failed"
+                );
+                return;
+            }
+        };
+        match stage::Stage::load(&conn, event.case_id as i64, "townhall") {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(err = %e, case_id = event.case_id, "Stage::load failed");
+                return;
+            }
+        }
+        // conn dropped here — Stage owns its in-memory state
+    };
+    room_event_client::drain_emits(
+        &mut stage,
+        &state.http_client,
+        &state.config.brehon_room_event_url,
+        &state.config.bridge_callback_secret,
+    )
+    .await;
+
+    tracing::info!(
+        case_id = event.case_id,
+        room_id = %room_id,
+        chair = %chair,
+        "townhall stage-mode room provisioned"
+    );
 }
 
 /// C2.2 — Community-event room provisioning.

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -1,0 +1,343 @@
+// Task 4/5/6 wire Stage into request handlers; allow dead_code until then.
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use anyhow::{anyhow, Result};
+use rusqlite::Connection;
+use crate::bridge_room;
+
+/// Seat state for the participant currently at the mic position.
+/// Participants in the FIFO queue are implicitly in Watcher status.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SeatState {
+    Watcher,
+    /// Granted publish; awaiting activation (Task 4 adds the 30s grace boundary).
+    Promoted,
+    Speaking,
+}
+
+/// Commands emitted by the state machine; the GrantSink adapter applies them to LiveKit.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GrantCmd {
+    GrantPublish(String),   // pseudonym (ADR-015: opaque strings only)
+    RevokePublish(String),  // pseudonym
+}
+
+/// Applied by the state machine; the real impl re-mints LiveKit tokens (Task 4+ wiring).
+/// Tests use the `Recorder` impl below.
+pub trait GrantSink {
+    fn apply(&mut self, cmd: GrantCmd);
+}
+
+/// Chair-override action variants.
+pub enum Override {
+    ForceDemote,
+    ForcePromote,
+}
+
+/// In-memory stage state with persisted FIFO queue and chair seat.
+///
+/// ADR-015: all stored strings are pseudonyms (opaque), never person_id or username.
+/// FIFO is single-writer (the chair's bridge controller) — no lock needed.
+pub struct Stage {
+    case_id: i64,
+    room_type: String,
+    pub chair: Option<String>,
+    /// Raised-hand FIFO; persisted to bridge_room.queue_state on every mutation.
+    pub fifo: VecDeque<String>,
+    /// Currently promoted or speaking participant. Not persisted (reconnect derives it
+    /// from LiveKit state; Task 6 wires the dual-source). None = seat empty.
+    pub current: Option<(String, SeatState)>,
+}
+
+impl Stage {
+    /// Load Stage from persisted bridge_room columns. Returns an empty Stage when no
+    /// row exists yet (first raise_hand will UPSERT the row via flush_queue).
+    pub fn load(conn: &Connection, case_id: i64, room_type: &str) -> Result<Self> {
+        let chair = bridge_room::read_chair_id(conn, case_id, room_type)?;
+        let fifo = match bridge_room::read_queue_state(conn, case_id, room_type)? {
+            Some(json) => serde_json::from_str::<Vec<String>>(&json)
+                .map(|v| v.into_iter().collect())
+                .unwrap_or_default(),
+            None => VecDeque::new(),
+        };
+        Ok(Stage {
+            case_id,
+            room_type: room_type.to_string(),
+            chair,
+            fifo,
+            current: None,
+        })
+    }
+
+    /// Append `p` to the raised-hand FIFO (no dup). Persists the queue immediately.
+    pub fn raise_hand(&mut self, p: &str, conn: &Connection) -> Result<()> {
+        let owned = p.to_string();
+        if !self.fifo.contains(&owned) {
+            self.fifo.push_back(owned);
+            self.flush_queue(conn)?;
+        }
+        Ok(())
+    }
+
+    /// Pop the FIFO head, emit GrantPublish, and move that participant to Promoted.
+    /// Returns Err if the FIFO is empty (invalid transition — type-state guard).
+    /// Note: the 30s grace timer is Task 4; this leaves the Promoted participant awaiting
+    /// on_activate with no timeout boundary.
+    pub fn promote_next(&mut self, sink: &mut dyn GrantSink, conn: &Connection) -> Result<()> {
+        let head = self
+            .fifo
+            .pop_front()
+            .ok_or_else(|| anyhow!("promote_next: FIFO is empty"))?;
+        sink.apply(GrantCmd::GrantPublish(head.clone()));
+        self.current = Some((head, SeatState::Promoted));
+        self.flush_queue(conn)?;
+        Ok(())
+    }
+
+    /// Transition the current Promoted participant to Speaking.
+    /// Returns Err if `p` is not the currently Promoted participant (type-state guard).
+    pub fn on_activate(&mut self, p: &str) -> Result<()> {
+        match &mut self.current {
+            Some((name, state)) => {
+                if name.as_str() != p {
+                    return Err(anyhow!(
+                        "on_activate: {} is not the current participant (current: {})",
+                        p,
+                        name
+                    ));
+                }
+                if *state != SeatState::Promoted {
+                    return Err(anyhow!(
+                        "on_activate: {} is in {:?} state, expected Promoted",
+                        p,
+                        state
+                    ));
+                }
+                *state = SeatState::Speaking;
+                Ok(())
+            }
+            None => Err(anyhow!("on_activate: no participant in seat")),
+        }
+    }
+
+    /// Stub signature — Task 4 adds the tokio::select! grace-timer wiring.
+    pub fn on_grace_expired(
+        &mut self,
+        _p: &str,
+        _sink: &mut dyn GrantSink,
+        _conn: &Connection,
+    ) -> Result<()> {
+        // Task 4: RevokePublish(_p) + promote_next(_sink, _conn)
+        Ok(())
+    }
+
+    /// Force-demote or force-promote a participant out of FIFO order.
+    ///
+    /// - `ForceDemote`: revoke the current seat holder (must be `target`), clear seat.
+    /// - `ForcePromote`: remove `target` from FIFO (if present), grant publish, set as Promoted.
+    pub fn chair_override(
+        &mut self,
+        action: Override,
+        target: &str,
+        sink: &mut dyn GrantSink,
+        conn: &Connection,
+    ) -> Result<()> {
+        match action {
+            Override::ForceDemote => match &self.current {
+                Some((name, _)) if name.as_str() == target => {
+                    sink.apply(GrantCmd::RevokePublish(target.to_string()));
+                    self.current = None;
+                    Ok(())
+                }
+                Some((name, _)) => Err(anyhow!(
+                    "force_demote: {} is not the current participant (current: {})",
+                    target,
+                    name
+                )),
+                None => Err(anyhow!("force_demote: seat is empty")),
+            },
+            Override::ForcePromote => {
+                self.fifo.retain(|p| p.as_str() != target);
+                sink.apply(GrantCmd::GrantPublish(target.to_string()));
+                self.current = Some((target.to_string(), SeatState::Promoted));
+                self.flush_queue(conn)?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Transfer the chair to `to`. Returns `(from, to)` for the chain entry (Task 5 emits).
+    /// Persists the new chair_id immediately.
+    pub fn transfer_chair(&mut self, to: &str, conn: &Connection) -> Result<(String, String)> {
+        let from = self
+            .chair
+            .take()
+            .ok_or_else(|| anyhow!("transfer_chair: no current chair"))?;
+        self.chair = Some(to.to_string());
+        bridge_room::write_chair_id(conn, self.case_id, &self.room_type, to)?;
+        Ok((from, to.to_string()))
+    }
+
+    fn flush_queue(&self, conn: &Connection) -> Result<()> {
+        let v: Vec<&str> = self.fifo.iter().map(String::as_str).collect();
+        let json = serde_json::to_string(&v)?;
+        bridge_room::write_queue_state(conn, self.case_id, &self.room_type, &json)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_room;
+
+    /// Test GrantSink that records commands in order.
+    struct Recorder {
+        cmds: Vec<GrantCmd>,
+    }
+
+    impl Recorder {
+        fn new() -> Self {
+            Self { cmds: Vec::new() }
+        }
+    }
+
+    impl GrantSink for Recorder {
+        fn apply(&mut self, cmd: GrantCmd) {
+            self.cmds.push(cmd);
+        }
+    }
+
+    fn open_stage(case_id: i64) -> (Stage, rusqlite::Connection) {
+        let conn = bridge_room::open(":memory:").expect("open in-memory DB");
+        let stage = Stage::load(&conn, case_id, "governance").expect("load stage");
+        (stage, conn)
+    }
+
+    /// §16a Story 1 — marquee DoD: four raise_hand + four promote_next/on_activate cycles;
+    /// GrantPublish must fire in FIFO order for all four participants.
+    #[test]
+    fn fifo_mic_pass_in_sequence() -> Result<()> {
+        let (mut stage, conn) = open_stage(1);
+        let mut sink = Recorder::new();
+
+        stage.raise_hand("W1", &conn)?;
+        stage.raise_hand("W2", &conn)?;
+        stage.raise_hand("W3", &conn)?;
+        stage.raise_hand("W4", &conn)?;
+
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W1")?;
+
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W2")?;
+
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W3")?;
+
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W4")?;
+
+        let grants: Vec<&str> = sink.cmds.iter().filter_map(|c| {
+            if let GrantCmd::GrantPublish(p) = c { Some(p.as_str()) } else { None }
+        }).collect();
+        assert_eq!(
+            grants,
+            &["W1", "W2", "W3", "W4"],
+            "GrantPublish must fire in FIFO order"
+        );
+        Ok(())
+    }
+
+    /// force_promote a watcher out of FIFO order (before the FIFO head),
+    /// then force_demote the speaker; exercises the guarded-error path on double-demote.
+    #[test]
+    fn chair_override_reorder() -> Result<()> {
+        let (mut stage, conn) = open_stage(2);
+        let mut sink = Recorder::new();
+
+        stage.raise_hand("W1", &conn)?;
+        stage.raise_hand("W2", &conn)?;
+        stage.raise_hand("W3", &conn)?;
+
+        // Force-promote W3 out of order — W3 is granted before W1 (the FIFO head).
+        stage.chair_override(Override::ForcePromote, "W3", &mut sink, &conn)?;
+        assert_eq!(
+            sink.cmds.last(),
+            Some(&GrantCmd::GrantPublish("W3".to_string())),
+            "force_promote must emit GrantPublish before the FIFO head"
+        );
+        // W3 removed from FIFO; [W1, W2] remain.
+        assert_eq!(
+            stage.fifo.iter().collect::<Vec<_>>(),
+            &["W1", "W2"],
+            "force_promote must remove target from FIFO"
+        );
+
+        // Activate W3 as the speaker.
+        stage.on_activate("W3")?;
+
+        // Force-demote W3.
+        stage.chair_override(Override::ForceDemote, "W3", &mut sink, &conn)?;
+        let revokes: Vec<&str> = sink.cmds.iter().filter_map(|c| {
+            if let GrantCmd::RevokePublish(p) = c { Some(p.as_str()) } else { None }
+        }).collect();
+        assert_eq!(revokes, &["W3"], "force_demote must emit RevokePublish");
+
+        // Guarded-error path: force_demote with no current speaker must fail.
+        let err = stage.chair_override(Override::ForceDemote, "W1", &mut sink, &conn);
+        assert!(err.is_err(), "force_demote on empty seat must return an error");
+        Ok(())
+    }
+
+    #[test]
+    fn promote_next_on_empty_fifo_errors() -> Result<()> {
+        let (mut stage, conn) = open_stage(3);
+        let mut sink = Recorder::new();
+        let err = stage.promote_next(&mut sink, &conn);
+        assert!(err.is_err(), "promote_next on empty FIFO must return an error");
+        Ok(())
+    }
+
+    #[test]
+    fn on_activate_wrong_participant_errors() -> Result<()> {
+        let (mut stage, conn) = open_stage(4);
+        let mut sink = Recorder::new();
+        stage.raise_hand("W1", &conn)?;
+        stage.promote_next(&mut sink, &conn)?;
+        // W1 is Promoted; activating a different participant must fail.
+        let err = stage.on_activate("W2");
+        assert!(err.is_err(), "on_activate with wrong participant must return an error");
+        Ok(())
+    }
+
+    #[test]
+    fn raise_hand_no_dup() -> Result<()> {
+        let (mut stage, conn) = open_stage(5);
+        stage.raise_hand("W1", &conn)?;
+        stage.raise_hand("W1", &conn)?;
+        assert_eq!(stage.fifo.len(), 1, "raise_hand must not add duplicate entries");
+        Ok(())
+    }
+
+    #[test]
+    fn stage_load_roundtrip() -> Result<()> {
+        let conn = bridge_room::open(":memory:").expect("open DB");
+        let mut stage = Stage::load(&conn, 10, "governance")?;
+        let mut sink = Recorder::new();
+        stage.raise_hand("A", &conn)?;
+        stage.raise_hand("B", &conn)?;
+        // promote_next pops "A"; FIFO should be ["B"] after.
+        stage.promote_next(&mut sink, &conn)?;
+
+        // Reload from persisted state.
+        let stage2 = Stage::load(&conn, 10, "governance")?;
+        assert_eq!(
+            stage2.fifo.iter().collect::<Vec<_>>(),
+            &["B"],
+            "FIFO must survive a reload (queue_state round-trip)"
+        );
+        Ok(())
+    }
+}

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -107,6 +107,10 @@ impl Stage {
             .fifo
             .pop_front()
             .ok_or_else(|| anyhow!("promote_next: FIFO is empty"))?;
+        // ponytail: single-presenter invariant — revoke the seated holder before granting the next.
+        if let Some((prev, _)) = self.current.take() {
+            sink.apply(GrantCmd::RevokePublish(prev));
+        }
         sink.apply(GrantCmd::GrantPublish(head.clone()));
         self.current = Some((head, SeatState::Promoted));
         self.flush_queue(conn)?;
@@ -239,6 +243,10 @@ impl Stage {
                 let lifecycle_stage = self.room_type.clone();
                 let actor = self.chair.clone();
                 self.fifo.retain(|p| p.as_str() != target);
+                // ponytail: single-presenter invariant — revoke the seated holder before force-promoting.
+                if let Some((prev, _)) = self.current.take() {
+                    sink.apply(GrantCmd::RevokePublish(prev));
+                }
                 sink.apply(GrantCmd::GrantPublish(target.to_string()));
                 self.current = Some((target.to_string(), SeatState::Promoted));
                 self.flush_queue(conn)?;
@@ -362,13 +370,29 @@ mod tests {
         stage.promote_next(&mut sink, &conn)?;
         stage.on_activate("W4")?;
 
+        // Grants still fire in FIFO order.
         let grants: Vec<&str> = sink.cmds.iter().filter_map(|c| {
             if let GrantCmd::GrantPublish(p) = c { Some(p.as_str()) } else { None }
         }).collect();
-        assert_eq!(
-            grants,
-            &["W1", "W2", "W3", "W4"],
-            "GrantPublish must fire in FIFO order"
+        assert_eq!(grants, &["W1", "W2", "W3", "W4"], "GrantPublish must fire in FIFO order");
+        // Single-presenter: each handoff revokes the prior holder before granting the next.
+        assert!(
+            sink.cmds.windows(2).any(|w|
+                w[0] == GrantCmd::RevokePublish("W1".to_string())
+                && w[1] == GrantCmd::GrantPublish("W2".to_string())),
+            "handoff must RevokePublish(W1) before GrantPublish(W2)"
+        );
+        assert!(
+            sink.cmds.windows(2).any(|w|
+                w[0] == GrantCmd::RevokePublish("W2".to_string())
+                && w[1] == GrantCmd::GrantPublish("W3".to_string())),
+            "handoff must RevokePublish(W2) before GrantPublish(W3)"
+        );
+        assert!(
+            sink.cmds.windows(2).any(|w|
+                w[0] == GrantCmd::RevokePublish("W3".to_string())
+                && w[1] == GrantCmd::GrantPublish("W4".to_string())),
+            "handoff must RevokePublish(W3) before GrantPublish(W4)"
         );
         Ok(())
     }

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use std::collections::VecDeque;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 use crate::bridge_room;
 
@@ -58,7 +58,7 @@ impl Stage {
         let fifo = match bridge_room::read_queue_state(conn, case_id, room_type)? {
             Some(json) => serde_json::from_str::<Vec<String>>(&json)
                 .map(|v| v.into_iter().collect())
-                .unwrap_or_default(),
+                .context("corrupt bridge_room.queue_state")?,
             None => VecDeque::new(),
         };
         Ok(Stage {

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -157,9 +157,9 @@ impl Stage {
     /// `tokio::time::advance` and `#[tokio::test(start_paused = true)]` (R7).
     ///
     /// Callers supply the cancel Future:
-    ///   - Tests: `std::future::pending::<()>()` for the boundary case;
-    ///            `std::future::ready(())` when activation already happened.
-    ///   - Production (Task 5+): a `oneshot::Receiver<()>` that `on_activate` fires.
+    /// - Tests: `std::future::pending::<()>()` for the boundary case;
+    ///   `std::future::ready(())` when activation already happened.
+    /// - Production (Task 5+): a `oneshot::Receiver<()>` that `on_activate` fires.
     pub async fn run_grace<F: std::future::Future + Unpin>(
         &mut self,
         p: &str,

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 use crate::bridge_room;
+use crate::room_event_client::RoomEventPayload;
 
 /// Grace period before a promoted-but-not-activated participant is auto-revoked.
 /// Timer is tokio::time (virtual-time-controllable) so tests drive it deterministically.
@@ -39,6 +40,16 @@ pub enum Override {
     ForcePromote,
 }
 
+/// Pending room-event POST intent produced by sync state-mutation methods.
+/// The async bridge controller (Task 6) drains `Stage::pending_emits` and
+/// calls `post_room_event` for each. Fire-and-forget: transport failure is
+/// logged and swallowed at the callsite (best-effort chain entry).
+pub struct EmitIntent {
+    pub entry_kind: &'static str,
+    pub payload: RoomEventPayload,
+    pub actor_pseudonym: Option<String>,
+}
+
 /// In-memory stage state with persisted FIFO queue and chair seat.
 ///
 /// ADR-015: all stored strings are pseudonyms (opaque), never person_id or username.
@@ -52,6 +63,9 @@ pub struct Stage {
     /// Currently promoted or speaking participant. Not persisted (reconnect derives it
     /// from LiveKit state; Task 6 wires the dual-source). None = seat empty.
     pub current: Option<(String, SeatState)>,
+    /// Queued room-event POST intents from sync state mutations. Drained by the
+    /// async controller (Task 6). In-memory only — cleared on reload (best-effort).
+    pub pending_emits: Vec<EmitIntent>,
 }
 
 impl Stage {
@@ -71,6 +85,7 @@ impl Stage {
             chair,
             fifo,
             current: None,
+            pending_emits: Vec::new(),
         })
     }
 
@@ -190,8 +205,26 @@ impl Stage {
         match action {
             Override::ForceDemote => match &self.current {
                 Some((name, _)) if name.as_str() == target => {
+                    let case_id = self.case_id as i32;
+                    let lifecycle_stage = self.room_type.clone();
+                    let actor = self.chair.clone();
                     sink.apply(GrantCmd::RevokePublish(target.to_string()));
                     self.current = None;
+                    self.pending_emits.push(EmitIntent {
+                        entry_kind: "room_chair_override",
+                        payload: RoomEventPayload {
+                            case_id,
+                            matrix_room_id: None,
+                            lifecycle_stage,
+                            member_count: None,
+                            action: Some("force_demote".to_string()),
+                            target_pseudonym: Some(target.to_string()),
+                            from_pseudonym: None,
+                            to_pseudonym: None,
+                            at: None,
+                        },
+                        actor_pseudonym: actor,
+                    });
                     Ok(())
                 }
                 Some((name, _)) => Err(anyhow!(
@@ -202,17 +235,36 @@ impl Stage {
                 None => Err(anyhow!("force_demote: seat is empty")),
             },
             Override::ForcePromote => {
+                let case_id = self.case_id as i32;
+                let lifecycle_stage = self.room_type.clone();
+                let actor = self.chair.clone();
                 self.fifo.retain(|p| p.as_str() != target);
                 sink.apply(GrantCmd::GrantPublish(target.to_string()));
                 self.current = Some((target.to_string(), SeatState::Promoted));
                 self.flush_queue(conn)?;
+                self.pending_emits.push(EmitIntent {
+                    entry_kind: "room_chair_override",
+                    payload: RoomEventPayload {
+                        case_id,
+                        matrix_room_id: None,
+                        lifecycle_stage,
+                        member_count: None,
+                        action: Some("force_promote".to_string()),
+                        target_pseudonym: Some(target.to_string()),
+                        from_pseudonym: None,
+                        to_pseudonym: None,
+                        at: None,
+                    },
+                    actor_pseudonym: actor,
+                });
                 Ok(())
             }
         }
     }
 
-    /// Transfer the chair to `to`. Returns `(from, to)` for the chain entry (Task 5 emits).
-    /// Persists the new chair_id immediately.
+    /// Transfer the chair to `to`. Returns `(from, to)` for callers; also pushes a
+    /// `room_chair_transferred` EmitIntent to `pending_emits` (Task 5 — first emission).
+    /// Persists the new chair_id immediately. ADR-015: `from`/`to` are pseudonyms.
     pub fn transfer_chair(&mut self, to: &str, conn: &Connection) -> Result<(String, String)> {
         let from = self
             .chair
@@ -220,6 +272,33 @@ impl Stage {
             .ok_or_else(|| anyhow!("transfer_chair: no current chair"))?;
         self.chair = Some(to.to_string());
         bridge_room::write_chair_id(conn, self.case_id, &self.room_type, to)?;
+        let case_id = self.case_id as i32;
+        let lifecycle_stage = self.room_type.clone();
+        let now = time::OffsetDateTime::now_utc();
+        let at = format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+            now.year(),
+            now.month() as u8,
+            now.day(),
+            now.hour(),
+            now.minute(),
+            now.second()
+        );
+        self.pending_emits.push(EmitIntent {
+            entry_kind: "room_chair_transferred",
+            payload: RoomEventPayload {
+                case_id,
+                matrix_room_id: None,
+                lifecycle_stage,
+                member_count: None,
+                action: None,
+                target_pseudonym: None,
+                from_pseudonym: Some(from.clone()),
+                to_pseudonym: Some(to.to_string()),
+                at: Some(at),
+            },
+            actor_pseudonym: Some(from.clone()),
+        });
         Ok((from, to.to_string()))
     }
 
@@ -422,6 +501,77 @@ mod tests {
             sink.cmds[2],
             GrantCmd::GrantPublish("W2".to_string()),
             "grace expiry must promote next queued watcher"
+        );
+        Ok(())
+    }
+
+    /// §16a Story 3 DoD — transfer_chair pushes a room_chair_transferred EmitIntent
+    /// with from_pseudonym, to_pseudonym, at (timestamp), and actor_pseudonym set.
+    #[test]
+    fn transfer_chair_produces_emit_intent() -> Result<()> {
+        let (mut stage, conn) = open_stage(9);
+        stage.chair = Some("old_chair".to_string());
+        let (from, to) = stage.transfer_chair("new_chair", &conn)?;
+        assert_eq!(from, "old_chair");
+        assert_eq!(to, "new_chair");
+        assert_eq!(stage.pending_emits.len(), 1, "exactly one EmitIntent must be queued");
+        let emit = &stage.pending_emits[0];
+        assert_eq!(emit.entry_kind, "room_chair_transferred");
+        assert_eq!(
+            emit.payload.from_pseudonym,
+            Some("old_chair".to_string()),
+            "from_pseudonym must be the old chair (ADR-015: pseudonym only)"
+        );
+        assert_eq!(
+            emit.payload.to_pseudonym,
+            Some("new_chair".to_string()),
+            "to_pseudonym must be the new chair"
+        );
+        assert!(emit.payload.at.is_some(), "at timestamp must be present");
+        assert_eq!(
+            emit.actor_pseudonym,
+            Some("old_chair".to_string()),
+            "actor_pseudonym must be the transferring chair"
+        );
+        Ok(())
+    }
+
+    /// §16a Story 4 DoD — chair_override (ForceDemote) pushes a room_chair_override
+    /// EmitIntent with action + target_pseudonym; transfer fields absent.
+    #[test]
+    fn chair_override_produces_emit_intent() -> Result<()> {
+        let (mut stage, conn) = open_stage(10);
+        let mut sink = Recorder::new();
+        stage.chair = Some("chair_pseudonym".to_string());
+        stage.raise_hand("W1", &conn)?;
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W1")?;
+        stage.chair_override(Override::ForceDemote, "W1", &mut sink, &conn)?;
+        assert_eq!(stage.pending_emits.len(), 1, "exactly one EmitIntent must be queued");
+        let emit = &stage.pending_emits[0];
+        assert_eq!(emit.entry_kind, "room_chair_override");
+        assert_eq!(
+            emit.payload.action,
+            Some("force_demote".to_string()),
+            "action must be force_demote"
+        );
+        assert_eq!(
+            emit.payload.target_pseudonym,
+            Some("W1".to_string()),
+            "target_pseudonym must be the demoted participant"
+        );
+        assert!(
+            emit.payload.from_pseudonym.is_none(),
+            "from_pseudonym must be absent in override emit (transfer-only field)"
+        );
+        assert!(
+            emit.payload.to_pseudonym.is_none(),
+            "to_pseudonym must be absent in override emit (transfer-only field)"
+        );
+        assert_eq!(
+            emit.actor_pseudonym,
+            Some("chair_pseudonym".to_string()),
+            "actor_pseudonym must be the chair who issued the override"
         );
         Ok(())
     }

--- a/services/bridge/src/stage.rs
+++ b/services/bridge/src/stage.rs
@@ -6,12 +6,16 @@ use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 use crate::bridge_room;
 
+/// Grace period before a promoted-but-not-activated participant is auto-revoked.
+/// Timer is tokio::time (virtual-time-controllable) so tests drive it deterministically.
+const GRACE_SECS: u64 = 30;
+
 /// Seat state for the participant currently at the mic position.
 /// Participants in the FIFO queue are implicitly in Watcher status.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SeatState {
     Watcher,
-    /// Granted publish; awaiting activation (Task 4 adds the 30s grace boundary).
+    /// Granted publish; awaiting activation (30s grace — run_grace drives the boundary).
     Promoted,
     Speaking,
 }
@@ -82,8 +86,7 @@ impl Stage {
 
     /// Pop the FIFO head, emit GrantPublish, and move that participant to Promoted.
     /// Returns Err if the FIFO is empty (invalid transition — type-state guard).
-    /// Note: the 30s grace timer is Task 4; this leaves the Promoted participant awaiting
-    /// on_activate with no timeout boundary.
+    /// Call `run_grace` after this to start the 30s activation window (Task 4).
     pub fn promote_next(&mut self, sink: &mut dyn GrantSink, conn: &Connection) -> Result<()> {
         let head = self
             .fifo
@@ -121,14 +124,55 @@ impl Stage {
         }
     }
 
-    /// Stub signature — Task 4 adds the tokio::select! grace-timer wiring.
+    /// Auto-revoke the grace-expired Promoted participant and promote the next FIFO head.
+    ///
+    /// Idempotent: returns Ok without side-effects if `p` is no longer in Promoted state
+    /// (activation or chair-demote already happened before the timer fired).
+    /// ADR-015: `p` is a pseudonym string — never person_id or username.
     pub fn on_grace_expired(
         &mut self,
-        _p: &str,
-        _sink: &mut dyn GrantSink,
-        _conn: &Connection,
+        p: &str,
+        sink: &mut dyn GrantSink,
+        conn: &Connection,
     ) -> Result<()> {
-        // Task 4: RevokePublish(_p) + promote_next(_sink, _conn)
+        match &self.current {
+            Some((name, SeatState::Promoted)) if name.as_str() == p => {}
+            _ => return Ok(()), // already activated or demoted; idempotent guard
+        }
+        sink.apply(GrantCmd::RevokePublish(p.to_string()));
+        self.current = None;
+        if !self.fifo.is_empty() {
+            self.promote_next(sink, conn)?;
+        }
+        Ok(())
+    }
+
+    /// Drive the 30s grace window for the Promoted participant `p` using virtual time.
+    ///
+    /// Races `tokio::time::sleep(GRACE_SECS)` against `cancel` (the activation signal).
+    /// On sleep expiry without activation: fires `on_grace_expired` (RevokePublish + next-promote).
+    /// On `cancel` resolving first: exits cleanly — no revoke.
+    ///
+    /// The timer is `tokio::time` (never wall-clock) so tests control it with
+    /// `tokio::time::advance` and `#[tokio::test(start_paused = true)]` (R7).
+    ///
+    /// Callers supply the cancel Future:
+    ///   - Tests: `std::future::pending::<()>()` for the boundary case;
+    ///            `std::future::ready(())` when activation already happened.
+    ///   - Production (Task 5+): a `oneshot::Receiver<()>` that `on_activate` fires.
+    pub async fn run_grace<F: std::future::Future + Unpin>(
+        &mut self,
+        p: &str,
+        sink: &mut dyn GrantSink,
+        conn: &Connection,
+        cancel: F,
+    ) -> Result<()> {
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(GRACE_SECS)) => {
+                self.on_grace_expired(p, sink, conn)?;
+            }
+            _ = cancel => {}
+        }
         Ok(())
     }
 
@@ -337,6 +381,77 @@ mod tests {
             stage2.fifo.iter().collect::<Vec<_>>(),
             &["B"],
             "FIFO must survive a reload (queue_state round-trip)"
+        );
+        Ok(())
+    }
+
+    /// §16a Story 2 DoD — the load-bearing 30s boundary (R7):
+    /// promote W1 (W2 queued), advance virtual clock 30s WITHOUT activating W1,
+    /// assert RevokePublish(W1) THEN GrantPublish(W2).
+    ///
+    /// Requires tokio features: `time` (sleep) + `test-util` (start_paused / advance).
+    #[tokio::test(start_paused = true)]
+    async fn grace_no_activate_auto_revokes_and_promotes_next() -> Result<()> {
+        let (mut stage, conn) = open_stage(7);
+        let mut sink = Recorder::new();
+        stage.raise_hand("W1", &conn)?;
+        stage.raise_hand("W2", &conn)?;
+        stage.promote_next(&mut sink, &conn)?;
+
+        // Spawn the advance task BEFORE awaiting run_grace; otherwise the single-threaded
+        // runtime would have nothing to fire the sleep (time is paused).
+        let advance_task = tokio::spawn(async {
+            tokio::time::advance(std::time::Duration::from_secs(30)).await;
+        });
+        // cancel = pending (never resolves): only the sleep branch can fire.
+        stage
+            .run_grace("W1", &mut sink, &conn, std::future::pending::<()>())
+            .await?;
+        advance_task.await?;
+
+        // cmds[0] = GrantPublish(W1) from promote_next
+        // cmds[1] = RevokePublish(W1) from on_grace_expired
+        // cmds[2] = GrantPublish(W2) from next promote_next
+        assert_eq!(sink.cmds.len(), 3, "promote + grace-revoke + next-promote expected");
+        assert_eq!(
+            sink.cmds[1],
+            GrantCmd::RevokePublish("W1".to_string()),
+            "grace expiry must emit RevokePublish(W1)"
+        );
+        assert_eq!(
+            sink.cmds[2],
+            GrantCmd::GrantPublish("W2".to_string()),
+            "grace expiry must promote next queued watcher"
+        );
+        Ok(())
+    }
+
+    /// Contrast: activate W1 before grace fires, advance 30s — no revoke fires.
+    /// cancel = ready() resolves immediately, selecting the cancel branch over the sleep.
+    #[tokio::test(start_paused = true)]
+    async fn grace_activate_before_expiry_no_revoke() -> Result<()> {
+        let (mut stage, conn) = open_stage(8);
+        let mut sink = Recorder::new();
+        stage.raise_hand("W1", &conn)?;
+        stage.raise_hand("W2", &conn)?;
+        stage.promote_next(&mut sink, &conn)?;
+        stage.on_activate("W1")?;
+
+        // cancel = ready (resolves immediately): activation already happened, no revoke.
+        stage
+            .run_grace("W1", &mut sink, &conn, std::future::ready(()))
+            .await?;
+        tokio::time::advance(std::time::Duration::from_secs(30)).await;
+
+        let revoke_count = sink
+            .cmds
+            .iter()
+            .filter(|c| matches!(c, GrantCmd::RevokePublish(_)))
+            .count();
+        assert_eq!(
+            revoke_count,
+            0,
+            "activation before grace must not fire RevokePublish"
         );
         Ok(())
     }

--- a/services/bridge/tests/stage_mode.rs
+++ b/services/bridge/tests/stage_mode.rs
@@ -1,0 +1,23 @@
+// Integration tests: stage-mode town-hall suite (docker-compose-gated).
+//
+// Run with:
+//   cd services/bridge
+//   docker compose up -d
+//   cargo test --test stage_mode -- --ignored
+//   docker compose down
+//
+// All test functions are #[ignore]'d so bare `cargo test` inside
+// services/bridge/ skips this suite without requiring the docker stack.
+
+#[tokio::test]
+#[ignore = "requires docker-compose stack"]
+async fn four_mic_pass_then_grace_boundary_emits_chair_entries() -> anyhow::Result<()> {
+    // 1. provision a town-hall stage room (chair + 4 watchers)
+    // 2. drive 4 raise-hand + promote/activate passes via the real LiveKit grants
+    // 3. drive a 5th promote with no activation; assert auto-revoke + next-promote at 30s
+    // 4. drive a chair transfer + a chair override
+    // 5. query governance_log: assert room_chair_transferred {from_pseudonym, to_pseudonym, at}
+    //    + room_chair_override {action, target_pseudonym} rows exist with PSEUDONYM payload
+    //    fields (never a real identity or Matrix user ID — ADR-015)
+    todo!("implement against live docker-compose stack (Phase-6 pilot grade)")
+}


### PR DESCRIPTION
## Summary

Adds **chair-controlled stage mode** to M3 town-hall rooms (Phase 3, bridge-side): a single presenter slot the chair drives, a FIFO raised-hand queue, mic-passing via LiveKit publish-grants (not Matrix power-levels), a 30s grace auto-revoke + next-promote boundary, chair transfer (delegate) + chair override (force promote/demote), and the **FIRST emission** of `room_chair_transferred` / `room_chair_override` governance-log chain entries from the bridge. All chain payloads are pseudonyms-only (ADR-015); the Q&A sidebar is the Matrix text timeline, never hashed (ADR-016). The deterministic DoD is unit tests (no e2e); the docker-gated end-to-end is an #[ignore]'d compile-gated stub (Phase-6 pilot grade).

- **`RoomEventPayload` chair-action fields** (binary): 5 optional `#[serde(default)]` fields (`action`, `target_pseudonym`, `from_pseudonym`, `to_pseudonym`, `at`) + `CaseTransitionEvent.chair_pseudonym`; non-breaking (zero existing constructors); `bridge_notify.rs` sets `chair_pseudonym: None` (Phase-3 default) (Task 1).
- **LiveKit publish-grant mint** (`livekit_jwt.rs::mint_access_token(can_publish)`): presenter token (`can_publish=true`) vs watcher token (`false`) — mic = publish-grant re-mint, NO Matrix power-level call (Task 2).
- **Stage state machine** (`services/bridge/src/stage.rs` NEW): chair seat + persisted FIFO raised-hand queue (`bridge_room.queue_state`) + mic-pass state machine (`raise_hand`/`promote_next`/`on_activate`) + `GrantSink` adapter + type-state `Result<()>` guards; FIFO survives bridge restart via `Stage::load` (Task 3).
- **30s grace auto-revoke** (`run_grace`/`on_grace_expired`/`GRACE_SECS=30`): a promoted speaker who doesn't activate within 30s is auto-revoked and the next is promoted — deterministic `#[tokio::test(start_paused)]` virtual-time boundary test (the load-bearing boundary) (Task 4).
- **Bridge→binary room-event client** (`room_event_client.rs` NEW): `post_room_event` POSTs chair-action METADATA to `/api/v4/governance/room-event` with Bearer auth; the emit-intent seam (`Stage::pending_emits`) keeps `transfer_chair`/`chair_override`/`promote_next` synchronous; `drain_emits` is the async controller drain (fire-and-forget warn-on-error) wired from the provisioning path (Tasks 5+6).
- **Stage-mode provisioning + Q&A sidebar** (`room_provisioner.rs`): town-hall path opens in stage mode (chair presenter, watchers muted), seats `chair_id` from `chair_pseudonym ?? juror_pseudonyms.first()` (foreperson fallback, OQ-V2-05), initialises the FIFO to `[]`, drains room-event intents; the Q&A sidebar IS the Matrix text timeline (no new room type, no content hashing) (Task 6).
- **Docker-gated e2e stub** (`services/bridge/tests/stage_mode.rs` NEW): `#[ignore]` compile-gated end-to-end asserting `room_chair_transferred {from,to,at}` + `room_chair_override {action,target_pseudonym}` rows land with pseudonym payloads on a live stack (Phase-6 pilot grade) (Task 6).

## Plan reference

`.claude/PRPs/plans/m3-core-stage-mode.plan.md`

## Validation

- **Bridge Linux-compile gate** (`cargo-linux.sh check + clippy --no-deps -- -D warnings`, Docker rust:1.95): EXIT 0 @ `9152aa4d6` (advisor-laptop, DQ bc10e175f0da-001). clippy 0 errors — the Task-5 scaffold dead_code allows were removed when Task 6's `drain_emits` made `post_room_event`/`RoomEventRequest`/`brehon_room_event_url` live.
- **Bridge unit tests** (`cargo-linux.sh test`): `stage` 10 passed, 0 failed (incl `fifo_mic_pass_in_sequence` marquee, `grace_no_activate_auto_revokes_and_promotes_next` 30s virtual-time boundary at 0.04s, 2 emit-intent tests); `room_event_client` 2 passed, 0 failed (override/transfer JSON shape).
- **Integration-test compile** (`cargo-linux.sh test --test stage_mode --no-run`): EXIT 0 — the docker-gated `#[ignore]` `stage_mode.rs` test compiles (1 filtered/not-run); live run is Phase-6 pilot.
- **crates static** (Task 1, Windows `--workspace --features full`): check + clippy EXIT 0 (governance-log chair-payload serde roundtrip).
- **No migration** (no new `bridge_room` column; `chair_id`/`queue_state` from Task 3 m3-core-stage-mode). **No new dep.**

## Commits

- 9152aa4d6 merge(rtc): Task 6 — stage-mode provisioning + Q&A sidebar + room-event drain + e2e stub into phase
- d8c5e3c25 chore(decision-queue): advisor-laptop resolved DQ bc10e175f0da-001 — Task 6 cargo-linux PASS
- b3fdfa9ab chore(decision-queue): impl raised DQ bc10e175f0da-001 — task6-linux-validate-bridge
- 425eb6a25 feat(rtc): stage-mode provisioning + Q&A sidebar + room-event drain + e2e stub (task 6)
- b0b5dab95 chore(advisor): sync Task 6 brief onto phase branch (Mode B trunk->phase)
- 11580d5d8 merge(rtc): Task 5 room-event client + emit-intent seam + fix-impl-5 dead_code allows into phase
- d6f674fdd chore(decision-queue): advisor-laptop resolved DQ 33017c985c6a-001 — fix-impl-5 cargo-linux PASS
- f8df98092 fix(rtc): allow(dead_code) on room-event emitter scaffold pending Task 6 drain (fix-impl 5)
- c2678067c chore(advisor): sync fix-impl-5 brief onto task5 worker branch
- efb9c9d9d feat(rtc): bridge→binary room-event client + chair-action emitters (task 5)
- cfa07d041 chore(advisor): sync impl-5 brief onto phase branch
- 29b16adf0 feat(rtc): merge Task 4 — 30s grace auto-revoke + next-promote (job-716 lineage: code+tokio-features+doc) into phase
- dcdf0267d chore(decision-queue): advisor-laptop resolved validate DQ e5510f969130-001 — Task 4 PASS
- 08147c230 fix(rtc): re-indent run_grace doc list to satisfy clippy doc-overindent (fix-impl 4)
- bcded3387 chore(advisor): sync fix-impl-4 brief onto fix3 worker branch
- 8c9f0ec56 fix(rtc): enable tokio time + test-util features for stage grace timer (fix-impl 3)
- 4df314b39 chore(advisor): sync fix-impl-3 brief onto task4 worker branch
- 9d035ade5 chore(decision-queue): impl raised DQ 6302ef3b3382-001 — tokio-time-feature-gate
- 53b8c5612 feat(rtc): 30s grace auto-revoke + next-promote boundary (task 4)
- 9c395e4c5 docs(advisor): sync Task 4 brief onto phase branch (Mode B)
- 806f0d3b6 merge: Task 3 — stage-mode core (FIFO + mic-pass state machine) + corrupt-queue fix (#711/#712)
- a8a1b4dd9 chore(decision-queue): advisor-laptop resolved d6dcd385fffa-001 — task3 fix validate PASS (check+clippy+6 tests green)
- 5e20a2933 fix(rtc): propagate corrupt queue_state parse error in Stage::load (fix-impl 2)
- 0dc5ee812 docs(advisor): sync fix-impl-2 brief onto task3 worker branch (Mode B)
- d26d87ba2 chore(decision-queue): advisor-laptop mutated e1256574bda6-001 -> FAIL (clippy unwrap_or_default stage.rs:61, non-allowlist)
- 215fd692b chore(decision-queue): impl raised validate-pending-laptop-linux DQ e1256574bda6-001 — task3 stage bridge check+clippy+test
- 77731ea73 feat(rtc): stage-mode core — chair seat + persisted FIFO + mic-pass state machine (task 3)
- 9a4963f0a docs(advisor): sync Task 3 brief onto phase branch (Mode B)
- ee630ad71 fix(rtc): allow(dead_code) on livekit scaffold until stage.rs caller (cherry-pick fix-impl 9760441ed, bridge files only)
- fa92f3eb1 feat(governance): merge task1 RoomEventPayload chair-action fields + CaseTransitionEvent.chair_pseudonym
- 86127a39f chore(decision-queue): resolve merge conflict — keep both task1 + task2 validate-pending entries
- e8dcee1fe chore(decision-queue): retain dq-task1 fragment artifact (task 1 debug)
- e8b032661 feat(rtc): merge task2 livekit can_publish presenter/watcher grant
- 20f8357ac feat(governance): RoomEventPayload chair-action fields + CaseTransitionEvent.chair_pseudonym (task 1)
- a6d39dbb1 chore(decision-queue): impl raised DQ 8f77bcfc296e-001 — bridge task2 linux validate
- b8bad9baf feat(rtc): livekit can_publish presenter/watcher grant (task 2)
- d722cbc1d Merge remote-tracking branch 'origin/governance-v0' into phase-m3-core-stage-mode
- b2f4d5e9a chore(bm-task): log branch cut phase-m3-core-stage-mode post-planning approval

*PR opened by branch-manager. CodeRabbit review will follow automatically.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added town-hall stage-mode with persisted raised-hand queue, chair seat lifecycle, and grace-period auto-revocation/promotions.
  * Enabled governance room-event notifications for chair transfers and overrides.
* **Improvements**
  * LiveKit access tokens now support explicit publish permission control.
  * Governance transition events can include chair pseudonym metadata.
  * Enhanced persistence for raised-hand queue and current chair state.
* **Bug Fixes**
  * Improved resilience when persisted queue data is corrupt, and ensured revoke-before-grant handoff ordering.
* **Tests**
  * Added/extended unit test coverage for persistence, grace behaviour, and room-event JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->