### PR TITLE
fix(ai-review): robust merge-base resolution for MiniMax governance review (workflow_dispatch mode)

### DIFF
--- a/.github/workflows/governance-ai-review.yml
+++ b/.github/workflows/governance-ai-review.yml
@@ -56,12 +56,19 @@ jobs:
           git fetch origin "$BASE_REF" --unshallow 2>/dev/null \
             || git fetch origin "$BASE_REF"
           BASE=$(git merge-base "origin/$BASE_REF" HEAD || true)
+          # `A...HEAD` recomputes the merge-base internally, so it re-fails in
+          # the no-common-ancestor path even after we pick a fallback BASE. Use
+          # `...` only when a real merge-base exists; `..` (plain range) in the
+          # fallback so the chosen BASE is honoured literally.
+          DIFF_OP="..."
           if [ -z "$BASE" ]; then
             echo "::warning::no merge-base between origin/$BASE_REF and HEAD; falling back to origin/$BASE_REF as base"
             BASE=$(git rev-parse "origin/$BASE_REF")
+            DIFF_OP=".."
           fi
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
-          git diff --name-only "$BASE"...HEAD > /tmp/changed.txt
+          echo "diff_op=$DIFF_OP" >> "$GITHUB_OUTPUT"
+          git diff --name-only "$BASE$DIFF_OP"HEAD > /tmp/changed.txt
           cat /tmp/changed.txt
 
       - name: Detect phase from changed paths
@@ -88,7 +95,7 @@ jobs:
       - name: Assemble diff and gate on size
         id: diff
         run: |
-          git diff --unified=3 "${{ steps.base.outputs.base }}"...HEAD > /tmp/full.diff
+          git diff --unified=3 "${{ steps.base.outputs.base }}${{ steps.base.outputs.diff_op }}HEAD" > /tmp/full.diff
           full_bytes=$(wc -c < /tmp/full.diff)
           # 28KB cap keeps the "AI review for small PRs only" semantic: phase-size
           # PRs are skipped cleanly so review adds signal on focused diffs rather

--- a/.github/workflows/governance-ai-review.yml
+++ b/.github/workflows/governance-ai-review.yml
@@ -49,8 +49,17 @@ jobs:
         id: base
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref || 'governance-v0' }}"
-          git fetch origin "$BASE_REF" --depth=50
-          BASE=$(git merge-base "origin/$BASE_REF" HEAD)
+          # Full fetch of the base — a shallow (--depth) fetch can miss the
+          # merge-base with the fetch-depth:0 PR head, which fails under
+          # workflow_dispatch (manual re-runs) even when the pull_request
+          # event path works. Unshallow keeps merge-base reliable in both modes.
+          git fetch origin "$BASE_REF" --unshallow 2>/dev/null \
+            || git fetch origin "$BASE_REF"
+          BASE=$(git merge-base "origin/$BASE_REF" HEAD || true)
+          if [ -z "$BASE" ]; then
+            echo "::warning::no merge-base between origin/$BASE_REF and HEAD; falling back to origin/$BASE_REF as base"
+            BASE=$(git rev-parse "origin/$BASE_REF")
+          fi
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           git diff --name-only "$BASE"...HEAD > /tmp/changed.txt
           cat /tmp/changed.txt


### PR DESCRIPTION
## Summary

The MiniMax M3 governance-ai-review workflow (now live on `governance-v0`) failed its first `workflow_dispatch` smoke-test at the **Resolve base ref + diff** step. Root cause: the base branch was fetched shallow (`--depth=50`) while the PR head is checked out at `fetch-depth: 0`, so `git merge-base origin/<base> HEAD` could return empty and `set -e` killed the step.

This fix:
- fetches the base branch **unshallow** (falls back to a plain fetch if already complete), so `merge-base` is reliable in both `pull_request` and `workflow_dispatch` modes;
- guards `merge-base` with `|| true` + a fallback to `origin/<base>` tip, with a `::warning::` if no common ancestor exists.

## Why a PR (not direct-commit)

`.github/workflows/**` is CodeRabbit's lane per `phase-branch.md`. This PR also serves as the **live dogfood** of the workflow: opening it triggers `governance-ai-review` on its own diff (paths are `.github/**`, not a governance namespace, so it detects `phase=unknown` and applies the ADR rubric only / posts a thin review — proving the plumbing runs end-to-end with the fix).

## Verification

- Failing run before fix: [27865726858](https://github.com/barrie-cork/lemmy/actions/runs/27865726858) (`workflow_dispatch` on PR #199) — failed at Resolve-base, exit 1.
- YAML re-validated post-edit.
- The `governance-ai-review` run on THIS PR is the post-fix proof.

## Context

MiniMax M3 is the governance ADR reviewer (ADR-001..015 rubric) — wired as the second automated reviewer after Copilot ran out of usage minutes. CodeRabbit remains the primary reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the continuous integration workflow’s base reference resolution to handle missing or empty merge-base results more robustly.
  * Adjusted how the diff range is assembled, ensuring the correct comparison window is generated in both normal and fallback scenarios.
  * Enhanced warning and fallback behaviour to improve overall build validation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->